### PR TITLE
pass exposed into effects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,11 @@
-<style>
-  .badges > * {
-    margin: 0 0.5rem;
-  }
-</style>
-
 # Rematch
 
 <p class='badges'>
-  <a href='https://travis-ci.org/rematch/rematch'>
+  <a href='https://travis-ci.org/rematch/rematch' style='margin: 0 0.5rem;'>
     <img src='https://travis-ci.org/rematch/rematch.svg?branch=master' alt='Build Status'/>
   </a>
 
-  <a href='https://coveralls.io/github/rematch/rematch?branch=master'>
+  <a href='https://coveralls.io/github/rematch/rematch?branch=master' style='margin: 0 0.5rem;'>
     <img src='https://coveralls.io/repos/github/rematch/rematch/badge.svg?branch=master' alt='Coverage Status' />
   </a>
 </p>

--- a/examples/react/count/src/models.js
+++ b/examples/react/count/src/models.js
@@ -7,7 +7,7 @@ export const countA = {
     increment: s => s + 1
   },
   effects: {
-    asyncIncrement: async (payload, getState) => {
+    asyncIncrement: async () => {
       await new Promise((resolve) => {
         setTimeout(resolve, 1000)
       })

--- a/src/plugins/effects.js
+++ b/src/plugins/effects.js
@@ -4,37 +4,47 @@ export default {
     effects: {}
   },
   init: ({
-    effects, dispatch, createDispatcher, validate
-  }) => ({
-    onModel(model: $model) {
-      Object.keys(model.effects || {}).forEach((effectName: string) => {
-        validate([
-          [
-            effectName.match(/\//),
-            `Invalid effect name (${model.name}/${effectName})`
-          ],
-          [
-            typeof model.effects[effectName] !== 'function',
-            `Invalid effect (${model.name}/${effectName}). Must be a function`
-          ]
-        ])
-        effects[`${model.name}/${effectName}`] = model.effects[effectName].bind(dispatch[model.name])
-        // add effect to dispatch
-        // is assuming dispatch is available already... that the dispatch plugin is in there
-        dispatch[model.name][effectName] = createDispatcher(model.name, effectName)
-        // tag effects so they can be differentiated from normal actions
-        dispatch[model.name][effectName].isEffect = true
-      })
-    },
-    middleware: (store: $store) => (next: (action: $action) => any) => async (action: $action) => {
-      // async/await acts as promise middleware
-      let result
-      if (action.type in effects) {
-        result = await effects[action.type](action.payload, store.getState)
-      } else {
-        result = await next(action)
-      }
-      return result
+    effects, dispatch, select, createDispatcher, validate
+  }) => {
+    const exposeToEffects = {
+      dispatch,
+      select,
     }
-  })
+    return {
+      onModel(model: $model) {
+        Object.keys(model.effects || {}).forEach((effectName: string) => {
+          validate([
+            [
+              effectName.match(/\//),
+              `Invalid effect name (${model.name}/${effectName})`
+            ],
+            [
+              typeof model.effects[effectName] !== 'function',
+              `Invalid effect (${model.name}/${effectName}). Must be a function`
+            ]
+          ])
+          effects[`${model.name}/${effectName}`] = model.effects[effectName].bind(dispatch[model.name])
+          // add effect to dispatch
+          // is assuming dispatch is available already... that the dispatch plugin is in there
+          dispatch[model.name][effectName] = createDispatcher(model.name, effectName)
+          // tag effects so they can be differentiated from normal actions
+          dispatch[model.name][effectName].isEffect = true
+        })
+      },
+      middleware: (store: $store) => (next: (action: $action) => any) => async (action: $action) => {
+      // async/await acts as promise middleware
+        let result
+        if (action.type in effects) {
+          // NOTE: if possible, bind getState to exposeToEffects outside middleware
+          result = await effects[action.type](action.payload, {
+            ...exposeToEffects,
+            getState: store.getState,
+          })
+        } else {
+          result = await next(action)
+        }
+        return result
+      }
+    }
+  }
 }

--- a/test/effects.test.js
+++ b/test/effects.test.js
@@ -17,6 +17,77 @@ describe('effects:', () => {
 
     expect(typeof dispatch.count.add).toBe('function')
   })
+  test('first param should be payload', () => {
+    const {
+      model, init, dispatch
+    } = require('../src')
+    init()
+
+    let value = 1
+
+    model({
+      name: 'count',
+      state: 0,
+      effects: {
+        add: (payload) => {
+          value += payload
+        },
+      },
+    })
+
+    dispatch({ type: 'count/add', payload: 4 })
+
+    expect(value).toBe(5)
+  })
+
+  test('second param should contain dispatch', () => {
+    const {
+      model, init, getStore, dispatch
+    } = require('../src')
+    init()
+
+    model({
+      name: 'count',
+      state: 0,
+      reducers: {
+        call: s => s + 1
+      },
+      effects: {
+        makeCall: (payload, { dispatch }) => {
+          dispatch.count.call()
+        },
+      },
+    })
+
+    dispatch.count.makeCall()
+
+    expect(getStore().getState().count).toBe(1)
+  })
+
+  test('second param should contain getState', () => {
+    const {
+      model, init, getStore, dispatch
+    } = require('../src')
+    init()
+
+    model({
+      name: 'count',
+      state: 7,
+      reducers: {
+        add: (s, p) => s + p
+      },
+      effects: {
+        makeCall: (payload, { getState }) => {
+          const { count } = getState()
+          dispatch.count.add(count + 1)
+        },
+      },
+    })
+
+    dispatch.count.makeCall(2)
+
+    expect(getStore().getState().count).toBe(15)
+  })
 
   // test('should create an effect', () => {
   //   init()


### PR DESCRIPTION
### BREAKING CHANGE

Passes a subset of exposed into effects.

##### BEFORE
```js
effects: {
  doSomething(payload, getState) {
    /* ... */
  }
}
```

##### AFTER 
```js
effects: {
  doSomething(payload, { dispatch, getState, select }) {
    /* ... */
  }
}
```

closes #125. 

### TODO
- [x] verify this is a good idea
- [x] update docs
- [x] update examples