### PR TITLE
closes #16. add codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,23 @@
+---
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+        javascript:
+          mass_threshold: 50
+  fixme:
+    enabled: true
+    config:
+      strings:
+        - FIXME
+        - HACK
+        - BUG
+  eslint:
+    enabled: false
+ratings:
+  paths:
+  - "**.js"
+exclude_paths:
+  - node_modules/
+  


### PR DESCRIPTION
setup [CodeClimate](https://codeclimate.com). No need to enable this until after the plugin API is completed.