### PR TITLE
closes #50. Autobind selector to model state as first param

### DIFF
--- a/examples/react-redux-count/src/index.js
+++ b/examples/react-redux-count/src/index.js
@@ -67,7 +67,7 @@ const App = ({ valueA, valueB, valueADoubled, asyncAIncr, incrB, incrA }) => (
 const AppContainer = connect(state => ({
   valueA: state.countA,
   valueB: state.countB,
-  valueADoubled : select.countA.double(state),
+  valueADoubled : select.countA.double(),
   incrA: () => dispatch.countA.increment(),
   asyncAIncr: () => dispatch.countA.asyncIncrement(),
   incrB: () => dispatch.countB.increment()

--- a/src/plugins/selectors.js
+++ b/src/plugins/selectors.js
@@ -1,12 +1,15 @@
 // @flow
+import { getStore } from '../utils/store'
+
 export const select = {}
 
 export default {
   onModel: (model: $model) => {
     select[model.name] = {}
     Object.keys(model.selectors || {}).forEach((selectorName: string) => {
-      select[model.name][selectorName] = (state: any, ...args) =>
-        model.selectors[selectorName](state[model.name], ...args)
+      select[model.name][selectorName] = (...args) =>
+        // autobind selector to state as first param, followed by args
+        model.selectors[selectorName](getStore().getState()[model.name], ...args)
     })
   }
 }

--- a/test/select.test.js
+++ b/test/select.test.js
@@ -1,12 +1,10 @@
-// Test for internal store
-import { init, model, select, getStore } from '../src'
-
 beforeEach(() => {
   jest.resetModules()
 })
 
 describe('select:', () => {
   it('should create a valid list of selectors', () => {
+    const { init, model, select } = require('../src')
     init()
     model({
       name: 'a',
@@ -22,6 +20,7 @@ describe('select:', () => {
   })
 
   it('should allow access to the selector', () => {
+    const { init, model, select } = require('../src')
     init()
     model({
       name: 'a',
@@ -33,8 +32,25 @@ describe('select:', () => {
         double: s => s * 2
       },
     })
-    const doubled = select.a.double(getStore().getState())
+    const doubled = select.a.double()
     expect(doubled).toBe(4)
+  })
+
+  it('should allow passing in of params toselector', () => {
+    const { init, model, select } = require('../src')
+    init()
+    model({
+      name: 'a',
+      state: 2,
+      reducers: {
+        increment: s => s + 1
+      },
+      selectors: {
+        prependWithLetter: (s, letter) => letter + s
+      },
+    })
+    const prepended = select.a.prependWithLetter('P')
+    expect(prepended).toBe('P2')
   })
 })
 


### PR DESCRIPTION
Selectors no longer needs state as the first param.

```js
// before:
select.a.b(state)

// after PR:
select.a.b() // automatically passes store in
```

See examples in "select.test.js"