### PR TITLE
Plugins api

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -6,20 +6,25 @@ import createModel from './model'
 export const modelHooks = []
 export const pluginMiddlewares = []
 
-const validatePlugin = (plugin: $plugin) =>
-  validate([
-    [
-      plugin.onModel && typeof plugin.onModel !== 'function',
-      'Plugin onModel must be a function',
-    ],
-    [
-      plugin.middleware && typeof plugin.middleware !== 'function',
-      'Plugin middleware must be a function',
-    ],
-  ])
+const validatePlugin = (plugin: $plugin) => validate([
+  [
+    plugin.onModel && typeof plugin.onModel !== 'function',
+    'Plugin onModel must be a function',
+  ],
+  [
+    plugin.middleware && typeof plugin.middleware !== 'function',
+    'Plugin middleware must be a function',
+  ],
+])
 
-export const createPlugins = (plugins: $plugin[]) => {
-  plugins.forEach((plugin: $plugin) => {
+const buildPlugin = (createPlugin): $plugin => {
+  const { dispatch } = getStore()
+  return createPlugin(dispatch)
+}
+
+export const createPlugins = (plugins) => {
+  plugins.forEach(createPlugin => {
+    const plugin = buildPlugin(createPlugin)
     validatePlugin(plugin)
     if (plugin.onModel) {
       modelHooks.push(plugin.onModel)
@@ -27,14 +32,8 @@ export const createPlugins = (plugins: $plugin[]) => {
     if (plugin.middleware) {
       pluginMiddlewares.push(plugin.middleware)
     }
-  })
-}
-
-export const initPlugins = (plugins: $plugin[]) => {
-  plugins.forEach((plugin: $plugin) => {
     if (plugin.onInit) {
-      const { dispatch } = getStore()
-      plugin.onInit(dispatch)
+      plugin.onInit()
     }
     if (plugin.model) {
       createModel(plugin.model)

--- a/src/core.js
+++ b/src/core.js
@@ -22,6 +22,15 @@ const buildPlugin = (createPlugin): $plugin => {
   return createPlugin(dispatch)
 }
 
+export const addPluginMiddleware = (plugins) => {
+  plugins.forEach(createPlugin => {
+    const plugin = createPlugin()
+    if (plugin.middleware) {
+      pluginMiddlewares.push(plugin.middleware)
+    }
+  })
+}
+
 export const createPlugins = (plugins) => {
   plugins.forEach(createPlugin => {
     const plugin = buildPlugin(createPlugin)
@@ -31,9 +40,6 @@ export const createPlugins = (plugins) => {
     }
     if (plugin.onModel) {
       modelHooks.push(plugin.onModel)
-    }
-    if (plugin.middleware) {
-      pluginMiddlewares.push(plugin.middleware)
     }
     if (plugin.model) {
       createModel(plugin.model)

--- a/src/core.js
+++ b/src/core.js
@@ -26,14 +26,14 @@ export const createPlugins = (plugins) => {
   plugins.forEach(createPlugin => {
     const plugin = buildPlugin(createPlugin)
     validatePlugin(plugin)
+    if (plugin.onInit) {
+      plugin.onInit()
+    }
     if (plugin.onModel) {
       modelHooks.push(plugin.onModel)
     }
     if (plugin.middleware) {
       pluginMiddlewares.push(plugin.middleware)
-    }
-    if (plugin.onInit) {
-      plugin.onInit()
     }
     if (plugin.model) {
       createModel(plugin.model)

--- a/src/init.js
+++ b/src/init.js
@@ -1,7 +1,7 @@
 // @flow
 import validate from './utils/validate'
 import { createStore } from './utils/store'
-import { createPlugins } from './core'
+import { createPlugins, addPluginMiddleware } from './core'
 import corePlugins from './plugins'
 
 const validateConfig = (config: $config) =>
@@ -22,11 +22,16 @@ const validateConfig = (config: $config) =>
 
 const init = (config: $config = {}): void => {
   validateConfig(config)
-  // setup plugin pipeline
+
   const plugins = corePlugins.concat(config.plugins || [])
+  // plugin middleware must be added before creating store
+  addPluginMiddleware(plugins)
+
   // create a redux store with initialState
   // merge in additional extra reducers
   createStore(config.initialState, config.extraReducers)
+
+  // setup plugin pipeline
   createPlugins(plugins)
 }
 

--- a/src/init.js
+++ b/src/init.js
@@ -1,7 +1,7 @@
 // @flow
 import validate from './utils/validate'
 import { createStore } from './utils/store'
-import { createPlugins, initPlugins } from './core'
+import { createPlugins } from './core'
 import corePlugins from './plugins'
 
 const validateConfig = (config: $config) =>
@@ -24,12 +24,10 @@ const init = (config: $config = {}): void => {
   validateConfig(config)
   // setup plugin pipeline
   const plugins = corePlugins.concat(config.plugins || [])
-  createPlugins(plugins)
   // create a redux store with initialState
   // merge in additional extra reducers
   createStore(config.initialState, config.extraReducers)
-  // run init after completed
-  initPlugins(plugins)
+  createPlugins(plugins)
 }
 
 export default init

--- a/src/model.js
+++ b/src/model.js
@@ -1,6 +1,6 @@
 // @flow
 import validate from './utils/validate'
-import { createReducersAndUpdateStore, getStore } from './utils/store'
+import { createReducersAndUpdateStore } from './utils/store'
 import { modelHooks } from './core'
 
 const validateModel = (model: $model) =>
@@ -20,8 +20,7 @@ const createModel = (model: $model): void => {
   createReducersAndUpdateStore(model)
 
   // run plugin model subscriptions
-  const { dispatch } = getStore()
-  modelHooks.forEach(modelHook => modelHook(model, dispatch))
+  modelHooks.forEach(modelHook => modelHook(model))
 }
 
 export default createModel

--- a/src/plugins/dispatch.js
+++ b/src/plugins/dispatch.js
@@ -3,11 +3,11 @@ let callDispatch
 
 export const dispatch = (action: $action) => callDispatch(action)
 
-export default {
-  onInit: (storeDispatch: $dispatch) => {
+export default (storeDispatch: $dispatch) => ({
+  onInit() {
     callDispatch = storeDispatch
   },
-  onModel: (model: $model, storeDispatch: $dispatch) => {
+  onModel(model: $model) {
     const createDispatcher = (modelName: string, reducerName: string) => async (payload: any) => {
       const action = {
         type: `${modelName}/${reducerName}`,
@@ -20,5 +20,5 @@ export default {
     Object.keys(model.reducers || {}).forEach((reducerName: string) => {
       dispatch[model.name][reducerName] = createDispatcher(model.name, reducerName)
     })
-  },
-}
+  }
+})

--- a/src/plugins/effects.js
+++ b/src/plugins/effects.js
@@ -4,8 +4,8 @@ import { dispatch } from './dispatch'
 export const effects = {}
 
 // TODO assumes there is a dispatch plugin
-export default {
-  onModel: (model: $model, storeDispatch: $dispatch) => {
+export default (storeDispatch: $dispatch) => ({
+  onModel(model: $model) {
     const createDispatcher = (modelName: string, reducerName: string) => (payload: any) => {
       const action = {
         type: `${modelName}/${reducerName}`,
@@ -33,4 +33,4 @@ export default {
     }
     return result
   }
-}
+})

--- a/src/plugins/selectors.js
+++ b/src/plugins/selectors.js
@@ -3,8 +3,8 @@ import { getStore } from '../utils/store'
 
 export const select = {}
 
-export default {
-  onModel: (model: $model) => {
+export default () => ({
+  onModel(model: $model) {
     select[model.name] = {}
     Object.keys(model.selectors || {}).forEach((selectorName: string) => {
       select[model.name][selectorName] = (...args) =>
@@ -12,4 +12,4 @@ export default {
         model.selectors[selectorName](getStore().getState()[model.name], ...args)
     })
   }
-}
+})

--- a/src/plugins/subscriptions/index.js
+++ b/src/plugins/subscriptions/index.js
@@ -26,7 +26,6 @@ export default () => ({
 
     // exact match
     if (subscriptions.has(type)) {
-      console.log('---------------here')
       const allSubscriptions = subscriptions.get(type)
       // call each hook[modelName] with action
       triggerAllSubscriptions(allSubscriptions)(action)

--- a/src/plugins/subscriptions/index.js
+++ b/src/plugins/subscriptions/index.js
@@ -11,7 +11,7 @@ const triggerAllSubscriptions = (matches) => (action) => {
 }
 
 export default () => ({
-  onModel: (model: $model) => {
+  onModel(model: $model) {
     // necessary to prevent invalid subscription names
     const actionList = [
       ...Object.keys(model.reducers || {}),
@@ -26,6 +26,7 @@ export default () => ({
 
     // exact match
     if (subscriptions.has(type)) {
+      console.log('---------------here')
       const allSubscriptions = subscriptions.get(type)
       // call each hook[modelName] with action
       triggerAllSubscriptions(allSubscriptions)(action)

--- a/src/plugins/subscriptions/index.js
+++ b/src/plugins/subscriptions/index.js
@@ -10,7 +10,7 @@ const triggerAllSubscriptions = (matches) => (action) => {
   })
 }
 
-export default {
+export default () => ({
   onModel: (model: $model) => {
     // necessary to prevent invalid subscription names
     const actionList = [
@@ -40,4 +40,4 @@ export default {
 
     return next(action)
   },
-}
+})

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,32 +1,35 @@
-import { init } from '../src'
-
 beforeEach(() => {
   jest.resetModules()
 })
 
 describe('init config', () => {
   test('should not throw with an empty config', () => {
+    const { init } = require('../src')
     expect(() => init()).not.toThrow()
   })
   test('should not accept invalid plugins', () => {
+    const { init } = require('../src')
     expect(() => init({
       plugins: {}
     })).toThrow()
   })
 
   test('should not accept invalid "middleware"', () => {
+    const { init } = require('../src')
     expect(() => init({
       middleware: {}
     })).toThrow()
   })
 
   test('should not accept invalid array for "extraReducers"', () => {
+    const { init } = require('../src')
     expect(() => init({
       extraReducers: []
     })).toThrow()
   })
 
   test('should not accept invalid value as "extraReducers"', () => {
+    const { init } = require('../src')
     expect(() => init({
       extraReducers: 42
     })).toThrow()

--- a/test/dispatch.test.js
+++ b/test/dispatch.test.js
@@ -1,5 +1,3 @@
-import { model, init, getStore, dispatch } from '../src'
-
 beforeEach(() => {
   jest.resetModules()
 })
@@ -7,6 +5,7 @@ beforeEach(() => {
 describe('dispatch:', () => {
   describe('action:', () => {
     it('should be call in the form "modelName/reducerName"', () => {
+      const { model, init, getStore } = require('../src')
       init()
 
       model({
@@ -25,6 +24,7 @@ describe('dispatch:', () => {
     })
 
     test('should be able to call dispatch directly', () => {
+      const { model, init, getStore, dispatch } = require('../src')
       init()
 
       model({
@@ -43,6 +43,7 @@ describe('dispatch:', () => {
     })
 
     test('should dispatch an action', () => {
+      const { model, init, getStore, dispatch } = require('../src')
       init()
 
       model({
@@ -61,6 +62,7 @@ describe('dispatch:', () => {
     })
 
     test('should dispatch multiple actions', () => {
+      const { model, init, getStore, dispatch } = require('../src')
       init()
 
       model({
@@ -80,6 +82,7 @@ describe('dispatch:', () => {
     })
 
     test('should handle multiple models', () => {
+      const { model, init, getStore, dispatch } = require('../src')
       init()
 
       model({
@@ -110,6 +113,7 @@ describe('dispatch:', () => {
 
   describe('params:', () => {
     test('should pass state as the first reducer param', () => {
+      const { model, init, getStore, dispatch } = require('../src')
       init()
 
       model({
@@ -128,6 +132,7 @@ describe('dispatch:', () => {
     })
 
     test('should pass payload as the second param', () => {
+      const { model, init, getStore, dispatch } = require('../src')
       init()
 
       model({
@@ -148,6 +153,7 @@ describe('dispatch:', () => {
 
   describe('promise middleware', () => {
     test('should return a promise from an action', () => {
+      const { model, init, dispatch } = require('../src')
       init()
 
       model({
@@ -164,6 +170,7 @@ describe('dispatch:', () => {
     })
 
     test('should return a promise from an effect', () => {
+      const { model, init, dispatch } = require('../src')
       init()
 
       model({

--- a/test/effects.test.js
+++ b/test/effects.test.js
@@ -1,12 +1,10 @@
-import { model, init, dispatch, getStore } from '../src'
-// import { effects } from '../src/effects'
-
 beforeEach(() => {
   jest.resetModules()
 })
 
 describe('effects:', () => {
   test('should create an action', () => {
+    const { model, init, dispatch } = require('../src')
     init()
 
     model({
@@ -35,6 +33,7 @@ describe('effects:', () => {
   // })
 
   test('should be able to trigger another action', async () => {
+    const { model, init, dispatch, getStore } = require('../src')
     init()
 
     model({
@@ -60,6 +59,7 @@ describe('effects:', () => {
   // currently no solution for arrow functions as they are often transpiled by Babel or Typescript
   // there is no clear way to detect arrow functions
   xtest('should be able trigger a local reducer using arrow functions and `this`', async () => {
+    const { model, init, dispatch, getStore } = require('../src')
     init()
 
     model({
@@ -83,6 +83,7 @@ describe('effects:', () => {
   })
 
   test('should be able trigger a local reducer using functions and `this`', async () => {
+    const { model, init, dispatch, getStore } = require('../src')
     init()
 
     model({
@@ -92,7 +93,7 @@ describe('effects:', () => {
         addOne: (state) => state + 1,
       },
       effects: {
-        asyncAddOne: async function () {
+        asyncAddOne: async function () { // eslint-disable-line
           await this.addOne()
         }
       }
@@ -106,6 +107,7 @@ describe('effects:', () => {
   })
 
   test('should be able trigger a local reducer using object function shorthand and `this`', async () => {
+    const { model, init, dispatch, getStore } = require('../src')
     init()
 
     model({
@@ -129,6 +131,7 @@ describe('effects:', () => {
   })
 
   test('should be able to trigger another action with a value', async () => {
+    const { model, init, dispatch, getStore } = require('../src')
     init()
 
     model({
@@ -152,6 +155,7 @@ describe('effects:', () => {
   })
 
   test('should be able to trigger another action w/ an object value', async () => {
+    const { model, init, dispatch, getStore } = require('../src')
     init()
 
     model({
@@ -175,6 +179,7 @@ describe('effects:', () => {
   })
 
   test('should be able to trigger another action w/ another action', async () => {
+    const { model, init, dispatch, getStore } = require('../src')
     init()
 
     model({
@@ -201,6 +206,7 @@ describe('effects:', () => {
   })
 
   test('should be able to trigger another action w/ multiple actions', async () => {
+    const { model, init, dispatch, getStore } = require('../src')
     init()
 
     model({

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -1,18 +1,17 @@
-// Tests for consumer API
-import { model, init, getStore } from '../src'
-
 beforeEach(() => {
   jest.resetModules()
 })
 
 describe('init:', () => {
   test('no params should create store with state `{}`', () => {
+    const { init, getStore } = require('../src')
     init()
 
     expect(getStore().getState()).toEqual({})
   })
 
   test('init() & one model of state type `string`', () => {
+    const { model, init, getStore } = require('../src')
     init()
 
     model({
@@ -26,6 +25,7 @@ describe('init:', () => {
   })
 
   test('init() & one model of state type `number`', () => {
+    const { model, init, getStore } = require('../src')
     init()
 
     model({
@@ -39,6 +39,7 @@ describe('init:', () => {
   })
 
   test('init() & one model of state is 0', () => {
+    const { model, init, getStore } = require('../src')
     init()
 
     model({
@@ -52,6 +53,7 @@ describe('init:', () => {
   })
 
   test('init() & one model of state type `object`', () => {
+    const { model, init, getStore } = require('../src')
     init()
 
     model({
@@ -74,6 +76,7 @@ describe('init:', () => {
     })
   })
   test('init() & two models', () => {
+    const { model, init, getStore } = require('../src')
     init()
 
     model({
@@ -93,6 +96,7 @@ describe('init:', () => {
   })
 
   test('init() & three models', () => {
+    const { model, init, getStore } = require('../src')
     init()
 
     model({

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -1,59 +1,61 @@
-// Tests for consumer API
-import { createPlugins, modelHooks, pluginMiddlewares } from '../src/core'
-
 beforeEach(() => {
   jest.resetModules()
 })
 
 describe('plugins:', () => {
   test('should add onModel subscriptions', () => {
+    const { init } = require('../src')
+    const { modelHooks } = require('../src/core')
     const fns = [() => 1, () => 2]
-    const plugins = [{
-      onModel: fns[0],
-    }, {
-      onModel: fns[1]
-    }]
-    createPlugins(plugins)
-    expect(modelHooks).toEqual(fns)
+    init({
+      plugins: [
+        () => ({ onModel: fns[0] }),
+        () => ({ onModel: fns[1] }),
+      ]
+    })
+    expect(modelHooks.slice(-2)).toEqual(fns)
   })
 
   test('should add multiple middleware', () => {
+    const { init } = require('../src')
+    const { pluginMiddlewares } = require('../src/core')
     const m1 = () => next => action => next(action)
     const m2 = () => next => action => next(action)
-    const plugins = [{
-      middleware: m1,
-    }, {
-      middleware: m2
-    }]
-    createPlugins(plugins)
-    expect(pluginMiddlewares).toEqual([m1, m2])
+    init({
+      plugins: [
+        () => ({ middleware: m1 }),
+        () => ({ middleware: m2 }),
+      ]
+    })
+    expect(pluginMiddlewares.slice(-2)).toEqual([m1, m2])
   })
 
   test('should add a model', () => {
     const { init, getStore } = require('../src')
+    const model = {
+      name: 'a',
+      state: 0,
+    }
     init({
-      plugins: [{
-        model: {
-          name: 'a',
-          state: 0,
-        }
-      }]
+      plugins: [() => ({ model })]
     })
     expect(getStore().getState()).toEqual({ a: 0 })
   })
 
   test('should not create a plugin with invalid "onModel"', () => {
-    const plugin1 = {
+    const { createPlugins } = require('../src/core')
+    const plugin1 = () => ({
       onModel: {},
-    }
+    })
     const plugins = [plugin1]
     expect(() => createPlugins(plugins)).toThrow()
   })
 
   test('should not create a plugin with invalid "middleware"', () => {
-    const plugin1 = {
+    const { createPlugins } = require('../src/core')
+    const plugin1 = () => ({
       middleware: {},
-    }
+    })
     const plugins = [plugin1]
     expect(() => createPlugins(plugins)).toThrow()
   })

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -1,30 +1,31 @@
-// Test for internal store
-import { createStore, getStore } from '../src/utils/store'
-
 beforeEach(() => {
   jest.resetModules()
 })
 
 describe('createStore:', () => {
   it('no params should create store with state `{}`', () => {
+    const { createStore, getStore } = require('../src/utils/store')
     createStore()
 
     expect(getStore().getState()).toEqual({})
   })
 
   it('initialState `null` should create store with state `null`', () => {
+    const { createStore, getStore } = require('../src/utils/store')
     createStore(null)
 
     expect(getStore().getState()).toEqual(null)
   })
 
   it('initialState `{ app: "hello, world" }` should create store with state `{ app: "hello, world" }`', () => {
+    const { createStore, getStore } = require('../src/utils/store')
     createStore({ app: 'hello, world' })
 
     expect(getStore().getState()).toEqual({ app: 'hello, world' })
   })
 
   it('extraReducers should create store with extra reducers', () => {
+    const { createStore, getStore } = require('../src/utils/store')
     const extraReducers = { todos: (state = 999) => state }
     createStore(undefined, extraReducers)
     expect(getStore().getState()).toEqual({ todos: 999 })


### PR DESCRIPTION
Sets plugins as functions. 

```js
// AFTER
const plugin = (storeDispatch: $dispatch, config: $pluginConfig) => ({
  onInit() {},                          // removed storeDispatch as param
  onModel(model: $model) {}             // removed storeDispatch as param
  middleware: (store) => (next) => (action) => {}
})
```

Currently there is a "storeDispatch" param passed in initially.

### TODO
- [x] subscription tests failing
- [x] effects tests failing