### PR TITLE
fix redux devtools.

### DIFF
--- a/flow-typed/local/config.js
+++ b/flow-typed/local/config.js
@@ -7,5 +7,6 @@ declare type $config = {
  overwrites?: {
   combineReducers?: (rootReducer: $reducer) => any,
   createStore?: () => any,
- }
+ },
+ devtoolOptions?: Object,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rematch/core",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/redux/devtools.js
+++ b/src/redux/devtools.js
@@ -1,0 +1,9 @@
+/* eslint-disable */
+import { compose } from 'redux'
+
+
+export const composeEnhancers = (devtoolOptions = {}) =>
+    /* istanbul ignore next */
+    (typeof window === 'object' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__)
+      ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__(devtoolOptions)
+      : compose

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,22 +1,16 @@
 // @flow
 /* eslint no-underscore-dangle: 0 */
-import { createStore as _createStore, applyMiddleware, compose } from 'redux'
+import { createStore as _createStore, applyMiddleware } from 'redux'
+import { composeEnhancers } from './devtools'
 import { mergeReducers, createModelReducer } from './reducers'
 import { pluginMiddlewares } from '../core'
-
-// enable redux devtools
-/* istanbul ignore next */
-const composeEnhancers =
- process.env.NODE_ENV !== 'production' && global.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
-   ? global.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
-   : compose
 
 let store = null
 
 export const getStore = () => store
 
 // create store
-export const initStore = ({ initialState, overwrites }) => {
+export const initStore = ({ initialState, overwrites, devtoolOptions }) => {
   // initial state
   if (initialState === undefined) {
     initialState = {}
@@ -32,7 +26,9 @@ export const initStore = ({ initialState, overwrites }) => {
 
   // middleware
   const middlewares = applyMiddleware(...pluginMiddlewares)
-  const enhancer = composeEnhancers(middlewares)
+
+  // devtools
+  const enhancer = composeEnhancers(devtoolOptions)(middlewares)
 
   // store
   store = createStore(rootReducer, initialState, enhancer)

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -34,4 +34,21 @@ describe('init config', () => {
       extraReducers: 42
     })).toThrow()
   })
+
+  test('should run with devtool options', () => {
+    const { init, getStore } = require('../src')
+    init({
+      initialState: { a: 1 },
+      devtoolOptions: {
+        maxAge: 60000,
+      }
+    })
+    expect(getStore().getState()).toEqual({ a: 1 })
+  })
+
+  test('devtools should default to compose', () => {
+    const { composeEnhancers } = require('../src/redux/devtools')
+    const { compose } = require('redux')
+    expect(composeEnhancers()).toEqual(compose)
+  })
 })


### PR DESCRIPTION
closes #124 . Fixes broken redux devtools

Also allows users to pass in their own devtools config.

```js
init({
  devtoolsConfig: {},
})
```