### PR TITLE
Feature/validate

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -59,7 +59,9 @@ export const setupPlugins = (config) => {
   }, config)
 
   const plugins = corePlugins.concat(mergedConfig.plugins || [])
-  const exposed = {}
+  const exposed = {
+    validate,
+  }
 
   plugins.forEach((plugin) => {
     // create plugin shared data space called "exposed"

--- a/src/plugins/dispatch.js
+++ b/src/plugins/dispatch.js
@@ -13,13 +13,23 @@ export default {
         await storeDispatch(action)
       }
   },
-  init: ({ dispatch, createDispatcher }) => ({
+  init: ({ dispatch, createDispatcher, validate }) => ({
     onInit(getStore) {
       storeDispatch = getStore().dispatch
     },
     onModel(model: $model) {
       dispatch[model.name] = {}
       Object.keys(model.reducers || {}).forEach((reducerName: string) => {
+        validate([
+          [
+            reducerName.match(/\//),
+            `Invalid reducer name (${model.name}/${reducerName})`
+          ],
+          [
+            typeof model.reducers[reducerName] !== 'function',
+            `Invalid reducer (${model.name}/${reducerName}). Must be a function`
+          ]
+        ])
         dispatch[model.name][reducerName] = createDispatcher(model.name, reducerName)
       })
     }

--- a/src/plugins/effects.js
+++ b/src/plugins/effects.js
@@ -3,9 +3,21 @@ export default {
   expose: {
     effects: {}
   },
-  init: ({ effects, dispatch, createDispatcher }) => ({
+  init: ({
+    effects, dispatch, createDispatcher, validate
+  }) => ({
     onModel(model: $model) {
       Object.keys(model.effects || {}).forEach((effectName: string) => {
+        validate([
+          [
+            effectName.match(/\//),
+            `Invalid effect name (${model.name}/${effectName})`
+          ],
+          [
+            typeof model.effects[effectName] !== 'function',
+            `Invalid effect (${model.name}/${effectName}). Must be a function`
+          ]
+        ])
         effects[`${model.name}/${effectName}`] = model.effects[effectName].bind(dispatch[model.name])
         // add effect to dispatch
         // is assuming dispatch is available already... that the dispatch plugin is in there

--- a/src/plugins/selectors.js
+++ b/src/plugins/selectors.js
@@ -1,10 +1,16 @@
 // @flow
 export default {
   expose: { select: {} },
-  init: ({ select }) => ({
+  init: ({ select, validate }) => ({
     onModel(model: $model) {
       select[model.name] = {}
       Object.keys(model.selectors || {}).forEach((selectorName: string) => {
+        validate([
+          [
+            typeof model.selectors[selectorName] !== 'function',
+            `Selector (${model.name}/${selectorName}) must be a function`
+          ]
+        ])
         select[model.name][selectorName] = (state: any, ...args) =>
           model.selectors[selectorName](state[model.name], ...args)
       })

--- a/src/plugins/subscriptions/create.js
+++ b/src/plugins/subscriptions/create.js
@@ -1,4 +1,3 @@
-import validate from '../../utils/validate'
 import { onHandlers } from './handlers'
 
 export const createSubscription = (
@@ -7,11 +6,6 @@ export const createSubscription = (
   onAction: (action: $action) => void,
   actionList: string[]
 ) => {
-  validate([
-    [typeof matcher !== 'string', 'subscription matcher must be a string'],
-    [typeof onAction !== 'function', 'subscription onAction must be a function'],
-  ])
-
   const createHandler = (target, formattedMatcher) => {
     // prevent infinite loops within models by validating against
     // subscription matchers in the action name

--- a/src/plugins/subscriptions/index.js
+++ b/src/plugins/subscriptions/index.js
@@ -11,7 +11,7 @@ const triggerAllSubscriptions = (matches) => (action) => {
 }
 
 export default {
-  init: () => ({
+  init: ({ validate }) => ({
     onModel(model: $model) {
       // necessary to prevent invalid subscription names
       const actionList = [
@@ -19,6 +19,16 @@ export default {
         ...Object.keys(model.effects || {})
       ]
       Object.keys(model.subscriptions || {}).forEach((matcher: string) => {
+        validate([
+          [
+            matcher.match(/\/(.+)?\//),
+            `Invalid subscription matcher (${matcher})`
+          ],
+          [
+            typeof model.subscriptions[matcher] !== 'function',
+            `Subscription matcher in ${model.name} (${matcher}) must be a function`
+          ]
+        ])
         createSubscription(model.name, matcher, model.subscriptions[matcher], actionList)
       })
     },

--- a/src/utils/validate.js
+++ b/src/utils/validate.js
@@ -10,12 +10,14 @@ type $validation = Array<boolean | string>
  */
 /* istanbul ignore next */
 const validate = (validations: Array<$validation>): void => {
-  validations.forEach((validation: $validation) => {
-    const [condition: boolean, errorMessage: string] = validation
-    if (condition) {
-      throw new Error(errorMessage)
-    }
-  })
+  if (process.env.NODE_ENV !== 'production') {
+    validations.forEach((validation: $validation) => {
+      const [condition: boolean, errorMessage: string] = validation
+      if (condition) {
+        throw new Error(errorMessage)
+      }
+    })
+  }
 }
 
 export default validate

--- a/test/dispatch.test.js
+++ b/test/dispatch.test.js
@@ -24,7 +24,9 @@ describe('dispatch:', () => {
     })
 
     test('should be able to call dispatch directly', () => {
-      const { model, init, getStore, dispatch } = require('../src')
+      const {
+        model, init, getStore, dispatch
+      } = require('../src')
       init()
 
       model({
@@ -43,7 +45,9 @@ describe('dispatch:', () => {
     })
 
     test('should dispatch an action', () => {
-      const { model, init, getStore, dispatch } = require('../src')
+      const {
+        model, init, getStore, dispatch
+      } = require('../src')
       init()
 
       model({
@@ -62,7 +66,9 @@ describe('dispatch:', () => {
     })
 
     test('should dispatch multiple actions', () => {
-      const { model, init, getStore, dispatch } = require('../src')
+      const {
+        model, init, getStore, dispatch
+      } = require('../src')
       init()
 
       model({
@@ -82,7 +88,9 @@ describe('dispatch:', () => {
     })
 
     test('should handle multiple models', () => {
-      const { model, init, getStore, dispatch } = require('../src')
+      const {
+        model, init, getStore, dispatch
+      } = require('../src')
       init()
 
       model({
@@ -111,9 +119,41 @@ describe('dispatch:', () => {
     })
   })
 
+  test('should throw if the reducer name is invalid', () => {
+    const {
+      model, init
+    } = require('../src')
+    init()
+
+    expect(() => model({
+      name: 'a',
+      state: 42,
+      reducers: {
+        'invalid/name': () => 43
+      },
+    })).toThrow()
+  })
+
+  test('should throw if the reducer is not a function', () => {
+    const {
+      model, init
+    } = require('../src')
+    init()
+
+    expect(() => model({
+      name: 'a',
+      state: 42,
+      reducers: {
+        is43: 43,
+      },
+    })).toThrow()
+  })
+
   describe('params:', () => {
     test('should pass state as the first reducer param', () => {
-      const { model, init, getStore, dispatch } = require('../src')
+      const {
+        model, init, getStore, dispatch
+      } = require('../src')
       init()
 
       model({
@@ -132,7 +172,9 @@ describe('dispatch:', () => {
     })
 
     test('should pass payload as the second param', () => {
-      const { model, init, getStore, dispatch } = require('../src')
+      const {
+        model, init, getStore, dispatch
+      } = require('../src')
       init()
 
       model({

--- a/test/effects.test.js
+++ b/test/effects.test.js
@@ -33,7 +33,9 @@ describe('effects:', () => {
   // })
 
   test('should be able to trigger another action', async () => {
-    const { model, init, dispatch, getStore } = require('../src')
+    const {
+      model, init, dispatch, getStore
+    } = require('../src')
     init()
 
     model({
@@ -83,7 +85,9 @@ describe('effects:', () => {
   // })
 
   test('should be able trigger a local reducer using functions and `this`', async () => {
-    const { model, init, dispatch, getStore } = require('../src')
+    const {
+      model, init, dispatch, getStore
+    } = require('../src')
     init()
 
     model({
@@ -107,7 +111,9 @@ describe('effects:', () => {
   })
 
   test('should be able trigger a local reducer using object function shorthand and `this`', async () => {
-    const { model, init, dispatch, getStore } = require('../src')
+    const {
+      model, init, dispatch, getStore
+    } = require('../src')
     init()
 
     model({
@@ -131,7 +137,9 @@ describe('effects:', () => {
   })
 
   test('should be able to trigger another action with a value', async () => {
-    const { model, init, dispatch, getStore } = require('../src')
+    const {
+      model, init, dispatch, getStore
+    } = require('../src')
     init()
 
     model({
@@ -155,7 +163,9 @@ describe('effects:', () => {
   })
 
   test('should be able to trigger another action w/ an object value', async () => {
-    const { model, init, dispatch, getStore } = require('../src')
+    const {
+      model, init, dispatch, getStore
+    } = require('../src')
     init()
 
     model({
@@ -179,7 +189,9 @@ describe('effects:', () => {
   })
 
   test('should be able to trigger another action w/ another action', async () => {
-    const { model, init, dispatch, getStore } = require('../src')
+    const {
+      model, init, dispatch, getStore
+    } = require('../src')
     init()
 
     model({
@@ -206,7 +218,9 @@ describe('effects:', () => {
   })
 
   test('should be able to trigger another action w/ multiple actions', async () => {
-    const { model, init, dispatch, getStore } = require('../src')
+    const {
+      model, init, dispatch, getStore
+    } = require('../src')
     init()
 
     model({
@@ -237,5 +251,35 @@ describe('effects:', () => {
         example: 5,
       })
     })
+  })
+
+  test('should throw if the effect name is invalid', () => {
+    const {
+      model, init
+    } = require('../src')
+    init()
+
+    expect(() => model({
+      name: 'a',
+      state: 42,
+      effects: {
+        'invalid/effect': () => 43,
+      },
+    })).toThrow()
+  })
+
+  test('should throw if the effect is not a function', () => {
+    const {
+      model, init
+    } = require('../src')
+    init()
+
+    expect(() => model({
+      name: 'a',
+      state: 42,
+      effects: {
+        is43: 43,
+      },
+    })).toThrow()
   })
 })

--- a/test/select.test.js
+++ b/test/select.test.js
@@ -20,7 +20,9 @@ describe('select:', () => {
   })
 
   it('should allow access to the selector', () => {
-    const { init, model, select, getStore } = require('../src')
+    const {
+      init, model, select, getStore
+    } = require('../src')
     init()
     model({
       name: 'a',
@@ -38,7 +40,9 @@ describe('select:', () => {
   })
 
   it('should allow passing in of params toselector', () => {
-    const { init, model, select, getStore } = require('../src')
+    const {
+      init, model, select, getStore
+    } = require('../src')
     init()
     model({
       name: 'a',
@@ -55,10 +59,25 @@ describe('select:', () => {
     expect(prepended).toBe('P2')
   })
 
-  describe('reselect: ', () => {
+  test('should throw if selector is not a function', () => {
+    const {
+      init, model
+    } = require('../src')
+    init()
+    expect(() => model({
+      name: 'a',
+      state: 2,
+      selectors: {
+        invalid: 42,
+      },
+    })).toThrow()
+  })
 
+  describe('reselect: ', () => {
     it('should allow for createSelector to be used instead of a normal selector', () => {
-      const { init, model, select, getStore } = require('../src')
+      const {
+        init, model, select, getStore
+      } = require('../src')
       const { createSelector } = require('reselect')
       init()
       model({
@@ -77,7 +96,9 @@ describe('select:', () => {
     })
 
     it('should allow createSelector to be used outside of a model', () => {
-      const { init, model, select, getStore } = require('../src')
+      const {
+        init, model, select, getStore
+      } = require('../src')
       const { createSelector } = require('reselect')
       init()
       model({
@@ -107,7 +128,9 @@ describe('select:', () => {
     })
 
     it('should allow for mixing normal selectors and reselect selectors', () => {
-      const { init, model, select, getStore } = require('../src')
+      const {
+        init, model, select, getStore
+      } = require('../src')
       const { createSelector } = require('reselect')
       init()
       model({

--- a/test/subscriptions.test.js
+++ b/test/subscriptions.test.js
@@ -11,7 +11,9 @@ const common = {
 
 describe('subscriptions:', () => {
   test('should create a working subscription', () => {
-    const { model, init, dispatch, getStore } = require('../src')
+    const {
+      model, init, dispatch, getStore
+    } = require('../src')
     init()
 
     model({
@@ -35,7 +37,9 @@ describe('subscriptions:', () => {
   })
 
   test('should allow for two subscriptions with same name in different models', () => {
-    const { model, init, dispatch, getStore } = require('../src')
+    const {
+      model, init, dispatch, getStore
+    } = require('../src')
     init()
 
     model({
@@ -67,7 +71,9 @@ describe('subscriptions:', () => {
   })
 
   test('should allow for three subscriptions with same name in different models', () => {
-    const { model, init, dispatch, getStore } = require('../src')
+    const {
+      model, init, dispatch, getStore
+    } = require('../src')
     init()
 
     model({
@@ -114,7 +120,7 @@ describe('subscriptions:', () => {
     })
   })
 
-  test('it should throw if a subscription matcher is invalid', () => {
+  test('should throw if a subscription matcher is invalid', () => {
     const { model, init, dispatch } = require('../src')
     init()
 
@@ -127,10 +133,24 @@ describe('subscriptions:', () => {
     })).toThrow()
   })
 
-  describe('pattern matching', () => {
+  test('should enforce subscriptions are functions', () => {
+    const { model, init } = require('../src')
+    init()
 
+    expect(() => model({
+      name: 'first',
+      ...common,
+      subscriptions: {
+        'valid/matcher': 42,
+      }
+    })).toThrow()
+  })
+
+  describe('pattern matching', () => {
     test('should create working pattern matching subscription (second/*)', () => {
-      const { model, init, dispatch, getStore } = require('../src')
+      const {
+        model, init, dispatch, getStore
+      } = require('../src')
       init()
 
       model({
@@ -154,7 +174,9 @@ describe('subscriptions:', () => {
     })
 
     test('should create working pattern matching subsription (*/addOne)', () => {
-      const { model, init, dispatch, getStore } = require('../src')
+      const {
+        model, init, dispatch, getStore
+      } = require('../src')
       init()
 
       model({
@@ -181,7 +203,9 @@ describe('subscriptions:', () => {
     })
 
     test('should create working pattern matching subscription (second/add*)', () => {
-      const { model, init, dispatch, getStore } = require('../src')
+      const {
+        model, init, dispatch, getStore
+      } = require('../src')
       init()
 
       model({
@@ -261,7 +285,9 @@ describe('subscriptions:', () => {
 
   describe('unsubscribe:', () => {
     test('a matched action', () => {
-      const { model, init, dispatch, getStore } = require('../src')
+      const {
+        model, init, dispatch, getStore
+      } = require('../src')
       const { unsubscribe } = require('../src/plugins/subscriptions/unsubscribe')
       init()
 
@@ -286,7 +312,9 @@ describe('subscriptions:', () => {
       })
     })
     test('a pattern matched action', () => {
-      const { model, init, dispatch, getStore } = require('../src')
+      const {
+        model, init, dispatch, getStore
+      } = require('../src')
       const { unsubscribe } = require('../src/plugins/subscriptions/unsubscribe')
       init()
 
@@ -311,7 +339,9 @@ describe('subscriptions:', () => {
       })
     })
     test('a pattern matched action when more than one', () => {
-      const { model, init, dispatch, getStore } = require('../src')
+      const {
+        model, init, dispatch, getStore
+      } = require('../src')
       const { unsubscribe } = require('../src/plugins/subscriptions/unsubscribe')
       init()
 
@@ -361,7 +391,9 @@ describe('subscriptions:', () => {
       expect(onUnsubscribe).toThrow()
     })
     test('should do nothing if no action', () => {
-      const { model, init, dispatch, getStore } = require('../src')
+      const {
+        model, init, dispatch, getStore
+      } = require('../src')
       const { unsubscribe } = require('../src/plugins/subscriptions/unsubscribe')
       init()
 


### PR DESCRIPTION
Closes #86.

Passes validate around in "exposed". This way everything uses the same validation function.

Validation is only run on start, and only if `process.env.NODE_ENV !== production`