### PR TITLE
closes #47. Add model option to plugin

### DIFF
--- a/flow-typed/local/plugin.js
+++ b/flow-typed/local/plugin.js
@@ -1,5 +1,6 @@
 declare type $plugin = {
-  onInit(dispatch: any): void,
-  onModel(model: $model, dispatch: any): void,
-  middleware: $middleware,
+  onInit?: (dispatch: any) => void,
+  onModel?: (model: $model, dispatch: any) => void,
+  model?: $model,
+  middleware?: $middleware,
 }

--- a/src/core.js
+++ b/src/core.js
@@ -1,6 +1,7 @@
 // @flow
 import validate from './utils/validate'
 import { getStore } from './utils/store'
+import createModel from './model'
 
 export const modelHooks = []
 export const pluginMiddlewares = []
@@ -34,6 +35,9 @@ export const initPlugins = (plugins: $plugin[]) => {
     if (plugin.onInit) {
       const { dispatch } = getStore()
       plugin.onInit(dispatch)
+    }
+    if (plugin.model) {
+      createModel(plugin.model)
     }
   })
 }

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -29,6 +29,19 @@ describe('plugins:', () => {
     expect(pluginMiddlewares).toEqual([m1, m2])
   })
 
+  test('should add a model', () => {
+    const { init, getStore } = require('../src')
+    init({
+      plugins: [{
+        model: {
+          name: 'a',
+          state: 0,
+        }
+      }]
+    })
+    expect(getStore().getState()).toEqual({ a: 0 })
+  })
+
   test('should not create a plugin with invalid "onModel"', () => {
     const plugin1 = {
       onModel: {},


### PR DESCRIPTION
Now add a model to a plugin.

Question though: Would a plugin ever require more than one model? This current PR only allows a single model. This opens the question.... could your entire app be broken into a series of plugins?

You right now. 

![](https://media.giphy.com/media/l4JyUVNpvtl2tByX6/giphy.gif)