### PR TITLE
Fixes #17 Expose store in public API

### DIFF
--- a/src/dispatch.js
+++ b/src/dispatch.js
@@ -3,7 +3,7 @@
 /**
  * dispatch
  */
-import { store } from './store'
+import { getStore } from './store'
 
 export let dispatch = {} // eslint-disable-line
 
@@ -12,7 +12,7 @@ export const createDispatcher = (modelName: string, reducerName: string) => (pay
     type: `${modelName}/${reducerName}`,
     ...(payload ? { payload } : {})
   }
-  store.dispatch(action)
+  getStore().dispatch(action)
 }
 
 export const createDispatchers = (model: $model) => {

--- a/src/index.js
+++ b/src/index.js
@@ -2,12 +2,14 @@ import init from './init'
 import model from './model'
 import { dispatch } from './dispatch'
 import { select } from './select'
+import { getStore } from './store'
 
 export default {
   init,
   model,
   dispatch,
   select,
+  getStore
 }
 
 export {
@@ -15,4 +17,5 @@ export {
   model,
   dispatch,
   select,
+  getStore
 }

--- a/src/store.js
+++ b/src/store.js
@@ -12,6 +12,8 @@ const composeEnhancers =
 
 export let store = null // eslint-disable-line
 
+export const getStore = () => store
+
 // create store
 export const createStore = (
   initialState: any = {},

--- a/test/dispatch.test.js
+++ b/test/dispatch.test.js
@@ -1,5 +1,4 @@
-import { model, init, dispatch } from '../src/index'
-import { store } from '../src/store'
+import { model, init, dispatch, getStore } from '../src/index'
 
 beforeEach(() => {
   jest.resetModules()
@@ -19,7 +18,7 @@ describe('dispatch:', () => {
 
     dispatch.count.add()
 
-    expect(store.getState()).toEqual({
+    expect(getStore().getState()).toEqual({
       count: 1,
     })
   })
@@ -38,7 +37,7 @@ describe('dispatch:', () => {
     dispatch.count.add()
     dispatch.count.add()
 
-    expect(store.getState()).toEqual({
+    expect(getStore().getState()).toEqual({
       count: 2,
     })
   })
@@ -65,7 +64,7 @@ describe('dispatch:', () => {
     dispatch.a.add()
     dispatch.b.add()
 
-    expect(store.getState()).toEqual({
+    expect(getStore().getState()).toEqual({
       a: 43,
       b: 1,
     })
@@ -82,9 +81,9 @@ describe('dispatch:', () => {
       },
     })
 
-    store.dispatch({ type: 'count/add' })
+    getStore().dispatch({ type: 'count/add' })
 
-    expect(store.getState()).toEqual({
+    expect(getStore().getState()).toEqual({
       count: 1,
     })
   })
@@ -102,7 +101,7 @@ describe('dispatch:', () => {
 
     dispatch.count.doNothing()
 
-    expect(store.getState()).toEqual({
+    expect(getStore().getState()).toEqual({
       count: 0,
     })
   })
@@ -123,7 +122,7 @@ describe('dispatch:', () => {
 
     dispatch.count.incrementBy(5)
 
-    expect(store.getState()).toEqual({
+    expect(getStore().getState()).toEqual({
       count: 6,
     })
   })

--- a/test/effects.test.js
+++ b/test/effects.test.js
@@ -1,6 +1,5 @@
-import { model, init, dispatch } from '../src/index'
+import { model, init, dispatch, getStore } from '../src/index'
 import { effects } from '../src/effects'
-import { store } from '../src/store'
 
 beforeEach(() => {
   jest.resetModules()
@@ -55,7 +54,7 @@ describe('effects:', () => {
 
     await dispatch.example.asyncAddOne()
 
-    expect(store.getState()).toEqual({
+    expect(getStore().getState()).toEqual({
       example: 1,
     })
   })
@@ -78,7 +77,7 @@ describe('effects:', () => {
 
     await dispatch.example.asyncAddBy(5)
 
-    expect(store.getState()).toEqual({
+    expect(getStore().getState()).toEqual({
       example: 7,
     })
   })
@@ -101,7 +100,7 @@ describe('effects:', () => {
 
     await dispatch.example.asyncAddBy({ value: 6 })
 
-    expect(store.getState()).toEqual({
+    expect(getStore().getState()).toEqual({
       example: 9,
     })
   })
@@ -127,7 +126,7 @@ describe('effects:', () => {
 
     await dispatch.example.asyncCallAddOne()
 
-    expect(store.getState()).toEqual({
+    expect(getStore().getState()).toEqual({
       example: 1,
     })
   })
@@ -158,7 +157,7 @@ describe('effects:', () => {
 
     await dispatch.example.asyncAddSome()
 
-    expect(store.getState()).toEqual({
+    expect(getStore().getState()).toEqual({
       example: 5,
     })
   })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,5 @@
 // Tests for consumer API
-import { model, init } from '../src/index'
-import { store } from '../src/store'
+import { model, init, getStore } from '../src/index'
 
 beforeEach(() => {
   jest.resetModules()
@@ -10,7 +9,7 @@ describe('init:', () => {
   test('no params should create store with state `{}`', () => {
     init({ view: () => () => {} })
 
-    expect(store.getState()).toEqual({})
+    expect(getStore().getState()).toEqual({})
   })
   test('init() & one model of state type `string`', () => {
     init({ view: () => () => {} })
@@ -20,7 +19,7 @@ describe('init:', () => {
       state: 'Hello, world',
     })
 
-    expect(store.getState()).toEqual({
+    expect(getStore().getState()).toEqual({
       app: 'Hello, world',
     })
   })
@@ -33,7 +32,7 @@ describe('init:', () => {
       state: 99,
     })
 
-    expect(store.getState()).toEqual({
+    expect(getStore().getState()).toEqual({
       count: 99,
     })
   })
@@ -46,7 +45,7 @@ describe('init:', () => {
       state: 0,
     })
 
-    expect(store.getState()).toEqual({
+    expect(getStore().getState()).toEqual({
       count: 0,
     })
   })
@@ -64,7 +63,7 @@ describe('init:', () => {
       },
     })
 
-    expect(store.getState()).toEqual({
+    expect(getStore().getState()).toEqual({
       todos: {
         abc: {
           text: 'PRty down',
@@ -86,7 +85,7 @@ describe('init:', () => {
       state: 99,
     })
 
-    expect(store.getState()).toEqual({
+    expect(getStore().getState()).toEqual({
       app: 'Hello, world',
       count: 99,
     })
@@ -115,7 +114,7 @@ describe('init:', () => {
       },
     })
 
-    expect(store.getState()).toEqual({
+    expect(getStore().getState()).toEqual({
       app: 'Hello, world',
       count: 99,
       todos: {


### PR DESCRIPTION
Fixes #17 

@ShMcK 

Ran into some issues when trying to expose the store reference directly. 

The store was always resolving to null. This didn't work:
```js
// src/index.js
import { store } from './src/store'
export default {
  store
}
```

So, I exposed it via a function: `getStore`. So the following works, all tests pass :)
```js
// src/index.js
import { getStore } from './src/store'
export default {
  getStore
}

// elsewhere
import { getStore } from './src/index'
const store = getStore()
```

