### PR TITLE
update examples. demonstrate failing dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,20 @@ A comparison may help:
 
 ##### model
 ```js
-import { init, model } from '@rematch/core'
+import { init } from '@rematch/core'
 
-init()
-
-model({
+const count = {
   name: 'count',
   state: 0,
   reducers: {
     upBy: (state, payload) => state + payload
   }
+}
+
+init({
+  models: { count }
 })
+
 ```
 
 ##### view
@@ -138,17 +141,19 @@ connect(mapStateToProps, mapDispatchToProps)(Component)
 ### Level 1
 
 ```js
-import { init, model, dispatch } from '@rematch/core'
+import { init, dispatch } from '@rematch/core'
 
-init()
-
-model({
+const count = {
   name: 'count',
   state: 0,
   reducers: {
     addOne: (state) => state + 1,
     addBy: (state, payload) => state + payload
   }
+}
+
+init({
+  models: { count }
 })
 
 dispatch.count.addOne() // { count: 1 }
@@ -162,9 +167,7 @@ dispatch({ type: 'count/addBy', payload: 5 }) // { count: 12 }
 ```js
 import { init, model, getStore } from '@rematch/core'
 
-init()
-
-model({
+const todos = {
   name: 'todos',
   state: {
     todos: {
@@ -197,6 +200,10 @@ model({
       return Object.keys(state).filter(id => state.todos[id].completed)
     }
   },
+}
+
+init({
+  models: { todos }
 })
 
 const state = getStore().getState()
@@ -212,6 +219,10 @@ npm install @rematch/core
 ## API
 
 - init
+  - models
+  - plugins
+  - extraReducers
+  - customCombineReducers
 - model
   - name
   - state

--- a/examples/react-redux-count/src/App.js
+++ b/examples/react-redux-count/src/App.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { dispatch, select } from '@rematch/core'
+
+// Make a presentational component.
+// It knows nothing about redux or rematch.
+const App = ({ valueA, valueB, valueADoubled, asyncAIncr, incrB, incrA }) => (
+  <div>
+    <h2>countA is <b style={{backgroundColor: '#ccc'}}>{valueA}</b></h2>
+    <h2>countB is <b style={{backgroundColor: '#ccc'}}>{valueB}</b></h2>
+
+    <h2>
+      <button onClick={incrA}>Increment countA</button>
+      {' '}
+      <em style={{backgroundColor: 'yellow'}}>(normal dispatch)</em>
+    </h2>
+    <h2>countA doubled is <b style={{backgroundColor: '#ccc'}}>{valueADoubled}</b> <em style={{backgroundColor: 'yellow'}}>(a selector!)</em></h2>
+    <h2>
+      <button onClick={asyncAIncr}>Increment countA (delayed 1 second)</button>
+      {' '}
+      <em style={{backgroundColor: 'yellow'}}>(an async effect!!!)</em>
+    </h2>
+    <h2>
+      <button onClick={incrB}>Increment countB</button>
+      {' '}
+      <em style={{backgroundColor: 'yellow'}}>(countA has a hook listening to 'countB/increment')</em>
+    </h2>
+  </div>
+)
+
+// Use react-redux's connect
+export default connect(state => ({
+  valueA: state.countA,
+  valueB: state.countB,
+  valueADoubled : 2, //select.countA.double(state),
+  incrA: dispatch.countA.increment,
+  asyncAIncr: dispatch.countA.asyncIncrement,
+  incrB: dispatch.countB.increment,
+}))(App)

--- a/examples/react-redux-count/src/App.js
+++ b/examples/react-redux-count/src/App.js
@@ -32,7 +32,7 @@ const App = ({ valueA, valueB, valueADoubled, asyncAIncr, incrB, incrA }) => (
 export default connect(state => ({
   valueA: state.countA,
   valueB: state.countB,
-  valueADoubled : 2, //select.countA.double(state),
+  valueADoubled: select.countA.double(state),
   incrA: dispatch.countA.increment,
   asyncAIncr: dispatch.countA.asyncIncrement,
   incrB: dispatch.countB.increment,

--- a/examples/react-redux-count/src/index.js
+++ b/examples/react-redux-count/src/index.js
@@ -1,82 +1,18 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { connect, Provider } from 'react-redux'
-import { model, init, dispatch, select, getStore } from '@rematch/core'
+import { Provider } from 'react-redux'
+import { init, getStore } from '@rematch/core'
+import App from './App'
+import * as models from './models'
 
-init()
-
-model({
-  name: 'countA',
-  state: 0,
-  reducers: {
-    increment: s => s + 1
-  },
-  effects: {
-    asyncIncrement: async (payload, getState) => {
-      await new Promise((resolve) => {
-        setTimeout(resolve, 1000)
-      })
-      dispatch.countA.increment()
-    }
-  },
-  selectors: {
-    double: s => s * 2
-  },
-  subscriptions: {
-    'countB/increment': () => {
-      dispatch.countA.increment()
-    }
-  }
+init({
+  models,
 })
-
-model({
-  name: 'countB',
-  state: 0,
-  reducers: {
-    increment: s => s + 1
-  },
-})
-
-// Make a presentational component.
-// It knows nothing about redux or rematch.
-const App = ({ valueA, valueB, valueADoubled, asyncAIncr, incrB, incrA }) => (
-  <div>
-    <h2>countA is <b style={{backgroundColor: '#ccc'}}>{valueA}</b></h2>
-    <h2>countB is <b style={{backgroundColor: '#ccc'}}>{valueB}</b></h2>
-
-    <h2>
-      <button onClick={incrA}>Increment countA</button>
-      {' '}
-      <em style={{backgroundColor: 'yellow'}}>(normal dispatch)</em>
-    </h2>
-    <h2>countA doubled is <b style={{backgroundColor: '#ccc'}}>{valueADoubled}</b> <em style={{backgroundColor: 'yellow'}}>(a selector!)</em></h2>
-    <h2>
-      <button onClick={asyncAIncr}>Increment countA (delayed 1 second)</button>
-      {' '}
-      <em style={{backgroundColor: 'yellow'}}>(an async effect!!!)</em>
-    </h2>
-    <h2>
-      <button onClick={incrB}>Increment countB</button>
-      {' '}
-      <em style={{backgroundColor: 'yellow'}}>(countA has a hook listening to 'countB/increment')</em>
-    </h2>
-  </div>
-)
-
-// Use react-redux's connect
-const AppContainer = connect(state => ({
-  valueA: state.countA,
-  valueB: state.countB,
-  valueADoubled : select.countA.double(state),
-  incrA: () => dispatch.countA.increment(),
-  asyncAIncr: () => dispatch.countA.asyncIncrement(),
-  incrB: () => dispatch.countB.increment()
-}))(App)
 
 // Use react-redux's <Provider /> and pass it the store.
 ReactDOM.render(
   <Provider store={getStore()}>
-    <AppContainer />
+    <App />
   </Provider>,
   document.getElementById('root')
 )

--- a/examples/react-redux-count/src/models.js
+++ b/examples/react-redux-count/src/models.js
@@ -1,0 +1,33 @@
+import { dispatch } from '@rematch/core'
+
+export const countA = {
+  name: 'countA',
+  state: 0,
+  reducers: {
+    increment: s => s + 1
+  },
+  effects: {
+    asyncIncrement: async (payload, getState) => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1000)
+      })
+      dispatch.countA.increment()
+    }
+  },
+  selectors: {
+    double: s => s * 2
+  },
+  subscriptions: {
+    'countB/increment': () => {
+      dispatch.countA.increment()
+    }
+  }
+}
+
+export const countB = {
+  name: 'countB',
+  state: 0,
+  reducers: {
+    increment: s => s + 1
+  },
+}

--- a/plugins/loading/src/index.js
+++ b/plugins/loading/src/index.js
@@ -14,7 +14,7 @@ const createLoadingAction = (show) => (state, { name, action }) => ({
 
 export default (config = {}) => {
   const loadingModelName = config.name || 'loading'
-  const model = {
+  const loading = {
     name: loadingModelName,
     state: {
       global: false,
@@ -28,18 +28,20 @@ export default (config = {}) => {
   }
   return {
     init: ({ dispatch }) => ({
-      model,
+      models: {
+        loading,
+      },
       onModel({ name }) {
         // do not run dispatch on loading model
         if (name === loadingModelName) { return }
-        model.state.models[name] = false
-        model.state.effects[name] = {}
+        loading.state.models[name] = false
+        loading.state.effects[name] = {}
         const modelActions = dispatch[name]
         // map over effects within models
         Object.keys(modelActions).forEach(action => {
           if (dispatch[name][action].isEffect) {
             // copy function
-            model.state.effects[name][action] = false
+            loading.state.effects[name][action] = false
             const fn = dispatch[name][action]
             // create function with pre & post loading calls
             const dispatchWithHooks = async function dispatchWithHooks(props) {
@@ -51,7 +53,7 @@ export default (config = {}) => {
             // replace existing effect with new dispatch
             dispatch[name][action] = dispatchWithHooks
           } else {
-            model.state.models[name] = false
+            loading.state.models[name] = false
           }
         })
       }

--- a/plugins/loading/test/loading.test.js
+++ b/plugins/loading/test/loading.test.js
@@ -25,7 +25,7 @@ describe('loading', () => {
       models: { count },
       plugins: [loadingPlugin()]
     })
-    dispatch.count.increment()
+    dispatch.count.addOne()
     expect(getStore().getState().loading.global).toBe(false)
   })
 
@@ -101,7 +101,7 @@ describe('loading', () => {
       models: { count },
       plugins: [loadingPlugin({ name: 'load' })]
     })
-    dispatch.count.increment()
+    dispatch.count.addOne()
     expect(getStore().getState().load.global).toBe(false)
   })
 })

--- a/plugins/loading/test/loading.test.js
+++ b/plugins/loading/test/loading.test.js
@@ -2,137 +2,104 @@ beforeEach(() => {
   jest.resetModules()
 })
 
+const count = {
+  name: 'count',
+  state: 0,
+  reducers: {
+    addOne: s => s + 1
+  },
+  effects: {
+    async timeout() {
+      await setTimeout(() => {}, 1000)
+    }
+  }
+}
+
 describe('loading', () => {
   test('loading.global should be false for normal dispatched action', () => {
     const {
-      init, model, dispatch, getStore
+      init, dispatch, getStore
     } = require('../../../src/index')
     const loadingPlugin = require('../src').default
     init({
+      models: { count },
       plugins: [loadingPlugin()]
-    })
-    model({
-      name: 'count',
-      state: 0,
-      reducers: {
-        increment: s => s + 1
-      }
     })
     dispatch.count.increment()
     expect(getStore().getState().loading.global).toBe(false)
   })
+
   test('loading.global should be true for dispatched effect', () => {
     const {
-      init, model, dispatch, getStore
+      init, dispatch, getStore
     } = require('../../../src/index')
     const loadingPlugin = require('../src').default
     init({
+      models: { count },
       plugins: [loadingPlugin()]
-    })
-    model({
-      name: 'count',
-      state: 0,
-      effects: {
-        async timeout() {
-          await setTimeout(() => {}, 1000)
-        }
-      }
     })
     dispatch.count.timeout()
     expect(getStore().getState().loading.global).toBe(true)
   })
+
   test('should set loading.models[name] to false', () => {
     const {
-      init, model, getStore
+      init, getStore
     } = require('../../../src/index')
     const loadingPlugin = require('../src').default
     init({
+      models: { count },
       plugins: [loadingPlugin()]
-    })
-    model({
-      name: 'count',
-      state: 0,
-      effects: {
-        async timeout() {
-          await setTimeout(() => {}, 1000)
-        }
-      }
     })
     expect(getStore().getState().loading.models.count).toBe(false)
   })
+
   test('should change the loading.models', () => {
     const {
-      init, model, dispatch, getStore
+      init, dispatch, getStore
     } = require('../../../src/index')
     const loadingPlugin = require('../src').default
     init({
+      models: { count },
       plugins: [loadingPlugin()]
-    })
-    model({
-      name: 'count',
-      state: 0,
-      effects: {
-        async timeout() {
-          await setTimeout(() => {}, 1000)
-        }
-      }
     })
     dispatch.count.timeout()
     expect(getStore().getState().loading.models.count).toBe(true)
   })
+
   test('should set loading.effects[name] to object of effects', () => {
     const {
-      init, model, dispatch, getStore
+      init, getStore
     } = require('../../../src/index')
     const loadingPlugin = require('../src').default
     init({
+      models: { count },
       plugins: [loadingPlugin()]
-    })
-    model({
-      name: 'count',
-      state: 0,
-      effects: {
-        async timeout() {
-          await setTimeout(() => {}, 1000)
-        }
-      }
     })
     expect(getStore().getState().loading.effects.count.timeout).toBe(false)
   })
+
   test('should change the loading.effects', () => {
     const {
-      init, model, dispatch, getStore
+      init, dispatch, getStore
     } = require('../../../src/index')
     const loadingPlugin = require('../src').default
     init({
+      models: { count },
       plugins: [loadingPlugin()]
-    })
-    model({
-      name: 'count',
-      state: 0,
-      effects: {
-        async timeout() {
-          await setTimeout(() => {}, 1000)
-        }
-      }
     })
     dispatch.count.timeout()
     expect(getStore().getState().loading.effects.count.timeout).toBe(true)
   })
+
   test('should configure the loading name', () => {
     const {
-      init, model, dispatch, getStore
+      init, dispatch, getStore
     } = require('../../../src/index')
     const loadingPlugin = require('../src').default
     init({
+      models: { count },
       plugins: [loadingPlugin({ name: 'load' })]
-    })
-    model({
-      name: 'count',
-      state: 0,
-      reducers: {
-        increment: s => s + 1
-      }
     })
     dispatch.count.increment()
     expect(getStore().getState().load.global).toBe(false)

--- a/plugins/persist/test/persist.test.js
+++ b/plugins/persist/test/persist.test.js
@@ -57,4 +57,21 @@ describe('persist', () => {
     const persistor = getPersistor()
     expect(persistor.purge).toBeDefined()
   })
+
+  test('should work with init models', () => {
+    const persistPlugin = require('../src').default
+    const { getPersistor } = require('../src')
+    const { init } = require('../../../src')
+    const a = {
+      name: 'a',
+      state: { b: 1 }
+    }
+    init({
+      initialState: {},
+      plugins: [persistPlugin()],
+      models: { a }
+    })
+    const persistor = getPersistor()
+    expect(persistor.purge).toBeDefined()
+  })
 })

--- a/src/core.js
+++ b/src/core.js
@@ -1,5 +1,4 @@
 // @flow
-import { createModel } from './model'
 import { getStore } from './redux/store'
 
 export const modelHooks = []

--- a/src/core.js
+++ b/src/core.js
@@ -21,10 +21,5 @@ export const postStore = (plugins) => {
     if (plugin.onInit) {
       plugin.onInit(getStore)
     }
-    if (plugin.models) {
-      Object.keys(plugin.models).forEach(key => {
-        createModel(plugin.models[key])
-      })
-    }
   })
 }

--- a/src/core.js
+++ b/src/core.js
@@ -10,19 +10,21 @@ export const preStore = (plugins) => {
     if (plugin.middleware) {
       pluginMiddlewares.push(plugin.middleware)
     }
+    if (plugin.onModel) {
+      modelHooks.push(plugin.onModel)
+    }
   })
 }
 
 export const postStore = (plugins) => {
   plugins.forEach((plugin) => {
-    if (plugin.onModel) {
-      modelHooks.push(plugin.onModel)
-    }
-    if (plugin.model) {
-      createModel(plugin.model)
-    }
     if (plugin.onInit) {
       plugin.onInit(getStore)
+    }
+    if (plugin.models) {
+      Object.keys(plugin.models).forEach(key => {
+        createModel(plugin.models[key])
+      })
     }
   })
 }

--- a/src/init.js
+++ b/src/init.js
@@ -41,7 +41,7 @@ const init = (initConfig: $config = {}): void => {
   const pluginConfigs = corePlugins.concat(config.plugins || [])
   const exposed = getExposed(pluginConfigs)
   const plugins = buildPlugins(pluginConfigs, exposed)
-  
+
   // preStore: middleware, model hooks
   preStore(plugins)
 
@@ -53,7 +53,7 @@ const init = (initConfig: $config = {}): void => {
   // create a redux store with initialState
   // merge in additional extra reducers
   createStore(config)
-  
+
   // postStore: onInit
   postStore(plugins)
 }

--- a/src/init.js
+++ b/src/init.js
@@ -41,7 +41,7 @@ const init = (initConfig: $config = {}): void => {
   const plugins = buildPlugins(pluginConfigs, exposed)
   // preStore: middleware, initModels
   preStore(plugins)
-  createInitModel(config.models)
+  createInitModel(config.models, plugins)
   // create a redux store with initialState
   // merge in additional extra reducers
   createStore(config)

--- a/src/init.js
+++ b/src/init.js
@@ -4,9 +4,10 @@ import isObject from './utils/isObject'
 import mergeConfig from './utils/mergeConfig'
 import getExposed from './utils/getExposed'
 import buildPlugins from './utils/buildPlugins'
+import getModels from './utils/getModels'
 import { preStore, postStore } from './core'
 import corePlugins from './plugins'
-import { createInitModel } from './model'
+import { createInitModels } from './model'
 import { createStore } from './redux/store'
 
 const validateConfig = (config: $config) =>
@@ -39,12 +40,18 @@ const init = (initConfig: $config = {}): void => {
   const pluginConfigs = corePlugins.concat(config.plugins || [])
   const exposed = getExposed(pluginConfigs)
   const plugins = buildPlugins(pluginConfigs, exposed)
-  // preStore: middleware, initModels
+  
+  // preStore: middleware, model hooks
   preStore(plugins)
-  createInitModel(config.models, plugins)
+
+  // collect all models
+  const models = getModels(config, plugins)
+  createInitModels(models)
+
   // create a redux store with initialState
   // merge in additional extra reducers
   createStore(config)
+  
   // postStore: onInit
   postStore(plugins)
 }

--- a/src/init.js
+++ b/src/init.js
@@ -52,7 +52,7 @@ const init = (initConfig: $config = {}): void => {
 
   // create a redux store with initialState
   // merge in additional extra reducers
-  createStore(config, models)
+  createStore(config)
   
   // postStore: onInit
   postStore(plugins)

--- a/src/init.js
+++ b/src/init.js
@@ -6,7 +6,7 @@ import getExposed from './utils/getExposed'
 import buildPlugins from './utils/buildPlugins'
 import { preStore, postStore } from './core'
 import corePlugins from './plugins'
-import { createInitModelHooks } from './model'
+import { createInitModel } from './model'
 import { createStore } from './redux/store'
 
 const validateConfig = (config: $config) =>
@@ -41,7 +41,7 @@ const init = (initConfig: $config = {}): void => {
   const plugins = buildPlugins(pluginConfigs, exposed)
   // preStore: middleware, initModels
   preStore(plugins)
-  createInitModelHooks(config)
+  createInitModel(config.models)
   // create a redux store with initialState
   // merge in additional extra reducers
   createStore(config)

--- a/src/init.js
+++ b/src/init.js
@@ -7,8 +7,9 @@ import buildPlugins from './utils/buildPlugins'
 import getModels from './utils/getModels'
 import { preStore, postStore } from './core'
 import corePlugins from './plugins'
-import { createInitModels } from './model'
+import { initModelHooks } from './model'
 import { createStore } from './redux/store'
+import { initReducers } from './redux/reducers'
 
 const validateConfig = (config: $config) =>
   validate([
@@ -46,11 +47,12 @@ const init = (initConfig: $config = {}): void => {
 
   // collect all models
   const models = getModels(config, plugins)
-  createInitModels(models)
+  initModelHooks(models)
+  initReducers(models, config)
 
   // create a redux store with initialState
   // merge in additional extra reducers
-  createStore(config)
+  createStore(config, models)
   
   // postStore: onInit
   postStore(plugins)

--- a/src/model.js
+++ b/src/model.js
@@ -22,8 +22,6 @@ export const createModel = (model: $model): void => {
   createReducersAndUpdateStore(model)
 }
 
-export const createInitModels = (models) => {
-  models.forEach(model => {
-    addModel(model)
-  })
+export const initModelHooks = (models) => {
+  models.forEach(model => addModel(model))
 }

--- a/src/model.js
+++ b/src/model.js
@@ -22,10 +22,8 @@ export const createModel = (model: $model): void => {
   createReducersAndUpdateStore(model)
 }
 
-export const createInitModelHooks = (config) => {
-  const models = config.models || {}
+export const createInitModel = (models = {}) => {
   Object.keys(models).forEach(key => {
-    const model = config.models[key]
-    addModel(model)
+    addModel(models[key])
   })
 }

--- a/src/model.js
+++ b/src/model.js
@@ -22,7 +22,17 @@ export const createModel = (model: $model): void => {
   createReducersAndUpdateStore(model)
 }
 
-export const createInitModel = (models = {}) => {
+export const createInitModel = (configModels = {}, plugins) => {
+  const models = configModels
+  // add plugin models
+  plugins.forEach(plugin => {
+    if (plugin.models) {
+      Object.keys(plugin.models).forEach(key => {
+        const model = plugin.models[key]
+        configModels[key] = plugin.models[key]
+      })
+    }
+  })
   Object.keys(models).forEach(key => {
     addModel(models[key])
   })

--- a/src/model.js
+++ b/src/model.js
@@ -22,18 +22,8 @@ export const createModel = (model: $model): void => {
   createReducersAndUpdateStore(model)
 }
 
-export const createInitModel = (configModels = {}, plugins) => {
-  const models = configModels
-  // add plugin models
-  plugins.forEach(plugin => {
-    if (plugin.models) {
-      Object.keys(plugin.models).forEach(key => {
-        const model = plugin.models[key]
-        configModels[key] = plugin.models[key]
-      })
-    }
-  })
-  Object.keys(models).forEach(key => {
-    addModel(models[key])
+export const createInitModels = (models) => {
+  models.forEach(model => {
+    addModel(model)
   })
 }

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -40,11 +40,9 @@ export const initReducers = (models, { customCombineReducers, extraReducers }) :
   if (customCombineReducers) {
     combine = customCombineReducers
   }
-  mergeReducers(
-    models.reduce((reducers, model) => ({
+  mergeReducers(models.reduce((reducers, model) => ({
     ...createModelReducer(model),
     ...reducers,
-  }), extraReducers || {})
-  )
+  }), extraReducers || {}))
 }
 

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -2,8 +2,10 @@
 /* eslint no-underscore-dangle: 0 */
 import { combineReducers } from 'redux'
 
-let _reducers: $reducers
 let combine = combineReducers
+
+let _reducers: $reducers = {}
+export const getReducers = () => combine(_reducers)
 
 // get reducer for given dispatch type
 // pass in (state, payload)
@@ -31,11 +33,16 @@ export const mergeReducers = (nextReducers: $reducers) => {
   return combine(_reducers)
 }
 
-export const initReducers = ({ customCombineReducers }) : void => {
+export const initReducers = (models, { customCombineReducers, extraReducers }) : void => {
   // overwrite combineReducers if config.customCombineReducers
   if (customCombineReducers) {
     combine = customCombineReducers
   }
-  _reducers = {}
+  mergeReducers(
+    models.reduce((reducers, model) => ({
+    ...createModelReducer(model),
+    ...reducers,
+  }), extraReducers || {})
+  )
 }
 

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -5,7 +5,6 @@ import { combineReducers } from 'redux'
 let combine = combineReducers
 
 let _reducers: $reducers = {}
-export const getReducers = () => combine(_reducers)
 
 // get reducer for given dispatch type
 // pass in (state, payload)
@@ -28,8 +27,11 @@ export const createModelReducer = ({ name, reducers, state }: $model) => ({
 })
 
 // uses combineReducers to merge new reducers into existing reducers
-export const mergeReducers = (nextReducers: $reducers) => {
+export const mergeReducers = (nextReducers: $reducers = {}) => {
   _reducers = { ..._reducers, ...nextReducers }
+  if (!Object.keys(_reducers).length) {
+    return state => state
+  }
   return combine(_reducers)
 }
 

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -16,16 +16,14 @@ let store = null
 export const getStore = () => store
 
 // create store
-export const createStore = ({
-  initialState, extraReducers, customCombineReducers
-} = {}, models) => {
+export const createStore = ({ initialState, extraReducers, customCombineReducers }) => {
   // initial state
   if (initialState === undefined) {
     initialState = {}
   }
 
   // reducers
-  const rootReducer = getReducers()
+  const rootReducer = mergeReducers()
 
   // middleware
   const middlewares = applyMiddleware(...pluginMiddlewares)

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,7 +1,7 @@
 // @flow
 /* eslint no-underscore-dangle: 0 */
 import { createStore as _createStore, applyMiddleware, compose } from 'redux'
-import { getReducers, mergeReducers, createModelReducer } from './reducers'
+import { mergeReducers, createModelReducer } from './reducers'
 import { pluginMiddlewares } from '../core'
 
 // enable redux devtools
@@ -16,7 +16,7 @@ let store = null
 export const getStore = () => store
 
 // create store
-export const createStore = ({ initialState, extraReducers, customCombineReducers }) => {
+export const createStore = ({ initialState }) => {
   // initial state
   if (initialState === undefined) {
     initialState = {}

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,7 +1,7 @@
 // @flow
 /* eslint no-underscore-dangle: 0 */
 import { createStore as _createStore, applyMiddleware, compose } from 'redux'
-import { initReducers, mergeReducers, createModelReducer } from './reducers'
+import { getReducers, mergeReducers, createModelReducer } from './reducers'
 import { pluginMiddlewares } from '../core'
 
 // enable redux devtools
@@ -17,26 +17,15 @@ export const getStore = () => store
 
 // create store
 export const createStore = ({
-  models, initialState, extraReducers, customCombineReducers
-} = {}) => {
+  initialState, extraReducers, customCombineReducers
+} = {}, models) => {
   // initial state
   if (initialState === undefined) {
     initialState = {}
   }
-  initReducers({ customCombineReducers })
 
   // reducers
-  let rootReducer = state => state
-  if (extraReducers) {
-    rootReducer = mergeReducers(extraReducers)
-  }
-  if (models) {
-    const modelReducers = Object.keys(models).reduce((reducers, key) => ({
-      ...createModelReducer(models[key]),
-      ...reducers,
-    }), {})
-    rootReducer = mergeReducers(modelReducers)
-  }
+  const rootReducer = getReducers()
 
   // middleware
   const middlewares = applyMiddleware(...pluginMiddlewares)

--- a/src/utils/getModels.js
+++ b/src/utils/getModels.js
@@ -2,7 +2,7 @@ export default (config, plugins) => [
   ...Object.keys(config.models || {}).map(key => config.models[key]),
   ...plugins.reduce((a, { models }) => {
     if (models) {
-      return a.concat(Object.keys(models || {}).map(key => models[key]))
+      return a.concat(Object.keys(models).map(key => models[key]))
     }
     return a
   }, [])

--- a/src/utils/getModels.js
+++ b/src/utils/getModels.js
@@ -1,0 +1,9 @@
+export default (config, plugins) => [
+  ...Object.keys(config.models || {}).map(key => config.models[key]),
+  ...plugins.reduce((a, { models }) => {
+    if (models) {
+      return a.concat(Object.keys(models || {}).map(key => models[key]))
+    }
+    return a
+  }, [])
+]

--- a/test/dispatch.test.js
+++ b/test/dispatch.test.js
@@ -5,15 +5,16 @@ beforeEach(() => {
 describe('dispatch:', () => {
   describe('action:', () => {
     it('should be call in the form "modelName/reducerName"', () => {
-      const { model, init, getStore } = require('../src')
-      init()
-
-      model({
+      const { init, getStore } = require('../src')
+      const count = {
         name: 'count',
         state: 0,
         reducers: {
           add: state => state + 1,
         },
+      }
+      init({
+        models: { count }
       })
 
       getStore().dispatch({ type: 'count/add' })
@@ -46,16 +47,19 @@ describe('dispatch:', () => {
 
     test('should dispatch an action', () => {
       const {
-        model, init, getStore, dispatch
+        init, getStore, dispatch
       } = require('../src')
-      init()
 
-      model({
+      const count = {
         name: 'count',
         state: 0,
         reducers: {
           add: state => state + 1,
         },
+      }
+
+      init({
+        models: { count }
       })
 
       dispatch.count.add()

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -32,12 +32,32 @@ describe('plugins:', () => {
 
   test('should add a model', () => {
     const { init, getStore } = require('../src')
-    const model = {
+    const a = {
       name: 'a',
       state: 0,
     }
     init({
-      plugins: [{ init: () => ({ model }) }]
+      plugins: [{ init: () => ({ models: {
+        a,
+      } }) }]
+    })
+    expect(getStore().getState()).toEqual({ a: 0 })
+  })
+
+  test('should add multiple models', () => {
+    const { init, getStore } = require('../src')
+    const a = {
+      name: 'a',
+      state: 0,
+    }
+    const b = {
+      name: 'b',
+      state: 0,
+    }
+    init({
+      plugins: [{ init: () => ({ models: {
+        a, b
+      } }) }]
     })
     expect(getStore().getState()).toEqual({ a: 0 })
   })

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -59,7 +59,7 @@ describe('plugins:', () => {
         a, b
       } }) }]
     })
-    expect(getStore().getState()).toEqual({ a: 0 })
+    expect(getStore().getState()).toEqual({ a: 0, b: 0 })
   })
 
   test('should merge plugin configs into configs', () => {

--- a/test/select.test.js
+++ b/test/select.test.js
@@ -4,9 +4,8 @@ beforeEach(() => {
 
 describe('select:', () => {
   it('should create a valid list of selectors', () => {
-    const { init, model, select } = require('../src')
-    init()
-    model({
+    const { init, select } = require('../src')
+    const a = {
       name: 'a',
       state: 0,
       reducers: {
@@ -15,6 +14,9 @@ describe('select:', () => {
       selectors: {
         double: s => s * 2
       },
+    }
+    init({
+      models: { a }
     })
     expect(typeof select.a.double).toBe('function')
   })

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -4,15 +4,15 @@ beforeEach(() => {
 
 describe('createStore:', () => {
   it('no params should create store with state `{}`', () => {
-    const { createStore, getStore } = require('../src/redux/store')
-    createStore()
+    const { init, getStore } = require('../src')
+    init()
 
     expect(getStore().getState()).toEqual({})
   })
 
   it('initialState `null` should create store with state `null`', () => {
-    const { createStore, getStore } = require('../src/redux/store')
-    createStore({
+    const { init, getStore } = require('../src')
+    init({
       initialState: null
     })
 
@@ -20,8 +20,8 @@ describe('createStore:', () => {
   })
 
   it('initialState `{ app: "hello, world" }` should create store with state `{ app: "hello, world" }`', () => {
-    const { createStore, getStore } = require('../src/redux/store')
-    createStore({
+    const { init, getStore } = require('../src')
+    init({
       initialState: { app: 'hello, world' }
     })
 
@@ -29,9 +29,9 @@ describe('createStore:', () => {
   })
 
   it('extraReducers should create store with extra reducers', () => {
-    const { createStore, getStore } = require('../src/redux/store')
+    const { init, getStore } = require('../src')
     const extraReducers = { todos: (state = 999) => state }
-    createStore({
+    init({
       extraReducers
     })
     expect(getStore().getState()).toEqual({ todos: 999 })


### PR DESCRIPTION
Issue

In the current build, dispatch & select aren't setup if you add it using the new `init({ models })` pattern. It seems `init` models aren't passed through the plugins pipeline.

I've added a failing test to demonstrate.

TODO
- [x] ensure config models run through plugin hooks
- [x] remove `plugin.models` in favor of `config.models`