### PR TITLE
WIP - plugins api refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "webpack --env build",
     "dev": "webpack --progress --colors --watch --env dev",
     "lint": "eslint ./src",
-    "test": "jest"
+    "test": "jest --watch"
   },
   "dependencies": {
     "redux": "^3.7.2"

--- a/src/core.js
+++ b/src/core.js
@@ -45,12 +45,10 @@ export const createPlugins = (plugins, exposed) => {
 
 const setupExpose = plugins => {
   const exposed = {}
-  plugins.forEach(p => {
-    if (p.expose) {
-      Object.keys(p.expose).forEach(key => {
-        exposed[key] = p.expose[key]
-      })
-    }
+  plugins.forEach(plugin => {
+    Object.keys(plugin.expose || {}).forEach(key => {
+      exposed[key] = plugin.expose[key]
+    })
   })
   return exposed
 }
@@ -69,5 +67,4 @@ export const setupPlugins = (config) => {
   // setup plugin pipeline
   createPlugins(plugins, exposed)
 }
-
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,11 @@ import init from './init'
 import model from './model'
 import { getStore } from './utils/store'
 
-import { dispatch } from './plugins/dispatch'
-import { select } from './plugins/selectors'
+import dispatchPlugin from './plugins/dispatch'
+import selectPlugin from './plugins/selectors'
+
+const { expose: { dispatch } } = dispatchPlugin
+const { expose: { select } } = selectPlugin
 
 export default {
   init,

--- a/src/init.js
+++ b/src/init.js
@@ -1,7 +1,7 @@
 // @flow
 import validate from './utils/validate'
 import { createStore } from './utils/store'
-import { createPlugins, addPluginMiddleware } from './core'
+import { createPlugins, addPluginMiddleware, populateExpose } from './core'
 import corePlugins from './plugins'
 
 const validateConfig = (config: $config) =>
@@ -24,6 +24,9 @@ const init = (config: $config = {}): void => {
   validateConfig(config)
 
   const plugins = corePlugins.concat(config.plugins || [])
+
+  populateExpose(plugins)
+
   // plugin middleware must be added before creating store
   addPluginMiddleware(plugins)
 

--- a/src/init.js
+++ b/src/init.js
@@ -1,8 +1,6 @@
 // @flow
 import validate from './utils/validate'
-import { createStore } from './utils/store'
-import { createPlugins, addPluginMiddleware, populateExpose } from './core'
-import corePlugins from './plugins'
+import { setupPlugins } from './core'
 
 const validateConfig = (config: $config) =>
   validate([
@@ -23,19 +21,7 @@ const validateConfig = (config: $config) =>
 const init = (config: $config = {}): void => {
   validateConfig(config)
 
-  const plugins = corePlugins.concat(config.plugins || [])
-
-  populateExpose(plugins)
-
-  // plugin middleware must be added before creating store
-  addPluginMiddleware(plugins)
-
-  // create a redux store with initialState
-  // merge in additional extra reducers
-  createStore(config.initialState, config.extraReducers)
-
-  // setup plugin pipeline
-  createPlugins(plugins)
+  setupPlugins(config)
 }
 
 export default init

--- a/src/plugins/dispatch.js
+++ b/src/plugins/dispatch.js
@@ -1,29 +1,27 @@
 // @flow
 let callDispatch
 
-export const internalInit = (exposed) => ({
-  onInit(getStore) {
-    callDispatch = getStore().dispatch
-  },
-  onModel(model: $model) {
-    const createDispatcher = (modelName: string, reducerName: string) => async (payload: any) => {
-      const action = {
-        type: `${modelName}/${reducerName}`,
-        ...(payload ? { payload } : {})
-      }
-      await callDispatch(action)
-    }
-
-    exposed.dispatch[model.name] = {}
-    Object.keys(model.reducers || {}).forEach((reducerName: string) => {
-      exposed.dispatch[model.name][reducerName] = createDispatcher(model.name, reducerName)
-    })
-  }
-})
-
 export default {
   expose: {
     dispatch: (action: $action) => callDispatch(action)
   },
-  internalInit
+  init: (exposed) => ({
+    onInit(getStore) {
+      callDispatch = getStore().dispatch
+    },
+    onModel(model: $model) {
+      const createDispatcher = (modelName: string, reducerName: string) => async (payload: any) => {
+        const action = {
+          type: `${modelName}/${reducerName}`,
+          ...(payload ? { payload } : {})
+        }
+        await callDispatch(action)
+      }
+
+      exposed.dispatch[model.name] = {}
+      Object.keys(model.reducers || {}).forEach((reducerName: string) => {
+        exposed.dispatch[model.name][reducerName] = createDispatcher(model.name, reducerName)
+      })
+    }
+  })
 }

--- a/src/plugins/effects.js
+++ b/src/plugins/effects.js
@@ -1,41 +1,39 @@
 // @flow
 let callDispatch
 
-export const internalInit = (exposed) => ({
-  onInit(getStore) {
-    callDispatch = getStore().dispatch
-  },
-  onModel(model: $model) {
-    const createDispatcher = (modelName: string, reducerName: string) => (payload: any) => {
-      const action = {
-        type: `${modelName}/${reducerName}`,
-        ...(payload ? { payload } : {})
-      }
-      callDispatch(action)
-    }
-
-    Object.keys(model.effects || {}).forEach((effectName: string) => {
-      exposed.effects[`${model.name}/${effectName}`] = model.effects[effectName].bind(
-        exposed.dispatch[model.name]
-      )
-      // add effect to dispatch
-      // is assuming dispatch is available already... that the dispatch plugin is in there
-      exposed.dispatch[model.name][effectName] = createDispatcher(model.name, effectName)
-    })
-  },
-  middleware: (store: $store) => (next: (action: $action) => any) => async (action: $action) => {
-    // async/await acts as promise middleware
-    let result
-    if (action.type in exposed.effects) {
-      result = await exposed.effects[action.type](action.payload, store.getState)
-    } else {
-      result = await next(action)
-    }
-    return result
-  }
-})
-
 export default {
   expose: { effects: {} },
-  internalInit
+  init: (exposed) => ({
+    onInit(getStore) {
+      callDispatch = getStore().dispatch
+    },
+    onModel(model: $model) {
+      const createDispatcher = (modelName: string, reducerName: string) => (payload: any) => {
+        const action = {
+          type: `${modelName}/${reducerName}`,
+          ...(payload ? { payload } : {})
+        }
+        callDispatch(action)
+      }
+
+      Object.keys(model.effects || {}).forEach((effectName: string) => {
+        exposed.effects[`${model.name}/${effectName}`] = model.effects[effectName].bind(
+          exposed.dispatch[model.name]
+        )
+        // add effect to dispatch
+        // is assuming dispatch is available already... that the dispatch plugin is in there
+        exposed.dispatch[model.name][effectName] = createDispatcher(model.name, effectName)
+      })
+    },
+    middleware: (store: $store) => (next: (action: $action) => any) => async (action: $action) => {
+      // async/await acts as promise middleware
+      let result
+      if (action.type in exposed.effects) {
+        result = await exposed.effects[action.type](action.payload, store.getState)
+      } else {
+        result = await next(action)
+      }
+      return result
+    }
+  })
 }

--- a/src/plugins/effects.js
+++ b/src/plugins/effects.js
@@ -23,6 +23,8 @@ export default {
         // add effect to dispatch
         // is assuming dispatch is available already... that the dispatch plugin is in there
         exposed.dispatch[model.name][effectName] = createDispatcher(model.name, effectName)
+        // tag effects so they can be differentiated from normal actions
+        exposed.dispatch[model.name][effectName].isEffect = true
       })
     },
     middleware: (store: $store) => (next: (action: $action) => any) => async (action: $action) => {

--- a/src/plugins/effects.js
+++ b/src/plugins/effects.js
@@ -17,9 +17,7 @@ export default {
       }
 
       Object.keys(model.effects || {}).forEach((effectName: string) => {
-        exposed.effects[`${model.name}/${effectName}`] = model.effects[effectName].bind(
-          exposed.dispatch[model.name]
-        )
+        exposed.effects[`${model.name}/${effectName}`] = model.effects[effectName].bind(exposed.dispatch[model.name])
         // add effect to dispatch
         // is assuming dispatch is available already... that the dispatch plugin is in there
         exposed.dispatch[model.name][effectName] = createDispatcher(model.name, effectName)

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,13 +1,13 @@
-import dispatch from './dispatch'
-import effects from './effects'
-import subscriptions from './subscriptions'
-import selectors from './selectors'
+import dispatchPlugin from './dispatch'
+import effectsPlugin from './effects'
+import subscriptionsPlugin from './subscriptions'
+import selectorsPlugin from './selectors'
 
 const corePlugins = [
-  dispatch,
-  effects,
-  selectors,
-  subscriptions,
+  dispatchPlugin,
+  effectsPlugin,
+  selectorsPlugin,
+  subscriptionsPlugin,
 ]
 
 export default corePlugins

--- a/src/plugins/loading.js
+++ b/src/plugins/loading.js
@@ -1,0 +1,51 @@
+// @flow
+const createLoadingAction = (show) => (state, { name, action }) => {
+  const next = Object.assign({}, state, {
+    global: show,
+    models: Object.assign({}, state.models, { [name]: show }),
+    effects: Object.assign({}, state.effects, {
+      [name]: Object.assign({}, state.effects[name], {
+        [action]: show
+      })
+    })
+  })
+  return next
+}
+
+export default {
+  init: (exposed) => ({
+    model: {
+      name: 'loading',
+      state: {
+        global: false,
+        models: {},
+        effects: {}
+      },
+      reducers: {
+        show: createLoadingAction(true),
+        hide: createLoadingAction(false),
+      }
+    },
+    onModel({ name }) {
+      // do not run dispatch on loading model
+      if (name === 'loading') { return }
+      const modelActions = exposed.dispatch[name]
+      // map over effects within models
+      Object.keys(modelActions).forEach(action => {
+        if (exposed.dispatch[name][action].isEffect) {
+          // copy function
+          const fn = exposed.dispatch[name][action]
+          // create function with pre & post loading calls
+          const dispatchWithHooks = async function (props) {
+            exposed.dispatch.loading.show({ name, action })
+            await fn(props)
+            // waits for dispatch function to finish before calling "hide"
+            exposed.dispatch.loading.hide({ name, action })
+          }
+          // replace existing effect with new dispatch
+          exposed.dispatch[name][action] = dispatchWithHooks
+        }
+      })
+    }
+  })
+}

--- a/src/plugins/loading.js
+++ b/src/plugins/loading.js
@@ -12,7 +12,7 @@ const createLoadingAction = (show) => (state, { name, action }) => {
   return next
 }
 
-export default {
+export default (config) => ({
   init: (exposed) => ({
     model: {
       name: 'loading',
@@ -48,4 +48,4 @@ export default {
       })
     }
   })
-}
+})

--- a/src/plugins/loading.js
+++ b/src/plugins/loading.js
@@ -36,7 +36,7 @@ export default {
           // copy function
           const fn = exposed.dispatch[name][action]
           // create function with pre & post loading calls
-          const dispatchWithHooks = async function (props) {
+          const dispatchWithHooks = async function dispatchWithHooks(props) {
             exposed.dispatch.loading.show({ name, action })
             await fn(props)
             // waits for dispatch function to finish before calling "hide"

--- a/src/plugins/selectors.js
+++ b/src/plugins/selectors.js
@@ -1,12 +1,15 @@
 // @flow
-export const select = {}
-
-export default () => ({
+export const internalInit = (exposed) => ({
   onModel(model: $model) {
-    select[model.name] = {}
+    exposed.select[model.name] = {}
     Object.keys(model.selectors || {}).forEach((selectorName: string) => {
-      select[model.name][selectorName] = (state: any, ...args) =>
+      exposed.select[model.name][selectorName] = (state: any, ...args) =>
         model.selectors[selectorName](state[model.name], ...args)
     })
   }
 })
+
+export default {
+  expose: { select: {} },
+  internalInit
+}

--- a/src/plugins/selectors.js
+++ b/src/plugins/selectors.js
@@ -1,15 +1,13 @@
 // @flow
-export const internalInit = (exposed) => ({
-  onModel(model: $model) {
-    exposed.select[model.name] = {}
-    Object.keys(model.selectors || {}).forEach((selectorName: string) => {
-      exposed.select[model.name][selectorName] = (state: any, ...args) =>
-        model.selectors[selectorName](state[model.name], ...args)
-    })
-  }
-})
-
 export default {
   expose: { select: {} },
-  internalInit
+  init: (exposed) => ({
+    onModel(model: $model) {
+      exposed.select[model.name] = {}
+      Object.keys(model.selectors || {}).forEach((selectorName: string) => {
+        exposed.select[model.name][selectorName] = (state: any, ...args) =>
+          model.selectors[selectorName](state[model.name], ...args)
+      })
+    }
+  })
 }

--- a/src/plugins/subscriptions/index.js
+++ b/src/plugins/subscriptions/index.js
@@ -10,38 +10,36 @@ const triggerAllSubscriptions = (matches) => (action) => {
   })
 }
 
-export const internalInit = () => ({
-  onModel(model: $model) {
-    // necessary to prevent invalid subscription names
-    const actionList = [
-      ...Object.keys(model.reducers || {}),
-      ...Object.keys(model.effects || {})
-    ]
-    Object.keys(model.subscriptions || {}).forEach((matcher: string) => {
-      createSubscription(model.name, matcher, model.subscriptions[matcher], actionList)
-    })
-  },
-  middleware: () => (next: (action: $action) => any) => (action: $action) => {
-    const { type } = action
-
-    // exact match
-    if (subscriptions.has(type)) {
-      const allSubscriptions = subscriptions.get(type)
-      // call each hook[modelName] with action
-      triggerAllSubscriptions(allSubscriptions)(action)
-    } else {
-      patternSubscriptions.forEach((handler: Object, matcher: string) => {
-        if (type.match(new RegExp(matcher))) {
-          const subscriptionMatches = patternSubscriptions.get(matcher)
-          triggerAllSubscriptions(subscriptionMatches)(action)
-        }
-      })
-    }
-
-    return next(action)
-  },
-})
-
 export default {
-  internalInit
+  init: () => ({
+    onModel(model: $model) {
+      // necessary to prevent invalid subscription names
+      const actionList = [
+        ...Object.keys(model.reducers || {}),
+        ...Object.keys(model.effects || {})
+      ]
+      Object.keys(model.subscriptions || {}).forEach((matcher: string) => {
+        createSubscription(model.name, matcher, model.subscriptions[matcher], actionList)
+      })
+    },
+    middleware: () => (next: (action: $action) => any) => (action: $action) => {
+      const { type } = action
+
+      // exact match
+      if (subscriptions.has(type)) {
+        const allSubscriptions = subscriptions.get(type)
+        // call each hook[modelName] with action
+        triggerAllSubscriptions(allSubscriptions)(action)
+      } else {
+        patternSubscriptions.forEach((handler: Object, matcher: string) => {
+          if (type.match(new RegExp(matcher))) {
+            const subscriptionMatches = patternSubscriptions.get(matcher)
+            triggerAllSubscriptions(subscriptionMatches)(action)
+          }
+        })
+      }
+
+      return next(action)
+    },
+  })
 }

--- a/src/plugins/subscriptions/index.js
+++ b/src/plugins/subscriptions/index.js
@@ -10,7 +10,7 @@ const triggerAllSubscriptions = (matches) => (action) => {
   })
 }
 
-export default () => ({
+export const internalInit = () => ({
   onModel(model: $model) {
     // necessary to prevent invalid subscription names
     const actionList = [
@@ -41,3 +41,7 @@ export default () => ({
     return next(action)
   },
 })
+
+export default {
+  internalInit
+}

--- a/src/utils/store.js
+++ b/src/utils/store.js
@@ -29,9 +29,7 @@ export const createStore = (
 }
 
 export const createReducersAndUpdateStore = (model: $model) : void => {
-  store.replaceReducer(
-    mergeReducers({
-      [model.name]: createReducers(model),
-    })
-  )
+  store.replaceReducer(mergeReducers({
+    [model.name]: createReducers(model),
+  }))
 }

--- a/src/utils/validate.js
+++ b/src/utils/validate.js
@@ -4,7 +4,7 @@ type $validation = Array<boolean | string>
 
 /**
  * Validate
- * 
+ *
  * takes an array of arrays of validations and
  * throws if an error occurs
  */

--- a/test/effects.test.js
+++ b/test/effects.test.js
@@ -58,29 +58,29 @@ describe('effects:', () => {
 
   // currently no solution for arrow functions as they are often transpiled by Babel or Typescript
   // there is no clear way to detect arrow functions
-  xtest('should be able trigger a local reducer using arrow functions and `this`', async () => {
-    const { model, init, dispatch, getStore } = require('../src')
-    init()
-
-    model({
-      name: 'example',
-      state: 0,
-      reducers: {
-        addOne: (state) => state + 1,
-      },
-      effects: {
-        asyncAddOneArrow: async () => {
-          await this.addOne()
-        }
-      }
-    })
-
-    await dispatch.example.asyncAddOneArrow()
-
-    expect(getStore().getState()).toEqual({
-      example: 1,
-    })
-  })
+  // xtest('should be able trigger a local reducer using arrow functions and `this`', async () => {
+  //   const { model, init, dispatch, getStore } = require('../src')
+  //   init()
+  //
+  //   model({
+  //     name: 'example',
+  //     state: 0,
+  //     reducers: {
+  //       addOne: (state) => state + 1,
+  //     },
+  //     effects: {
+  //       asyncAddOneArrow: async () => {
+  //         await this.addOne()
+  //       }
+  //     }
+  //   })
+  //
+  //   await dispatch.example.asyncAddOneArrow()
+  //
+  //   expect(getStore().getState()).toEqual({
+  //     example: 1,
+  //   })
+  // })
 
   test('should be able trigger a local reducer using functions and `this`', async () => {
     const { model, init, dispatch, getStore } = require('../src')

--- a/test/loading.test.js
+++ b/test/loading.test.js
@@ -1,0 +1,76 @@
+beforeEach(() => {
+  jest.resetModules()
+})
+
+describe('loading', () => {
+  it('loading.global should be false for normal dispatched action', () => {
+    const { init, model, dispatch, getStore } = require('../src/index')
+    const loadingPlugin = require('../src/plugins/loading').default
+    init({
+      plugins: [loadingPlugin]
+    })
+    model({
+      name: 'count',
+      state: 0,
+      reducers: {
+        increment: s => s + 1
+      }
+    })
+    dispatch.count.increment()
+    expect(getStore().getState().loading.global).toBe(false)
+  })
+  it('loading.global should be true for dispatched effect', () => {
+    const { init, model, dispatch, getStore } = require('../src/index')
+    const loadingPlugin = require('../src/plugins/loading').default
+    init({
+      plugins: [loadingPlugin]
+    })
+    model({
+      name: 'count',
+      state: 0,
+      effects: {
+        async timeout() {
+          await setTimeout(() => {}, 1000)
+        }
+      }
+    })
+    dispatch.count.timeout()
+    expect(getStore().getState().loading.global).toBe(true)
+  })
+  it('should change the loading.models', () => {
+    const { init, model, dispatch, getStore } = require('../src/index')
+    const loadingPlugin = require('../src/plugins/loading').default
+    init({
+      plugins: [loadingPlugin]
+    })
+    model({
+      name: 'count',
+      state: 0,
+      effects: {
+        async timeout() {
+          await setTimeout(() => {}, 1000)
+        }
+      }
+    })
+    dispatch.count.timeout()
+    expect(getStore().getState().loading.models.count).toBe(true)
+  })
+  it('should change the loading.effects', () => {
+    const { init, model, dispatch, getStore } = require('../src/index')
+    const loadingPlugin = require('../src/plugins/loading').default
+    init({
+      plugins: [loadingPlugin]
+    })
+    model({
+      name: 'count',
+      state: 0,
+      effects: {
+        async timeout() {
+          await setTimeout(() => {}, 1000)
+        }
+      }
+    })
+    dispatch.count.timeout()
+    expect(getStore().getState().loading.effects.count.timeout).toBe(true)
+  })
+})

--- a/test/loading.test.js
+++ b/test/loading.test.js
@@ -7,7 +7,7 @@ describe('loading', () => {
     const { init, model, dispatch, getStore } = require('../src/index')
     const loadingPlugin = require('../src/plugins/loading').default
     init({
-      plugins: [loadingPlugin]
+      plugins: [loadingPlugin()]
     })
     model({
       name: 'count',
@@ -23,7 +23,7 @@ describe('loading', () => {
     const { init, model, dispatch, getStore } = require('../src/index')
     const loadingPlugin = require('../src/plugins/loading').default
     init({
-      plugins: [loadingPlugin]
+      plugins: [loadingPlugin()]
     })
     model({
       name: 'count',
@@ -41,7 +41,7 @@ describe('loading', () => {
     const { init, model, dispatch, getStore } = require('../src/index')
     const loadingPlugin = require('../src/plugins/loading').default
     init({
-      plugins: [loadingPlugin]
+      plugins: [loadingPlugin()]
     })
     model({
       name: 'count',
@@ -59,7 +59,7 @@ describe('loading', () => {
     const { init, model, dispatch, getStore } = require('../src/index')
     const loadingPlugin = require('../src/plugins/loading').default
     init({
-      plugins: [loadingPlugin]
+      plugins: [loadingPlugin()]
     })
     model({
       name: 'count',

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -9,8 +9,8 @@ describe('plugins:', () => {
     const fns = [() => 1, () => 2]
     init({
       plugins: [
-        { internalInit: () => ({ onModel: fns[0] }) },
-        { internalInit: () => ({ onModel: fns[1] }) },
+        { init: () => ({ onModel: fns[0] }) },
+        { init: () => ({ onModel: fns[1] }) },
       ]
     })
     expect(modelHooks.slice(-2)).toEqual(fns)
@@ -23,8 +23,8 @@ describe('plugins:', () => {
     const m2 = () => next => action => next(action)
     init({
       plugins: [
-        { internalInit: () => ({ middleware: m1 }) },
-        { internalInit: () => ({ middleware: m2 }) },
+        { init: () => ({ middleware: m1 }) },
+        { init: () => ({ middleware: m2 }) },
       ]
     })
     expect(pluginMiddlewares.slice(-2)).toEqual([m1, m2])
@@ -37,7 +37,7 @@ describe('plugins:', () => {
       state: 0,
     }
     init({
-      plugins: [{ internalInit: () => ({ model }) }]
+      plugins: [{ init: () => ({ model }) }]
     })
     expect(getStore().getState()).toEqual({ a: 0 })
   })

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -9,8 +9,8 @@ describe('plugins:', () => {
     const fns = [() => 1, () => 2]
     init({
       plugins: [
-        () => ({ onModel: fns[0] }),
-        () => ({ onModel: fns[1] }),
+        { internalInit: () => ({ onModel: fns[0] }) },
+        { internalInit: () => ({ onModel: fns[1] }) },
       ]
     })
     expect(modelHooks.slice(-2)).toEqual(fns)
@@ -23,8 +23,8 @@ describe('plugins:', () => {
     const m2 = () => next => action => next(action)
     init({
       plugins: [
-        () => ({ middleware: m1 }),
-        () => ({ middleware: m2 }),
+        { internalInit: () => ({ middleware: m1 }) },
+        { internalInit: () => ({ middleware: m2 }) },
       ]
     })
     expect(pluginMiddlewares.slice(-2)).toEqual([m1, m2])
@@ -37,7 +37,7 @@ describe('plugins:', () => {
       state: 0,
     }
     init({
-      plugins: [() => ({ model })]
+      plugins: [{ internalInit: () => ({ model }) }]
     })
     expect(getStore().getState()).toEqual({ a: 0 })
   })


### PR DESCRIPTION
@ShMcK 

I'm typing this in a rush as I have to head to a dinner! Just playing around with some different ideas.

I'm not sure if I'm quite done with this, but as it stands:
- All tests pass.
- I changed all the core plugins to work with this approach. 

Take a look when you have a sec.

Maybe it makes life easier if you try and make some plugins with this API? 




#### plugins:
```js
export default {
  
  /*
    Expose stuff to other plugins.
    For other plugins: available as first param in 'internalInit'
    For the 'consumer': Available as normal. Just import it. see src/index.js for an example
  */
  expose: { select: {} },
  
  internalInit: (exposed) => ({
   onModel(model: $model) {
      exposed.select[model.name] = {}
      // do stuff with exposed things from other plugins
    }
  })
}
```