### PR TITLE
add `this` context to effects

### DIFF
--- a/src/effects.js
+++ b/src/effects.js
@@ -8,8 +8,11 @@ export const effects = {}
  */
 export const createEffects = (model: $model) => {
   Object.keys(model.effects || {}).forEach((effectName: string) => {
-    // add effect to effects
-    effects[`${model.name}/${effectName}`] = model.effects[effectName]
+    // bind effect to dispatch[model.name] context of "this"
+    // note: does not work with arrow functions
+    effects[`${model.name}/${effectName}`] = model.effects[effectName].bind(
+      dispatch[model.name]
+    )
     // add effect to dispatch
     dispatch[model.name][effectName] = createDispatcher(model.name, effectName)
   })

--- a/test/effects.test.js
+++ b/test/effects.test.js
@@ -20,20 +20,18 @@ describe('effects:', () => {
     expect(typeof dispatch.count.add).toBe('function')
   })
 
-  test('should create an effects', () => {
+  test('should create an effect', () => {
     init()
-
-    const add = () => 1
 
     model({
       name: 'example',
       state: 0,
       effects: {
-        add,
+        add: () => 1
       },
     })
 
-    expect(effects['example/add']).toEqual(add)
+    expect(effects['example/add']()).toBe(1)
   })
 
   test('should be able to trigger another action', async () => {
@@ -46,8 +44,79 @@ describe('effects:', () => {
         addOne: (state) => state + 1,
       },
       effects: {
-        asyncAddOne: async () => {
+        asyncAddOneArrow: async () => {
           await dispatch.example.addOne()
+        }
+      }
+    })
+
+    await dispatch.example.asyncAddOneArrow()
+
+    expect(getStore().getState()).toEqual({
+      example: 1,
+    })
+  })
+
+  // currently no solution for arrow functions as they are often transpiled by Babel or Typescript
+  // there is no clear way to detect arrow functions
+  xtest('should be able trigger a local reducer using arrow functions and `this`', async () => {
+    init()
+
+    model({
+      name: 'example',
+      state: 0,
+      reducers: {
+        addOne: (state) => state + 1,
+      },
+      effects: {
+        asyncAddOneArrow: async () => {
+          await this.addOne()
+        }
+      }
+    })
+
+    await dispatch.example.asyncAddOneArrow()
+
+    expect(getStore().getState()).toEqual({
+      example: 1,
+    })
+  })
+
+  test('should be able trigger a local reducer using functions and `this`', async () => {
+    init()
+
+    model({
+      name: 'example',
+      state: 0,
+      reducers: {
+        addOne: (state) => state + 1,
+      },
+      effects: {
+        asyncAddOne: async function () {
+          await this.addOne()
+        }
+      }
+    })
+
+    await dispatch.example.asyncAddOne()
+
+    expect(getStore().getState()).toEqual({
+      example: 1,
+    })
+  })
+
+  test('should be able trigger a local reducer using object function shorthand and `this`', async () => {
+    init()
+
+    model({
+      name: 'example',
+      state: 0,
+      reducers: {
+        addOne: (state) => state + 1,
+      },
+      effects: {
+        async asyncAddOne() {
+          await this.addOne()
         }
       }
     })


### PR DESCRIPTION
Progress with #7 .

Allows the following functionality:

```js
{
  name: 'example',
  state: 0,
  reducers: {
    addOne: (state) => state + 1
  },
  effects: {
    callAddOne() {
      // this references the local model dispatch
      this.addOne()
    }
  }
}
```

Currently works with.
- [x] - object function shorthand
- [x] - function
- [ ] - fat arrow functions