### PR TITLE
Setup createUnsubscribe

### DIFF
--- a/src/plugins/subscriptions/create.js
+++ b/src/plugins/subscriptions/create.js
@@ -3,7 +3,7 @@ import { onHandlers } from './handlers'
 export const createSubscription = (
   modelName: string,
   matcher: string,
-  onAction: (action: $action) => void,
+  onAction: (action: $action, unsubscribe: () => void) => void,
   actionList: string[]
 ) => {
   const createHandler = (target, formattedMatcher) => {

--- a/src/plugins/subscriptions/handlers.js
+++ b/src/plugins/subscriptions/handlers.js
@@ -13,10 +13,16 @@ const isAction = (matcher, regex) => !!matcher.match(regex)
 
 export const onHandlers = (call: (sub: Map) => any) => (matcher: string) => {
   if (isAction(matcher, actionRegex)) {
+    // exact match on create or unsubscribe
     call(subscriptions, matcher)
   } else if (isAction(matcher, patternRegex)) {
+    // pattern match on create
     const formattedMatcher = `^${escapeRegex(matcher)}$`
     call(patternSubscriptions, formattedMatcher)
+  } else if (matcher[0] === '^') {
+    // pattern match, already formatted. Called by unsubscribe
+    // NOTE: this should probably live elsewhere
+    call(patternSubscriptions, matcher)
   } else {
     throw new Error(`Invalid subscription matcher: ${matcher}`)
   }

--- a/src/plugins/subscriptions/index.js
+++ b/src/plugins/subscriptions/index.js
@@ -8,6 +8,7 @@ export const patternSubscriptions = new Map()
 const triggerAllSubscriptions = (matches) => (action, matcher) => {
   // call each subscription in each model
   Object.keys(matches).forEach(modelName => {
+    // create subscription with (action, unsubscribe)
     matches[modelName](action, () => createUnsubscribe(modelName, matcher)())
   })
 }

--- a/src/plugins/subscriptions/unsubscribe.js
+++ b/src/plugins/subscriptions/unsubscribe.js
@@ -1,18 +1,19 @@
 import { onHandlers } from './handlers'
 import omit from '../../utils/omit'
 
-export const unsubscribe = (modelName: string, matcher: string) => {
-  const unsubscribeFrom = (target, formattedMatcher) => {
-    const handler = target.get(formattedMatcher)
-    const next = omit(modelName, handler)
-    if (Object.keys(next).length) {
-      // still other hooks under matcher
-      target.set(formattedMatcher, next)
-    } else {
-      // no more hooks under matcher
-      target.delete(formattedMatcher)
-    }
+const unsubscribeFrom = (modelName) => (target, formattedMatcher) => {
+  const handler = target.get(formattedMatcher)
+  const next = omit(modelName, handler)
+  if (Object.keys(next).length) {
+    // still other hooks under matcher
+    target.set(formattedMatcher, next)
+  } else {
+    // no more hooks under matcher
+    target.delete(formattedMatcher)
   }
+}
 
-  onHandlers(unsubscribeFrom)(matcher)
+export const createUnsubscribe = (handler, matcher) => () => {
+  const modelName = Object.keys(handler)[0]
+  onHandlers(unsubscribeFrom(modelName))(matcher)
 }

--- a/src/plugins/subscriptions/unsubscribe.js
+++ b/src/plugins/subscriptions/unsubscribe.js
@@ -13,7 +13,7 @@ const unsubscribeFrom = (modelName) => (target, formattedMatcher) => {
   }
 }
 
-export const createUnsubscribe = (handler, matcher) => () => {
-  const modelName = Object.keys(handler)[0]
+// creates an unsubscribe function that can be called within a model
+export const createUnsubscribe = (modelName, matcher) => () => {
   onHandlers(unsubscribeFrom(modelName))(matcher)
 }

--- a/test/subscriptions.test.js
+++ b/test/subscriptions.test.js
@@ -301,8 +301,7 @@ describe('subscriptions:', () => {
       init({
         models: { first, second }
       })
-      const handler = { first: () => {} }
-      const unsubscribe = createUnsubscribe(handler, 'second/addOne')
+      const unsubscribe = createUnsubscribe('first', 'second/addOne')
       unsubscribe()
       dispatch.second.addOne()
 
@@ -330,8 +329,7 @@ describe('subscriptions:', () => {
         models: { first, second }
       })
 
-      const handler = { first: () => {} }
-      const unsubscribe = createUnsubscribe(handler, 'second/*')
+      const unsubscribe = createUnsubscribe('first', 'second/*')
       unsubscribe()
       dispatch.second.addOne()
 
@@ -365,8 +363,7 @@ describe('subscriptions:', () => {
       init({
         models: { first, second, third }
       })
-      const handler = { first: () => {} }
-      const unsubscribe = createUnsubscribe(handler, 'second/*')
+      const unsubscribe = createUnsubscribe('first', 'second/*')
       unsubscribe()
       dispatch.second.addOne()
 
@@ -388,8 +385,7 @@ describe('subscriptions:', () => {
         models: { first }
       })
 
-      const handler = { first: () => {} }
-      const unsubscribe = createUnsubscribe(handler, 'an/invalid/action')
+      const unsubscribe = createUnsubscribe('first', 'an/invalid/action')
 
       expect(unsubscribe).toThrow()
     })
@@ -413,8 +409,7 @@ describe('subscriptions:', () => {
         models: { first, second }
       })
 
-      const handler = { first: () => {} }
-      const unsubscribe = createUnsubscribe(handler, 'not/existing')
+      const unsubscribe = createUnsubscribe('first', 'not/existing')
       unsubscribe()
       dispatch.second.addOne()
 
@@ -422,36 +417,67 @@ describe('subscriptions:', () => {
         second: 1, first: 1,
       })
     })
-  })
-  xtest('should allow unsubscribe within a model', () => {
-    const {
-      init, dispatch, getStore
-    } = require('../src')
-    const first = {
-      name: 'first',
-      ...common,
-      subscriptions: {
-        'second/addOne': (action, unsubscribe) => {
-          dispatch.first.addOne()
-          console.log('unsubscribe', action, unsubscribe)
-          unsubscribe()
-        },
+
+    test('should allow unsubscribe within a model', () => {
+      const {
+        init, dispatch, getStore
+      } = require('../src')
+      const first = {
+        name: 'first',
+        ...common,
+        subscriptions: {
+          'second/addOne': (action, unsubscribe) => {
+            dispatch.first.addOne()
+            unsubscribe()
+          },
+        }
       }
-    }
-    const second = {
-      name: 'second',
-      ...common,
-    }
-    init({
-      models: { first, second }
+      const second = {
+        name: 'second',
+        ...common,
+      }
+      init({
+        models: { first, second }
+      })
+
+      dispatch.second.addOne()
+      dispatch.second.addOne()
+      dispatch.second.addOne()
+
+      expect(getStore().getState()).toEqual({
+        second: 3, first: 1,
+      })
     })
 
-    dispatch.second.addOne()
-    dispatch.second.addOne()
-    dispatch.second.addOne()
-    
-    expect(getStore().getState()).toEqual({
-      second: 3, first: 1,
+    test('should allow unsubscribe within a model with a pattern match', () => {
+      const {
+        init, dispatch, getStore
+      } = require('../src')
+      const first = {
+        name: 'first',
+        ...common,
+        subscriptions: {
+          'second/*': (action, unsubscribe) => {
+            dispatch.first.addOne()
+            unsubscribe()
+          },
+        }
+      }
+      const second = {
+        name: 'second',
+        ...common,
+      }
+      init({
+        models: { first, second }
+      })
+
+      dispatch.second.addOne()
+      dispatch.second.addOne()
+      dispatch.second.addOne()
+
+      expect(getStore().getState()).toEqual({
+        second: 3, first: 1,
+      })
     })
   })
 })

--- a/test/subscriptions.test.js
+++ b/test/subscriptions.test.js
@@ -457,26 +457,26 @@ describe('subscriptions:', () => {
         name: 'first',
         ...common,
         subscriptions: {
-          'second/*': (action, unsubscribe) => {
+          'other/*': (action, unsubscribe) => {
             dispatch.first.addOne()
             unsubscribe()
           },
         }
       }
-      const second = {
-        name: 'second',
+      const other = {
+        name: 'other',
         ...common,
       }
       init({
-        models: { first, second }
+        models: { first, other }
       })
 
-      dispatch.second.addOne()
-      dispatch.second.addOne()
-      dispatch.second.addOne()
+      dispatch.other.addOne()
+      dispatch.other.addOne()
+      dispatch.other.addOne()
 
       expect(getStore().getState()).toEqual({
-        second: 3, first: 1,
+        other: 3, first: 1,
       })
     })
   })


### PR DESCRIPTION
Closes #27. While "take" or "takeEvery", I think its a simpler API.

Sets up a way for users to unsubscribe from subscriptions.

```js
subscriptions: {
  'second/addOne': (action, unsubscribe) => {
    dispatch.first.addOne()
    unsubscribe()
  },
}
```

- [x] setup unsubscribe handler
- [ ] make unsubscribe work within a model