### PR TITLE
add meta option as second param in dispatch

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -28,7 +28,7 @@ Any data attached to an action is added in the payload.
 
 ## dispatch
 
-`dispatch(action)`
+`dispatch(action, meta)`
 
 A dispatch sends an [action](#action)
 
@@ -43,6 +43,10 @@ import { dispatch } from '@rematch/core'
 
 dispatch.cart.addToCart(item)
 ```
+
+Dispatch has an optional second property, "meta", which can be used in subscriptions or middleware. This is for advanced use cases only.
+
+`dispatch.cart.addToCart(item, { syncWithServer: true })`
 
 
 ## model

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,4 +12,3 @@ for plugin in 'plugins'/*
 do
  install_plugin_deps $plugin
 done
-n

--- a/src/plugins/dispatch.js
+++ b/src/plugins/dispatch.js
@@ -5,10 +5,13 @@ export default {
   expose: {
     dispatch: (action: $action) => storeDispatch(action),
     createDispatcher: (modelName: string, reducerName: string) =>
-      async (payload: any) => {
+      async (payload: any, meta: any) => {
         const action = { type: `${modelName}/${reducerName}` }
         if (payload) {
           action.payload = payload
+        }
+        if (meta) {
+          action.meta = meta
         }
         await storeDispatch(action)
       }

--- a/test/dispatch.test.js
+++ b/test/dispatch.test.js
@@ -203,6 +203,38 @@ describe('dispatch:', () => {
         count: 6,
       })
     })
+
+    test('should use second param as action meta', (done) => {
+      const {
+        init, dispatch
+      } = require('../src')
+
+      const count = {
+        state: 1,
+        reducers: {
+          incrementBy: (state, payload) => state + payload,
+        },
+      }
+
+      // TODO: capture actions in a more direct way
+      init({
+        models: { count },
+        plugins: [{
+          init() {
+            return {
+              middleware: () => next => action => {
+                if (action.meta) {
+                  expect(action).toEqual({ type: 'count/incrementBy', payload: 5, meta: { metaProperty: true } })
+                  done()
+                }
+                return next(action)
+              }
+            }
+          }
+        }]
+      })
+      dispatch.count.incrementBy(5, { metaProperty: true })
+    })
   })
 
   describe('promise middleware', () => {


### PR DESCRIPTION
closes #67.


```js
dispatch.count.addBy(1, { syncWithServer: true })

===

dispatch({ type: 'count/addBy', payload: 1, meta: { syncWithServer: true } })
```