### PR TITLE
Feature/subscribe exposed

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,9 @@ const profile = {
     userId: null,
   },
   subscriptions: {
-    'auth/login': (action, unsubscribe) => {
+    'auth/login': (action, { dispatch }, unsubscribe) => {
       dispatch.profile.loadProfile()
+      unsubscribe()
     }
   }
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -178,7 +178,7 @@ import { createSelector } from 'reselect'
 
 ### subscriptions
 
-`subscriptions: { [string]: (action, unsubscribe) => any }`
+`subscriptions: { [string]: (action, { dispatch, select, getState }, unsubscribe) => any }`
 
 Subscriptions are way for models to listen to changes in the app. 
 
@@ -190,7 +190,7 @@ Subscriptions are way for models to listen to changes in the app.
     set: (payload) => payload
   },
   subscriptions: {
-    'profile/load': (action) => {
+    'profile/load': (action, { dispatch }) => {
       dispatch.settings.set(action.payload)
     }
   }
@@ -209,7 +209,7 @@ Use `unsubscribe` if you'd like an action to fire only once.
     set: (payload) => payload
   },
   subscriptions: {
-    'profile/load': (action, unsubscribe) => {
+    'profile/load': (action, { dispatch }, unsubscribe) => {
       dispatch.settings.set(action.payload)
       unsubscribe()
     }

--- a/src/plugins/subscriptions/index.js
+++ b/src/plugins/subscriptions/index.js
@@ -5,57 +5,59 @@ import { createUnsubscribe } from './unsubscribe'
 export const subscriptions = new Map()
 export const patternSubscriptions = new Map()
 
-const triggerAllSubscriptions = (matches) => (action, matcher) => {
-  // call each subscription in each model
-  Object.keys(matches).forEach(modelName => {
-    // create subscription with (action, unsubscribe)
-    matches[modelName](action, () => createUnsubscribe(modelName, matcher)())
-  })
-}
-
 export default {
-  init: ({ validate }) => ({
-    onModel(model: $model) {
-      // a list of actions is only necessary
-      // to create warnings for invalid subscription names
-      const actionList = [
-        ...Object.keys(model.reducers || {}),
-        ...Object.keys(model.effects || {})
-      ]
-      Object.keys(model.subscriptions || {}).forEach((matcher: string) => {
-        validate([
-          [
-
-            matcher.match(/\/(.+)?\//),
-            `Invalid subscription matcher (${matcher})`
-          ],
-          [
-            typeof model.subscriptions[matcher] !== 'function',
-            `Subscription matcher in ${model.name} (${matcher}) must be a function`
-          ]
-        ])
-        const onAction = model.subscriptions[matcher]
-        createSubscription(model.name, matcher, onAction, actionList)
+  init: ({ validate, dispatch, select, getState }) => {
+    const exposed = { dispatch, select, getState }
+    const triggerAllSubscriptions = (matches) => (action, matcher) => {
+      // call each subscription in each model
+      Object.keys(matches).forEach(modelName => {
+        // create subscription with (action, unsubscribe)
+        matches[modelName](action, exposed, () => createUnsubscribe(modelName, matcher)())
       })
-    },
-    middleware: () => (next: (action: $action) => any) => (action: $action) => {
-      const { type } = action
+    }
+    return {
+      onModel(model: $model) {
+        // a list of actions is only necessary
+        // to create warnings for invalid subscription names
+        const actionList = [
+          ...Object.keys(model.reducers || {}),
+          ...Object.keys(model.effects || {})
+        ]
+        Object.keys(model.subscriptions || {}).forEach((matcher: string) => {
+          validate([
+            [
 
-      // exact match
-      if (subscriptions.has(type)) {
-        const allMatches = subscriptions.get(type)
-        // call each hook[modelName] with action
-        triggerAllSubscriptions(allMatches)(action, type)
-      } else {
-        patternSubscriptions.forEach((handler: Object, matcher: string) => {
-          if (type.match(new RegExp(matcher))) {
-            const patternMatches = patternSubscriptions.get(matcher)
-            triggerAllSubscriptions(patternMatches)(action, matcher)
-          }
+              matcher.match(/\/(.+)?\//),
+              `Invalid subscription matcher (${matcher})`
+            ],
+            [
+              typeof model.subscriptions[matcher] !== 'function',
+              `Subscription matcher in ${model.name} (${matcher}) must be a function`
+            ]
+          ])
+          const onAction = model.subscriptions[matcher]
+          createSubscription(model.name, matcher, onAction, actionList)
         })
-      }
+      },
+      middleware: () => (next: (action: $action) => any) => (action: $action) => {
+        const { type } = action
 
-      return next(action)
-    },
-  })
+        // exact match
+        if (subscriptions.has(type)) {
+          const allMatches = subscriptions.get(type)
+          // call each hook[modelName] with action
+          triggerAllSubscriptions(allMatches)(action, type)
+        } else {
+          patternSubscriptions.forEach((handler: Object, matcher: string) => {
+            if (type.match(new RegExp(matcher))) {
+              const patternMatches = patternSubscriptions.get(matcher)
+              triggerAllSubscriptions(patternMatches)(action, matcher)
+            }
+          })
+        }
+
+        return next(action)
+      },
+    }
+  }
 }

--- a/test/subscriptions.test.js
+++ b/test/subscriptions.test.js
@@ -280,6 +280,32 @@ describe('subscriptions:', () => {
       expect(createModel).toThrow()
     })
   })
+  
+  test('should have access to exposed from second param', () => {
+    const {
+      init, dispatch, getStore
+    } = require('../src')
+    const first = {
+      name: 'first',
+      ...common,
+      subscriptions: {
+        'second/addOne': (action, { dispatch }) => dispatch.first.addOne(),
+      }
+    }
+    const second = {
+      name: 'second',
+      ...common,
+    }
+    init({
+      models: { first, second }
+    })
+
+    dispatch.second.addOne()
+
+    expect(getStore().getState()).toEqual({
+      second: 1, first: 1,
+    })
+  })
 
   describe('unsubscribe:', () => {
     test('a matched action', () => {
@@ -426,7 +452,7 @@ describe('subscriptions:', () => {
         name: 'first',
         ...common,
         subscriptions: {
-          'second/addOne': (action, unsubscribe) => {
+          'second/addOne': (action, exposed, unsubscribe) => {
             dispatch.first.addOne()
             unsubscribe()
           },
@@ -457,7 +483,7 @@ describe('subscriptions:', () => {
         name: 'first',
         ...common,
         subscriptions: {
-          'other/*': (action, unsubscribe) => {
+          'other/*': (action, exposed, unsubscribe) => {
             dispatch.first.addOne()
             unsubscribe()
           },


### PR DESCRIPTION
### BREAKING CHANGE

closes #144.

Passes exposed into "subscriptions", as in "effects".

```js
subscriptions: {
  'model/action': (action, { dispatch, getState, select }, unsubscribe) => {}
}
```