### PR TITLE
closes #10. add promise middleware to dispatches

### DIFF
--- a/src/plugins/dispatch.js
+++ b/src/plugins/dispatch.js
@@ -8,17 +8,17 @@ export default {
     callDispatch = storeDispatch
   },
   onModel: (model: $model, storeDispatch: $dispatch) => {
-    const createDispatcher = (modelName: string, reducerName: string) => (payload: any) => {
+    const createDispatcher = (modelName: string, reducerName: string) => async (payload: any) => {
       const action = {
         type: `${modelName}/${reducerName}`,
         ...(payload ? { payload } : {})
       }
-      storeDispatch(action)
+      await storeDispatch(action)
     }
 
     dispatch[model.name] = {}
     Object.keys(model.reducers || {}).forEach((reducerName: string) => {
       dispatch[model.name][reducerName] = createDispatcher(model.name, reducerName)
     })
-  }
+  },
 }

--- a/src/plugins/effects.js
+++ b/src/plugins/effects.js
@@ -23,10 +23,14 @@ export default {
       dispatch[model.name][effectName] = createDispatcher(model.name, effectName)
     })
   },
-  middleware: (store: $store) => (next: (action: $action) => any) => (action: $action) => {
+  middleware: (store: $store) => (next: (action: $action) => any) => async (action: $action) => {
+    // async/await acts as promise middleware
+    let result
     if (action.type in effects) {
-      return effects[action.type](action.payload, store.getState)
+      result = await effects[action.type](action.payload, store.getState)
+    } else {
+      result = await next(action)
     }
-    return next(action)
+    return result
   }
 }

--- a/test/dispatch.test.js
+++ b/test/dispatch.test.js
@@ -145,4 +145,43 @@ describe('dispatch:', () => {
       })
     })
   })
+
+  describe('promise middleware', () => {
+    test('should return a promise from an action', () => {
+      init()
+
+      model({
+        name: 'count',
+        state: 0,
+        reducers: {
+          add: state => state + 1,
+        },
+      })
+
+      const dispatched = dispatch.count.add()
+
+      expect(typeof dispatched.then).toBe('function')
+    })
+
+    test('should return a promise from an effect', () => {
+      init()
+
+      model({
+        name: 'count',
+        state: 0,
+        reducers: {
+          addOne: state => state + 1,
+        },
+        effects: {
+          callAddOne() {
+            return dispatch.count.addOne()
+          }
+        }
+      })
+
+      const dispatched = dispatch.count.addOne()
+
+      expect(typeof dispatched.then).toBe('function')
+    })
+  })
 })


### PR DESCRIPTION
Dispatches now return a Promise.

This promise is handled in the "effects" middleware, so it can both wait until:
- an effect is completed
- a reducer is completed