### PR TITLE
capture store from init, rather than getStore export

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ The **model** brings together state, reducers, async actions & action creators i
 
 #### models.js
 ```js
-import { dispatch } from '@rematch/core'
-
 export const count = {
   state: 0, // initial state
   reducers: { // state changes with pure functions
@@ -78,9 +76,9 @@ Understanding models is as simple as answering a few questions:
 import { init } from '@rematch/core'
 import * as models from './models'
 
-init({
+const store = init({
   models,
-//plugins,
+  plugins: [],
 })
 ```
 
@@ -98,7 +96,12 @@ Dispatch standardizes your actions without the need for action types, action cre
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { Provider, connect } from 'react-redux'
-import { dispatch, getStore } from '@rematch/core'
+import { dispatch } from '@rematch/core'
+import * as models from './models'
+
+const store = init({
+  models
+})
 
 const Count = props => (
   <div>
@@ -113,8 +116,6 @@ const CountContainer = connect(state => ({
   addByOne: () => dispatch.count.addBy(1),
   addByOneAsync: () => dispatch.count.addByAsync(1)
 }))(Count)
-
-const store = getStore()
 
 ReactDOM.render(
   <Provider store={store}>

--- a/README.md
+++ b/README.md
@@ -38,8 +38,25 @@ npm install @rematch/core
 
 ## Getting Started
 
+### Step 1: Init
 
-### Step 1: Models
+**init** configures your reducers, devtools & store. 
+
+#### index.js
+
+```js
+import { init } from '@rematch/core'
+import * as models from './models'
+
+const store = init({
+  models,
+  plugins: [],
+})
+```
+
+For additional setup, pass in a configuration or one of many existing [plugins](./docs/plugins.md).
+
+### Step 2: Models
 
 The **model** brings together state, reducers, async actions & action creators in one place.
 
@@ -65,30 +82,22 @@ Understanding models is as simple as answering a few questions:
 2. How do I change the state? **reducers**
 3. How do I handle asynchronous actions? **effects** with async/await
 
+### Step 3: Dispatch
 
-### Step 2: Init
-
-**init** configures your reducers, devtools & store. 
-
-#### index.js
+**dispatch** is how we trigger reducers & effects in your models. Dispatch standardizes your actions without the need for action types, action creators, or mapDispatchToProps.
 
 ```js
-import { init } from '@rematch/core'
-import * as models from './models'
-
-const store = init({
-  models,
-  plugins: [],
-})
+import { dispatch } from '@rematch/core'
+                                              // state = { count: 0 }
+dispatch({ type: 'count/addBy', payload: 1 }) // state = { count: 1 }
+dispatch.count.addBy(1)                       // state = { count: 2 }
+dispatch.count.addByAsync(1)                  // state = { count: 3 } after delay
 ```
 
-For additional setup, pass in a configuration or one of many existing [plugins](./docs/plugins.md).
+Dispatch can be called directly, or with the `dispatch.model.action` shorthand.
 
 
-### Step 3: View
-
-**dispatch** is a helpful shorthand for triggering reducers & effects in your models.
-Dispatch standardizes your actions without the need for action types, action creators, or mapDispatchToProps. `dispatch.count.incrementBy(1)` is the same as `dispatch({ type: 'count/incrementBy', payload: 1 })`.
+## Example
 
 **React** | Vue | AngularJS | Angular 2
 
@@ -100,7 +109,7 @@ import { dispatch } from '@rematch/core'
 import * as models from './models'
 
 const store = init({
-  models
+  models,
 })
 
 const Count = props => (

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,30 +1,17 @@
 # API Reference
 
-- [action](#action)
 - [dispatch](#dispatch)
+  - [action](#action)
 - [model](#model)
   - [state](#state)
-  - [name](#name)
   - [reducers](#reducers)
   - [effects](#effects)
 - [init](#init)
   - [models](#models)
   - [initialState](#initialState)
   - [plugins](#plugins)
-  - [plugins API](./pluginsApi.md)
   - [redux](./initReduxApi.md)
-- [getStore](#getstore)
 
-
-## action
-
-`{ type: 'modelName/actionName', payload: any }`
-
-Actions are messages sent within Redux as a way for disparate parts of your app to communicate state updates.
-
-In Rematch, an action is always structured with a type of "modelName" and "actionName" - referring to either a reducer or effect name.
-
-Any data attached to an action is added in the payload.
 
 ## dispatch
 
@@ -48,6 +35,16 @@ Dispatch has an optional second property, "meta", which can be used in subscript
 
 `dispatch.cart.addToCart(item, { syncWithServer: true })`
 
+### action
+
+`{ type: 'modelName/actionName', payload: any }`
+
+Actions are messages sent within Redux as a way for disparate parts of your app to communicate state updates.
+
+In Rematch, an action is always structured with a type of "modelName" and "actionName" - referring to either a reducer or effect name.
+
+Any data attached to an action is added in the payload.
+
 
 ## model
 
@@ -66,20 +63,6 @@ const example = {
   state: { loading: false }
 }
 ```
-
-### name
-
-`name: string` Optional
-
-The name of your model. Inferred as the key referencing the models state, but can be overwritten if you use the key of "name".
-
-```js
-{
-  name: 'example',
-}
-```
-
-The above example would produce the initial state of `{ example: { loading: false } }`.
 
 ### reducers
 
@@ -131,12 +114,12 @@ Effects provide a simple way of handling async actions when used with `async/awa
 
 `init(config)`
 
-The function called to setup Rematch.
+The function called to setup Rematch. Returns `store`.
 
 ```js
 import { init } from '@rematch/core'
 
-init()
+const store = init()
 ```
 
 Init may also be called with the following configuration option below.
@@ -202,18 +185,6 @@ model({
   name: 'count',
   state: 0,
 })
-```
-
-## getStore
-
-`function`
-
-Provides access to the Redux store.
-
-```js
-import { getStore } from '@rematch/core'
-
-getStore() // store
 ```
 
 ### plugins

--- a/docs/initReduxApi.md
+++ b/docs/initReduxApi.md
@@ -7,6 +7,7 @@
     - [initialState](#initialState)
     - [reducers](#reducers)
     - [middlewares](#middlewares)
+    - [enhancers](#enhancers)
     - [combineReducers](#combinereducers)
     - [createStore](#createstore)
     - [devtoolOptions](#devtooloptions)
@@ -38,7 +39,7 @@ Allows passing in of reducer functions, rather than models. While not recommende
 
 ### middlewares
 
-```
+```js
 init({
   redux: {
     middlewares: [customMiddleware()]
@@ -47,6 +48,18 @@ init({
 ```
 
 Add middleware to your store.
+
+### enhancers
+
+```js
+init({
+  redux: {
+    enhancers: [customEnhancer()]
+  }
+})
+```
+
+Add enhancer to your store
 
 ### combineReducers
 

--- a/docs/pluginsApi.md
+++ b/docs/pluginsApi.md
@@ -111,7 +111,7 @@ See examples with "effects", "loading", & "subscriptions".
 ```js
 {
   init: (expose) => ({
-    onStoreCreated(getStore) {
+    onStoreCreated(store) {
       // do something
     }
   })

--- a/docs/recipes/react.md
+++ b/docs/recipes/react.md
@@ -30,18 +30,18 @@ Also note that it's recommended you keep your `dispatch` statements outside comp
 
 ---
 
-Use `getStore` to setup your React-Redux Provider.
+Use `store` to setup your React-Redux Provider.
 
 ```js
 import React from 'react'
 import { Provider } from 'react-redux'
-import { getStore } from '@rematch/core'
+import { init } from '@rematch/core'
 import App from './App'
 
-init()
+const store = init()
 
 export default () => (
-  <Provider store={getStore()}>
+  <Provider store={store}>
     <App />
   </Provider>
 )

--- a/examples/js/count/src/View.js
+++ b/examples/js/count/src/View.js
@@ -1,15 +1,16 @@
-import { dispatch, getStore } from '@rematch/core'
+import { dispatch } from '@rematch/core'
 
-// select html elements
-const countEl = document.getElementById('count')
-const incrementEl = document.getElementById('increment')
+export default (store) => {
+  // select html elements
+  const countEl = document.getElementById('count')
+  const incrementEl = document.getElementById('increment')
 
-// add onClick listener
-incrementEl.addEventListener('click', () => dispatch.count.addOne())
+  // add onClick listener
+  incrementEl.addEventListener('click', () => dispatch.count.addOne())
 
-// setup store store subscription
-const store = getStore()
-store.subscribe(() => {
-  const state = store.getState()
-  countEl.value = state.count
-})
+  // setup store store subscription
+  store.subscribe(() => {
+    const state = store.getState()
+    countEl.value = state.count
+  })
+}

--- a/examples/js/count/src/index.js
+++ b/examples/js/count/src/index.js
@@ -1,4 +1,5 @@
 import { init } from '@rematch/core'
+import createView from './View'
 
 const count = {
   state: 0,
@@ -7,8 +8,8 @@ const count = {
   }
 }
 
-init({
+const store = init({
   models: { count }
 })
 
-require('./View')
+createView(store)

--- a/examples/react/count/README.md
+++ b/examples/react/count/README.md
@@ -16,10 +16,10 @@ Then go to http://localhost:3000
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { connect, Provider } from 'react-redux'
-import { init, model, dispatch, select, getStore } from 'rematch-x'
+import { init, model, dispatch, select } from 'rematch-x'
 
 // No need to specify a 'view' in init.
-init()
+const store = init()
 
 // Create the model
 model({
@@ -52,7 +52,7 @@ const AppContainer = connect(state => ({
 
 // Use react-redux's <Provider /> and pass it the store.
 ReactDOM.render(
-  <Provider store={getStore()}>
+  <Provider store={store}>
     <AppContainer />
   </Provider>,
   document.getElementById('root')

--- a/examples/react/count/src/index.js
+++ b/examples/react/count/src/index.js
@@ -1,17 +1,17 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
-import { init, getStore } from '@rematch/core'
+import { init } from '@rematch/core'
 import App from './App'
 import * as models from './models'
 
-init({
+const store = init({
   models,
 })
 
 // Use react-redux's <Provider /> and pass it the store.
 ReactDOM.render(
-  <Provider store={getStore()}>
+  <Provider store={store}>
     <App />
   </Provider>,
   document.getElementById('root')

--- a/package-lock.json
+++ b/package-lock.json
@@ -968,6 +968,16 @@
         "subarg": "1.0.0"
       }
     },
+    "cross-env": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.1.1.tgz",
+      "integrity": "sha512-Wtvr+z0Z06KO1JxjfRRsPC+df7biIOiuV4iZ73cThjFGkH+ULBZq1MkBdywEcJC4cTDbO6c8IjgRjfswx3YTBA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "5.1.0",
+        "is-windows": "1.0.1"
+      }
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -2745,6 +2755,12 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.1.tgz",
+      "integrity": "sha1-MQ23D3QtJZoWo2kgK1GvhCMzENk=",
       "dev": true
     },
     "isarray": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "url": "git+https://github.com/rematch/rematch.git"
   },
   "scripts": {
-    "build": "rimraf build dist && tsc && NODE_ENV='production' rollup -c",
+    "build": "cross-env rimraf build dist && tsc && NODE_ENV='production' rollup -c",
     "build:all": "bash ./scripts/build.sh",
     "dev": "tsc --watch src",
     "install:all": "tsc && bash ./scripts/setup_plugins.sh",
@@ -46,6 +46,7 @@
     "@types/jest": "^21.1.8",
     "@types/redux": "^3.6.0",
     "coveralls": "^3.0.0",
+    "cross-env": "^5.1.1",
     "gitbook-plugin-edit-link": "^2.0.2",
     "gitbook-plugin-github": "^3.0.0",
     "gitbook-plugin-prism": "^2.3.0",

--- a/plugins/loading/examples/react-loading-example/src/index.js
+++ b/plugins/loading/examples/react-loading-example/src/index.js
@@ -1,20 +1,20 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
-import { init, getStore } from '@rematch/core'
+import { init } from '@rematch/core'
 import createLoadingPlugin from '@rematch/loading'
 import App from './App'
 import example from './example'
 
 const loadingPlugin = createLoadingPlugin()
 
-init({
+const store = init({
   plugins: [loadingPlugin],
   models: { example }
 })
 
 ReactDOM.render(
-  <Provider store={getStore()}>
+  <Provider store={store}>
     <App />
   </Provider>,
   document.getElementById('root')

--- a/plugins/loading/test/loading.test.js
+++ b/plugins/loading/test/loading.test.js
@@ -17,96 +17,96 @@ const count = {
 describe('loading', () => {
   test('loading.global should be false for normal dispatched action', () => {
     const {
-      init, dispatch, getStore
+      init, dispatch
     } = require('../../../src')
     const loadingPlugin = require('../src').default
-    init({
+    const store = init({
       models: { count },
       plugins: [loadingPlugin()]
     })
     dispatch.count.addOne()
-    expect(getStore().getState().loading.global).toBe(false)
+    expect(store.getState().loading.global).toBe(false)
   })
 
   test('loading.global should be true for dispatched effect', () => {
     const {
-      init, dispatch, getStore
+      init, dispatch
     } = require('../../../src')
     const loadingPlugin = require('../src').default
-    init({
+    const store = init({
       models: { count },
       plugins: [loadingPlugin()]
     })
     dispatch.count.timeout()
-    expect(getStore().getState().loading.global).toBe(true)
+    expect(store.getState().loading.global).toBe(true)
   })
 
   test('should set loading.models[name] to false', () => {
     const {
-      init, getStore
+      init
     } = require('../../../src')
     const loadingPlugin = require('../src').default
-    init({
+    const store = init({
       models: { count },
       plugins: [loadingPlugin()]
     })
-    expect(getStore().getState().loading.models.count).toBe(false)
+    expect(store.getState().loading.models.count).toBe(false)
   })
 
   test('should change the loading.models', () => {
     const {
-      init, dispatch, getStore
+      init, dispatch
     } = require('../../../src')
     const loadingPlugin = require('../src').default
-    init({
+    const store = init({
       models: { count },
       plugins: [loadingPlugin()]
     })
     dispatch.count.timeout()
-    expect(getStore().getState().loading.models.count).toBe(true)
+    expect(store.getState().loading.models.count).toBe(true)
   })
 
   test('should set loading.effects[name] to object of effects', () => {
     const {
-      init, getStore
+      init
     } = require('../../../src')
     const loadingPlugin = require('../src').default
-    init({
+    const store = init({
       models: { count },
       plugins: [loadingPlugin()]
     })
-    expect(getStore().getState().loading.effects.count.timeout).toBe(false)
+    expect(store.getState().loading.effects.count.timeout).toBe(false)
   })
 
   test('should change the loading.effects', () => {
     const {
-      init, dispatch, getStore
+      init, dispatch
     } = require('../../../src')
     const loadingPlugin = require('../src').default
-    init({
+    const store = init({
       models: { count },
       plugins: [loadingPlugin()]
     })
     dispatch.count.timeout()
-    expect(getStore().getState().loading.effects.count.timeout).toBe(true)
+    expect(store.getState().loading.effects.count.timeout).toBe(true)
   })
 
   test('should configure the loading name', () => {
     const {
-      init, dispatch, getStore
+      init, dispatch
     } = require('../../../src')
     const loadingPlugin = require('../src').default
-    init({
+    const store = init({
       models: { count },
       plugins: [loadingPlugin({ name: 'load' })]
     })
     dispatch.count.addOne()
-    expect(getStore().getState().load.global).toBe(false)
+    expect(store.getState().load.global).toBe(false)
   })
 
   // test('should handle "hide" if effect throws', () => {
   //   const {
-  //     init, dispatch, getStore
+  //     init, dispatch
   //   } = require('../../../src')
   //   const loadingPlugin = require('../src').default
   //   const count = {
@@ -117,11 +117,11 @@ describe('loading', () => {
   //       }
   //     }
   //   }
-  //   init({
+  //   const store = init({
   //     models: { count },
   //     plugins: [loadingPlugin()]
   //   })
   //   dispatch.count.throwError()
-  //   expect(getStore().getState().loading.global).toBe(false)
+  //   expect(store.getState().loading.global).toBe(false)
   // })
 })

--- a/plugins/persist/examples/react-persist/src/index.js
+++ b/plugins/persist/examples/react-persist/src/index.js
@@ -2,7 +2,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
-import { init, getStore } from '@rematch/core'
+import { init } from '@rematch/core'
 import createPersistPlugin, { getPersistor } from '@rematch/persist'
 import { PersistGate } from 'redux-persist/es/integration/react'
 import storage from 'redux-persist/lib/storage'
@@ -15,13 +15,13 @@ const persistPlugin = createPersistPlugin({
   storage,
 })
 
-init({
+const store = init({
   models,
   plugins: [persistPlugin],
 })
 
 ReactDOM.render(
-  <Provider store={getStore()}>
+  <Provider store={store}>
     <PersistGate persistor={getPersistor()}>
       <App />
     </PersistGate>

--- a/plugins/persist/src/index.ts
+++ b/plugins/persist/src/index.ts
@@ -24,9 +24,9 @@ export default (config): PluginCreator => {
       },
     },
     init: () => ({
-      onStoreCreated(getStore) {
+      onStoreCreated(store) {
         // run persist store once store is available
-        persistor = persistStore(getStore())
+        persistor = persistStore(store)
       },
     }),
   }

--- a/plugins/persist/test/persist.test.js
+++ b/plugins/persist/test/persist.test.js
@@ -17,7 +17,7 @@ const reducers = { todos: (state = 999) => state }
 describe('persist', () => {
   test('should throw if no config', () => {
     const persistPlugin = require('../src').default
-    const { init, getStore } = require('../../../src')
+    const { init } = require('../../../src')
     const storage = createLocalStorageMock()
     const callInit = () => init({
       plugins: [persistPlugin()],
@@ -31,9 +31,9 @@ describe('persist', () => {
 
   test('should load the persist plugin with a basic config', () => {
     const persistPlugin = require('../src').default
-    const { init, getStore } = require('../../../src')
+    const { init } = require('../../../src')
     const storage = createLocalStorageMock()
-    init({
+    const store = init({
       plugins: [persistPlugin({
         storage,
       })],
@@ -42,25 +42,25 @@ describe('persist', () => {
         reducers,
       }
     })
-    expect(getStore().getState()._persist).toEqual(defaultPersist)
+    expect(store.getState()._persist).toEqual(defaultPersist)
   })
 
   test('should load the persist plugin with a config', () => {
     const persistPlugin = require('../src').default
-    const { init, getStore } = require('../../../src')
+    const { init } = require('../../../src')
     const storage = createLocalStorageMock()
     const plugin = persistPlugin({
       key: 'test',
       version: 2,
       storage,
     })
-    init({
+    const store = init({
       plugins: [plugin],
       redux: {
         reducers,
       }
     })
-    expect(getStore().getState()._persist).toEqual({
+    expect(store.getState()._persist).toEqual({
       ...defaultPersist,
       version: 2,
     })
@@ -87,7 +87,7 @@ describe('persist', () => {
   test('should work with init models', () => {
     const persistPlugin = require('../src').default
     const { getPersistor } = require('../src')
-    const { init, dispatch, getStore } = require('../../../src')
+    const { init, dispatch } = require('../../../src')
     const storage = createLocalStorageMock()
     const a = {
       name: 'a',
@@ -96,14 +96,14 @@ describe('persist', () => {
         addOne: s => ({ b: s.b + 1 })
       }
     }
-    init({
+    const store = init({
       plugins: [persistPlugin({ storage })],
       models: { a }
     })
     dispatch.a.addOne()
     const persistor = getPersistor()
     expect(persistor.purge).toBeDefined()
-    expect(getStore().getState()._persist).toEqual(defaultPersist)
-    expect(getStore().getState().a).toEqual({ b: 2 })
+    expect(store.getState()._persist).toEqual(defaultPersist)
+    expect(store.getState().a).toEqual({ b: 2 })
   })
 })

--- a/plugins/react-navigation/README.md
+++ b/plugins/react-navigation/README.md
@@ -41,7 +41,7 @@ Note: unfortunately this package has build issues when referencing `react-naviga
 
 ```js
 // index.js
-import { init, dispatch, getStore } from '@rematch/core'
+import { init, dispatch } from '@rematch/core'
 import createReactNavigation from '@rematch/react-navigation'
 import * as ReactNavigation from 'react-navigation'
 import Routes from './Routes'
@@ -53,12 +53,12 @@ const { Navigator, reactNavigationPlugin } = createReactNavigation({
   initialScreen: 'Landing'
 })
 
-init({
+const store = init({
   plugins: [reactNavigationPlugin],
 })
 
 export default () => (
-  <Provider store={getStore()}>
+  <Provider store={store}>
     <Navigator />
   </Provider>
 )

--- a/plugins/select/test/select.test.js
+++ b/plugins/select/test/select.test.js
@@ -26,7 +26,7 @@ describe('select:', () => {
   it('should allow access to the selector', () => {
     const selectPlugin = require('../src').default
     const { select } = require('../src')
-    const { init, getStore } = require('../../../src')
+    const { init } = require('../../../src')
     const a = {
       state: 2,
       reducers: {
@@ -36,11 +36,11 @@ describe('select:', () => {
         double: s => s * 2
       },
     }
-    init({
+    const store = init({
       models: { a },
       plugins: [selectPlugin()]
     })
-    const state = getStore().getState()
+    const state = store.getState()
     const doubled = select.a.double(state)
     expect(doubled).toBe(4)
   })
@@ -48,7 +48,7 @@ describe('select:', () => {
   it('should allow passing in of params toselector', () => {
     const selectPlugin = require('../src').default
     const { select } = require('../src')
-    const { init, getStore } = require('../../../src')
+    const { init } = require('../../../src')
     const a = {
       state: 2,
       reducers: {
@@ -58,11 +58,11 @@ describe('select:', () => {
         prependWithLetter: (s, letter) => letter + s
       },
     }
-    init({
+    const store = init({
       models: { a },
       plugins: [selectPlugin()]
     })
-    const state = getStore().getState()
+    const state = store.getState()
     const prepended = select.a.prependWithLetter(state, 'P')
     expect(prepended).toBe('P2')
   })
@@ -102,7 +102,7 @@ describe('select:', () => {
     it('should allow for createSelector to be used instead of a normal selector', () => {
       const selectPlugin = require('../src').default
       const { select } = require('../src')
-      const { init, getStore } = require('../../../src')
+      const { init } = require('../../../src')
       const { createSelector } = require('reselect')
       const count = {
         state: 2,
@@ -113,11 +113,11 @@ describe('select:', () => {
           )
         },
       }
-      init({
+      const store = init({
         models: { count },
         plugins: [selectPlugin()]
       })
-      const state = getStore().getState()
+      const state = store.getState()
       const doubled = select.count.double(state)
       expect(doubled).toBe(4)
     })
@@ -125,7 +125,7 @@ describe('select:', () => {
     it('should allow createSelector to be used outside of a model', () => {
       const selectPlugin = require('../src').default
       const { select } = require('../src')
-      const { init, getStore } = require('../../../src')
+      const { init } = require('../../../src')
       const { createSelector } = require('reselect')
       const countA = {
         state: 2,
@@ -139,7 +139,7 @@ describe('select:', () => {
           double: state => state * 2
         }
       }
-      init({
+      const store = init({
         models: { countA, countB },
         plugins: [selectPlugin()]
       })
@@ -149,7 +149,7 @@ describe('select:', () => {
         (countADoubled, countBDoubled) => countADoubled + countBDoubled
       )
 
-      const state = getStore().getState()
+      const state = store.getState()
       const result = outsideSelector(state)
       expect(result).toBe(24)
     })
@@ -157,7 +157,7 @@ describe('select:', () => {
     it('should allow for mixing normal selectors and reselect selectors', () => {
       const selectPlugin = require('../src').default
       const { select } = require('../src')
-      const { init, getStore } = require('../../../src')
+      const { init } = require('../../../src')
       const { createSelector } = require('reselect')
       const countA = {
         state: 2,
@@ -179,7 +179,7 @@ describe('select:', () => {
         }
       }
 
-      init({
+      const store = init({
         models: { countA, countB },
         plugins: [selectPlugin()]
       })
@@ -192,7 +192,7 @@ describe('select:', () => {
           countADoubled + countAPlusOne + countBDoubled
       )
 
-      const state = getStore().getState()
+      const state = store.getState()
       const result = outsideSelector(state)
       expect(result).toBe(27)
     })

--- a/plugins/subscriptions/src/index.ts
+++ b/plugins/subscriptions/src/index.ts
@@ -15,8 +15,8 @@ export default (): PluginCreator => ({
       })
     }
     return {
-      onStoreCreated(getStore) {
-        localGetState = getStore().getState
+      onStoreCreated(store) {
+        localGetState = store.getState
       },
       onModel(model: Model) {
         // a list of actions is only necessary

--- a/plugins/subscriptions/test/subscriptions.test.js
+++ b/plugins/subscriptions/test/subscriptions.test.js
@@ -12,7 +12,7 @@ const common = {
 describe('subscriptions:', () => {
   test('should create a working subscription', () => {
     const {
-      init, dispatch, getStore
+      init, dispatch
     } = require('../../../src')
     const subscriptionsPlugin = require('../src').default
     const first = {
@@ -22,21 +22,21 @@ describe('subscriptions:', () => {
       }
     }
     const second = common
-    init({
+    const store = init({
       models: { first, second },
       plugins: [subscriptionsPlugin()]
     })
 
     dispatch.second.addOne()
 
-    expect(getStore().getState()).toEqual({
+    expect(store.getState()).toEqual({
       second: 1, first: 1,
     })
   })
 
   test('should allow for two subscriptions with same name in different models', () => {
     const {
-      init, dispatch, getStore
+      init, dispatch
     } = require('../../../src')
     const subscriptionsPlugin = require('../src').default
     const a1 = {
@@ -52,21 +52,21 @@ describe('subscriptions:', () => {
         'b1/addOne': () => dispatch.c1.addOne(),
       },
     }
-    init({
+    const store = init({
       models: { a1, b1, c1 },
       plugins: [subscriptionsPlugin()]
     })
 
     dispatch.b1.addOne()
 
-    expect(getStore().getState()).toEqual({
+    expect(store.getState()).toEqual({
       a1: 1, b1: 1, c1: 1,
     })
   })
 
   test('should allow for three subscriptions with same name in different models', () => {
     const {
-      init, dispatch, getStore
+      init, dispatch
     } = require('../../../src')
     const subscriptionsPlugin = require('../src').default
     const a = {
@@ -92,7 +92,7 @@ describe('subscriptions:', () => {
     // just an additional check to see that
     // other models are not effected
     const e = common
-    init({
+    const store = init({
       models: {
         a, b, c, d, e
       },
@@ -101,7 +101,7 @@ describe('subscriptions:', () => {
 
     dispatch.b.addOne()
 
-    expect(getStore().getState()).toEqual({
+    expect(store.getState()).toEqual({
       a: 1, b: 1, c: 1, d: 1, e: 0
     })
   })
@@ -109,7 +109,7 @@ describe('subscriptions:', () => {
   test('should throw if a subscription matcher is invalid', () => {
     const { model, init, dispatch } = require('../../../src')
     const subscriptionsPlugin = require('../src').default
-    init({
+    const store = init({
       plugins: [subscriptionsPlugin()]
     })
 
@@ -141,7 +141,7 @@ describe('subscriptions:', () => {
   describe('pattern matching', () => {
     test('should create working pattern matching subscription (second/*)', () => {
       const {
-        init, dispatch, getStore
+        init, dispatch
       } = require('../../../src')
       const subscriptionsPlugin = require('../src').default
 
@@ -152,21 +152,21 @@ describe('subscriptions:', () => {
         }
       }
       const second = common
-      init({
+      const store = init({
         models: { first, second },
         plugins: [subscriptionsPlugin()]
       })
 
       dispatch.second.addOne()
 
-      expect(getStore().getState()).toEqual({
+      expect(store.getState()).toEqual({
         second: 1, first: 1,
       })
     })
 
     test('should create working pattern matching subsription (*/addOne)', () => {
       const {
-        init, dispatch, getStore
+        init, dispatch
       } = require('../../../src')
       const subscriptionsPlugin = require('../src').default
       
@@ -182,21 +182,21 @@ describe('subscriptions:', () => {
           add: (state, payload) => state + payload
         }
       }
-      init({
+      const store = init({
         models: { first, second },
         plugins: [subscriptionsPlugin()]
       })
 
       dispatch.second.add(2)
 
-      expect(getStore().getState()).toEqual({
+      expect(store.getState()).toEqual({
         second: 2, first: 1,
       })
     })
 
     test('should create working pattern matching subscription (second/add*)', () => {
       const {
-        init, dispatch, getStore
+        init, dispatch
       } = require('../../../src')
       const subscriptionsPlugin = require('../src').default
       const first = {
@@ -206,14 +206,14 @@ describe('subscriptions:', () => {
         }
       }
       const second = common
-      init({
+      const store = init({
         models: { first, second },
         plugins: [subscriptionsPlugin()]
       })
 
       dispatch.second.addOne()
 
-      expect(getStore().getState()).toEqual({
+      expect(store.getState()).toEqual({
         second: 1, first: 1,
       })
     })
@@ -284,7 +284,7 @@ describe('subscriptions:', () => {
 
   test('should have access to state from second param', () => {
     const {
-      init, dispatch, getStore
+      init, dispatch
     } = require('../../../src')
     const subscriptionsPlugin = require('../src').default
     const first = {
@@ -301,14 +301,14 @@ describe('subscriptions:', () => {
     const second = {
       ...common,
     }
-    init({
+    const store = init({
       models: { first, second },
       plugins: [subscriptionsPlugin()]
     })
 
     dispatch.second.addOne()
 
-    expect(getStore().getState()).toEqual({
+    expect(store.getState()).toEqual({
       second: 1, first: 6,
     })
   })
@@ -316,7 +316,7 @@ describe('subscriptions:', () => {
   describe('unsubscribe:', () => {
     test('a matched action', () => {
       const {
-        init, dispatch, getStore
+        init, dispatch
       } = require('../../../src')
       const subscriptionsPlugin = require('../src').default
       const { createUnsubscribe } = require('../src/unsubscribe')
@@ -329,7 +329,7 @@ describe('subscriptions:', () => {
       const second = {
         ...common,
       }
-      init({
+      const store = init({
         models: { first, second },
         plugins: [subscriptionsPlugin()]
       })
@@ -337,13 +337,13 @@ describe('subscriptions:', () => {
       unsubscribe()
       dispatch.second.addOne()
 
-      expect(getStore().getState()).toEqual({
+      expect(store.getState()).toEqual({
         second: 1, first: 0,
       })
     })
     test('a pattern matched action', () => {
       const {
-        init, dispatch, getStore
+        init, dispatch
       } = require('../../../src')
       const subscriptionsPlugin = require('../src').default
       const { createUnsubscribe } = require('../src/unsubscribe')
@@ -356,7 +356,7 @@ describe('subscriptions:', () => {
       const second = {
         ...common,
       }
-      init({
+      const store = init({
         models: { first, second },
         plugins: [subscriptionsPlugin()]
       })
@@ -365,13 +365,13 @@ describe('subscriptions:', () => {
       unsubscribe()
       dispatch.second.addOne()
 
-      expect(getStore().getState()).toEqual({
+      expect(store.getState()).toEqual({
         second: 1, first: 0,
       })
     })
     test('a pattern matched action when more than one', () => {
       const {
-        init, dispatch, getStore
+        init, dispatch, 
       } = require('../../../src')
       const subscriptionsPlugin = require('../src').default
       const { createUnsubscribe } = require('../src/unsubscribe')
@@ -390,7 +390,7 @@ describe('subscriptions:', () => {
           'second/*': () => dispatch.third.addOne(),
         }
       }
-      init({
+      const store = init({
         models: { first, second, third },
         plugins: [subscriptionsPlugin()]
       })
@@ -398,7 +398,7 @@ describe('subscriptions:', () => {
       unsubscribe()
       dispatch.second.addOne()
 
-      expect(getStore().getState()).toEqual({
+      expect(store.getState()).toEqual({
         first: 0, second: 1, third: 1
       })
     })
@@ -423,7 +423,7 @@ describe('subscriptions:', () => {
     })
     test('should do nothing if no action', () => {
       const {
-        init, dispatch, getStore
+        init, dispatch
       } = require('../../../src')
       const subscriptionsPlugin = require('../src').default
       const { createUnsubscribe } = require('../src/unsubscribe')
@@ -434,7 +434,7 @@ describe('subscriptions:', () => {
         }
       }
       const second = common
-      init({
+      const store = init({
         models: { first, second },
         plugins: [subscriptionsPlugin()]
       })
@@ -443,14 +443,14 @@ describe('subscriptions:', () => {
       unsubscribe()
       dispatch.second.addOne()
 
-      expect(getStore().getState()).toEqual({
+      expect(store.getState()).toEqual({
         second: 1, first: 1,
       })
     })
 
     test('should allow unsubscribe within a model', () => {
       const {
-        init, dispatch, getStore
+        init, dispatch
       } = require('../../../src')
       const subscriptionsPlugin = require('../src').default
       const first = {
@@ -463,7 +463,7 @@ describe('subscriptions:', () => {
         }
       }
       const second = common
-      init({
+      const store = init({
         models: { first, second },
         plugins: [subscriptionsPlugin()]
       })
@@ -472,14 +472,14 @@ describe('subscriptions:', () => {
       dispatch.second.addOne()
       dispatch.second.addOne()
 
-      expect(getStore().getState()).toEqual({
+      expect(store.getState()).toEqual({
         second: 3, first: 1,
       })
     })
 
     test('should allow unsubscribe within a model with a pattern match', () => {
       const {
-        init, dispatch, getStore
+        init, dispatch
       } = require('../../../src')
       const subscriptionsPlugin = require('../src').default
       const first = {
@@ -492,7 +492,7 @@ describe('subscriptions:', () => {
         }
       }
       const other = common
-      init({
+      const store = init({
         models: { first, other },
         plugins: [subscriptionsPlugin()]
       })
@@ -501,7 +501,7 @@ describe('subscriptions:', () => {
       dispatch.other.addOne()
       dispatch.other.addOne()
 
-      expect(getStore().getState()).toEqual({
+      expect(store.getState()).toEqual({
         other: 3, first: 1,
       })
     })

--- a/plugins/updated/examples/count/README.md
+++ b/plugins/updated/examples/count/README.md
@@ -16,10 +16,10 @@ Then go to http://localhost:3000
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { connect, Provider } from 'react-redux'
-import { init, model, dispatch, select, getStore } from 'rematch-x'
+import { init, model, dispatch, select } from '@rematch/core'
 
 // No need to specify a 'view' in init.
-init()
+const store = init()
 
 // Create the model
 model({
@@ -52,7 +52,7 @@ const AppContainer = connect(state => ({
 
 // Use react-redux's <Provider /> and pass it the store.
 ReactDOM.render(
-  <Provider store={getStore()}>
+  <Provider store={store}>
     <AppContainer />
   </Provider>,
   document.getElementById('root')

--- a/plugins/updated/examples/count/src/index.js
+++ b/plugins/updated/examples/count/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
-import { init, getStore } from '@rematch/core'
+import { init } from '@rematch/core'
 import createUpdatedPlugin from '@rematch/updated'
 import App from './App'
 import * as models from './models'
@@ -9,13 +9,13 @@ import * as models from './models'
 // create plugin
 const updated = createUpdatedPlugin()
 
-init({
+const store = init({
   models,
   plugins: [updated] // add to plugin list
 })
 
 ReactDOM.render(
-  <Provider store={getStore()}>
+  <Provider store={store}>
     <App />
   </Provider>,
   document.getElementById('root')

--- a/plugins/updated/test/updated.test.js
+++ b/plugins/updated/test/updated.test.js
@@ -8,7 +8,7 @@ beforeEach(() => {
 describe('updated', () => {
   test('should setup with a config name', async () => {
     const {
-      init, dispatch, getStore
+      init, dispatch
     } = require('../../../src')
 
     const updatedPlugin = require('../src').default
@@ -26,7 +26,7 @@ describe('updated', () => {
       }
     }
 
-    init({
+    const store = init({
       models: { count },
       plugins: [updatedPlugin({
         name: 'chicken',
@@ -35,7 +35,7 @@ describe('updated', () => {
 
     await dispatch.count.timeout()
 
-    const state = getStore().getState()
+    const state = store.getState()
     expect(state).toEqual({
       count: 1,
       chicken: {
@@ -47,7 +47,7 @@ describe('updated', () => {
   })
   test('should record the timestamp of the last time an effect was updated', async () => {
     const {
-      init, dispatch, getStore
+      init, dispatch
     } = require('../../../src')
 
     const updatedPlugin = require('../src').default
@@ -65,14 +65,14 @@ describe('updated', () => {
       }
     }
 
-    init({
+    const store = init({
       models: { count },
       plugins: [updatedPlugin()]
     })
 
     await dispatch.count.timeout()
 
-    const state = getStore().getState()
+    const state = store.getState()
     expect(state).toEqual({
       count: 1,
       updated: {
@@ -85,7 +85,7 @@ describe('updated', () => {
   
   test('should work with multiple effects', async () => {
     const {
-      init, dispatch, getStore
+      init, dispatch
     } = require('../../../src')
 
     const updatedPlugin = require('../src').default
@@ -106,7 +106,7 @@ describe('updated', () => {
       }
     }
 
-    init({
+    const store = init({
       models: { count },
       plugins: [updatedPlugin()]
     })
@@ -114,7 +114,7 @@ describe('updated', () => {
     await dispatch.count.timeout()
     await dispatch.count.timeout2()
 
-    const state = getStore().getState()
+    const state = store.getState()
     expect(state).toEqual({
       count: 2,
       updated: {

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,5 +1,4 @@
 import { Middleware } from 'redux'
-import { getStore } from './redux/store'
 import { ModelHook, Plugin } from './typings/rematch'
 
 export const modelHooks: ModelHook[] = []
@@ -16,10 +15,10 @@ export const preStore = (plugins: Plugin[]) => {
   })
 }
 
-export const postStore = (plugins: Plugin[]) => {
+export const postStore = (plugins: Plugin[], store) => {
   plugins.forEach((plugin: Plugin) => {
     if (plugin.onStoreCreated) {
-      plugin.onStoreCreated(getStore)
+      plugin.onStoreCreated(store)
     }
   })
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,20 +1,17 @@
 import init from './init'
 import { createModel as model } from './model'
 import dispatchPlugin from './plugins/dispatch'
-import { getStore } from './redux/store'
 
 const { expose: { dispatch } } = dispatchPlugin
 
 export default {
   dispatch,
-  getStore,
   init,
   model,
 }
 
 export {
   dispatch,
-  getStore,
   init,
   model,
 }

--- a/src/init.ts
+++ b/src/init.ts
@@ -4,7 +4,7 @@ import { initModelHooks } from './model'
 import corePlugins from './plugins'
 import { initReducers } from './redux/reducers'
 import { initStore } from './redux/store'
-import { Config, Exposed } from './typings/rematch'
+import { Config, ConfigRedux, Exposed } from './typings/rematch'
 import buildPlugins from './utils/buildPlugins'
 import getExposed from './utils/getExposed'
 import getModels from './utils/getModels'
@@ -24,12 +24,18 @@ const init = (config: Config | undefined = {}): Store<any> => {
       'init config.models must be an object',
     ],
     [
+      config.redux.reducers
+      && isObject(config.redux.reducers),
+      'init config.redux.reducers must be an object',
+    ],
+    [
       config.redux.middlewares && !Array.isArray(config.redux.middlewares),
       'init config.redux.middlewares must be an array',
     ],
     [
-      config.redux.reducers && isObject(config.redux.reducers),
-      'init config.redux.reducers must be an object',
+      config.redux.enhancers
+      && !Array.isArray(config.redux.enhancers),
+      'init config.redux.enhancers must be an array of functions',
     ],
     [
       config.redux.combineReducers && typeof config.redux.combineReducers !== 'function',

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,3 +1,4 @@
+import { Store } from 'redux'
 import { postStore, preStore } from './core'
 import { initModelHooks } from './model'
 import corePlugins from './plugins'
@@ -11,7 +12,7 @@ import isObject from './utils/isObject'
 import mergeConfig from './utils/mergeConfig'
 import validate from './utils/validate'
 
-const init = (config: Config | undefined = {}): void => {
+const init = (config: Config | undefined = {}): Store<any> => {
   config.redux = config.redux || {}
   validate([
     [
@@ -55,9 +56,9 @@ const init = (config: Config | undefined = {}): void => {
 
   // create a redux store with initialState
   // merge in additional extra reducers
-  initStore(mergedConfig)
-
-  postStore(plugins)
+  const store: Store<any> = initStore(mergedConfig)
+  postStore(plugins, store)
+  return store
 }
 
 export default init

--- a/src/plugins/dispatch.ts
+++ b/src/plugins/dispatch.ts
@@ -19,8 +19,8 @@ const dispatchPlugin: PluginCreator = {
     dispatch: (action: Action) => storeDispatch(action),
   },
   init: ({ dispatch, createDispatcher, validate }: Exposed): Plugin => ({
-    onStoreCreated(getStore: () => Store<any>) {
-      storeDispatch = getStore().dispatch
+    onStoreCreated(store: Store<any>) {
+      storeDispatch = store.dispatch
     },
     onModel(model: Model) {
       dispatch[model.name] = {}

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -13,8 +13,9 @@ export const initStore = ({ redux }: Config): Store<any> => {
   const rootReducer: Reducer<any> = mergeReducers()
   const middlewareList: Middleware[] = [...pluginMiddlewares, ...(redux.middlewares || [])]
   const middlewares = applyMiddleware(...middlewareList)
-  const enhancers = composeEnhancers(redux.devtoolOptions)(middlewares)
-  store = createStore(rootReducer, initialState, enhancers)
+  const enhancers = [redux.devtoolOptions, ...(redux.enhancers || [])]
+  const composedEnhancers = composeEnhancers(...enhancers)(middlewares)
+  store = createStore(rootReducer, initialState, composedEnhancers)
   return store
 }
 

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -7,10 +7,7 @@ import { createModelReducer, mergeReducers  } from './reducers'
 
 let store: Store<any>
 
-// access file scoped store
-export const getStore = () => store
-
-export const initStore = ({ redux }: Config) => {
+export const initStore = ({ redux }: Config): Store<any> => {
   const initialState: any = typeof redux.initialState === 'undefined' ? {} : redux.initialState
   const createStore: StoreCreator = redux.createStore || _createStore
   const rootReducer: Reducer<any> = mergeReducers()
@@ -18,6 +15,7 @@ export const initStore = ({ redux }: Config) => {
   const middlewares = applyMiddleware(...middlewareList)
   const enhancers = composeEnhancers(redux.devtoolOptions)(middlewares)
   store = createStore(rootReducer, initialState, enhancers)
+  return store
 }
 
 export const createReducersAndUpdateStore = (model: Model): void => {

--- a/src/typings/rematch/index.d.ts
+++ b/src/typings/rematch/index.d.ts
@@ -2,7 +2,7 @@
 // Project: Rematch
 // Definitions by: Shawn McKay https://github.com/shmck
 
-import { Dispatch, MiddlewareAPI, Middleware, Reducer, ReducersMapObject, Store, StoreCreator } from 'redux'
+import { Dispatch, MiddlewareAPI, Middleware, Reducer, ReducersMapObject, Store, StoreCreator, StoreEnhancer } from 'redux'
 
 export as namespace rematch
 
@@ -74,6 +74,7 @@ export interface PluginCreator {
 export interface ConfigRedux {
   initialState?: any,
   reducers?: Reducers,
+  enhancers?: StoreEnhancer<any>[],
   middlewares?: Middleware[],
   combineReducers?: (reducers: ReducersMapObject) => Reducer<any>,
   createStore?: StoreCreator,

--- a/src/typings/rematch/index.d.ts
+++ b/src/typings/rematch/index.d.ts
@@ -7,14 +7,12 @@ import { Dispatch, MiddlewareAPI, Middleware, Reducer, ReducersMapObject, Store,
 export as namespace rematch
 
 export function dispatch(action: Action): Promise<Dispatch<any>>
-export function getStore(): Store<any>
-export function init(config: Config | undefined): void
+export function init(config: Config | undefined): Store<any>
 export function model(model: Model): void
 
 export namespace rematch {
   export function dispatch(action: Action): Promise<Dispatch<any>>
-  export function getStore(): Store<any>
-  export function init(config: Config): void
+  export function init(config: Config): Store<any>
   export function model(model: Model): void
 }
 
@@ -33,8 +31,6 @@ export type Models = {
 }
 
 export type ModelHook = (model: Model) => void
-
-type GetStore = () => Store<any>
 
 export type Validation = [boolean | undefined, string]
 
@@ -62,7 +58,7 @@ export interface Model {
 }
 
 export interface Plugin {
-  onStoreCreated?: (getStore: GetStore) => void,
+  onStoreCreated?: (store: Store<any>) => void,
   onModel?: ModelHook,
   middleware?: <S>(store: MiddlewareAPI<S>) => (next: Dispatch<S>) => (action: Action) => any,
 }

--- a/src/utils/mergeConfig.ts
+++ b/src/utils/mergeConfig.ts
@@ -23,6 +23,9 @@ export default (config: Config): Config => {
       if (plugin.config.redux) {
         merged.redux.initialState = merge(merged.redux.initialState, plugin.config.redux.initialState)
         merged.redux.reducers = merge(merged.redux.reducers, plugin.config.redux.reducers)
+        if (plugin.config.redux.enhancers) {
+          merged.redux.enhancers = merged.redux.enhancers.concat(plugin.config.redux.enhancers)
+        }
         merged.redux.combineReducers = merged.redux.combineReducers || plugin.config.redux.combineReducers
         merged.redux.createStore = merged.redux.createStore || plugin.config.redux.createStore
       }

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -62,7 +62,16 @@ describe('init config', () => {
     })).toThrow()
   })
 
-  test('should not accept invalid array for "extraReducers"', () => {
+  test('should not accept invalid "enhancers"', () => {
+    const { init } = require('../src')
+    expect(() => init({
+      redux: {
+        enhancers: {}
+      }
+    })).toThrow()
+  })
+
+  test('should not accept invalid array for "reducers"', () => {
     const { init } = require('../src')
     expect(() => init({
       redux: {
@@ -71,7 +80,7 @@ describe('init config', () => {
     })).toThrow()
   })
 
-  test('should not accept invalid value as "extraReducers"', () => {
+  test('should not accept invalid value as "reducers"', () => {
     const { init } = require('../src')
     expect(() => init({
       redux: {

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -81,8 +81,8 @@ describe('init config', () => {
   })
 
   test('should run with devtool options', () => {
-    const { init, getStore } = require('../src')
-    init({
+    const { init } = require('../src')
+    const store = init({
       redux: {
         initialState: { a: 1 },
         devtoolOptions: {
@@ -90,7 +90,7 @@ describe('init config', () => {
         }
       }
     })
-    expect(getStore().getState()).toEqual({ a: 1 })
+    expect(store.getState()).toEqual({ a: 1 })
   })
 
   test('devtools should default to compose', () => {

--- a/test/dispatch.test.js
+++ b/test/dispatch.test.js
@@ -5,27 +5,27 @@ beforeEach(() => {
 describe('dispatch:', () => {
   describe('action:', () => {
     it('should be call in the form "modelName/reducerName"', () => {
-      const { init, getStore } = require('../src')
+      const { init } = require('../src')
       const count = {
         state: 0,
         reducers: {
           add: state => state + 1,
         },
       }
-      init({
+      const store = init({
         models: { count }
       })
 
-      getStore().dispatch({ type: 'count/add' })
+      store.dispatch({ type: 'count/add' })
 
-      expect(getStore().getState()).toEqual({
+      expect(store.getState()).toEqual({
         count: 1,
       })
     })
 
     test('should be able to call dispatch directly', () => {
       const {
-        init, getStore, dispatch
+        init, dispatch
       } = require('../src')
 
       const count = {
@@ -35,20 +35,20 @@ describe('dispatch:', () => {
         },
       }
 
-      init({
+      const store = init({
         models: { count }
       })
 
       dispatch({ type: 'count/addOne' })
 
-      expect(getStore().getState()).toEqual({
+      expect(store.getState()).toEqual({
         count: 1,
       })
     })
 
     test('should dispatch an action', () => {
       const {
-        init, getStore, dispatch
+        init, dispatch
       } = require('../src')
 
       const count = {
@@ -58,20 +58,20 @@ describe('dispatch:', () => {
         },
       }
 
-      init({
+      const store = init({
         models: { count }
       })
 
       dispatch.count.add()
 
-      expect(getStore().getState()).toEqual({
+      expect(store.getState()).toEqual({
         count: 1,
       })
     })
 
     test('should dispatch multiple actions', () => {
       const {
-        init, getStore, dispatch
+        init, dispatch
       } = require('../src')
 
       const count = {
@@ -81,21 +81,21 @@ describe('dispatch:', () => {
         },
       }
 
-      init({
+      const store = init({
         models: { count }
       })
 
       dispatch.count.add()
       dispatch.count.add()
 
-      expect(getStore().getState()).toEqual({
+      expect(store.getState()).toEqual({
         count: 2,
       })
     })
 
     test('should handle multiple models', () => {
       const {
-        init, getStore, dispatch
+        init, dispatch
       } = require('../src')
 
       const a = {
@@ -112,14 +112,14 @@ describe('dispatch:', () => {
         },
       }
 
-      init({
+      const store = init({
         models: { a, b }
       })
 
       dispatch.a.add()
       dispatch.b.add()
 
-      expect(getStore().getState()).toEqual({
+      expect(store.getState()).toEqual({
         a: 43,
         b: 1,
       })
@@ -128,7 +128,7 @@ describe('dispatch:', () => {
 
   test('should include a payload if it is a false value', () => {
     const {
-      init, getStore, dispatch
+      init, dispatch
     } = require('../src')
 
     const a = {
@@ -138,13 +138,13 @@ describe('dispatch:', () => {
       },
     }
 
-    init({
+    const store = init({
       models: { a }
     })
 
     dispatch.a.toggle(false)
 
-    expect(getStore().getState()).toEqual({
+    expect(store.getState()).toEqual({
       a: false,
     })
   })
@@ -182,7 +182,7 @@ describe('dispatch:', () => {
   describe('params:', () => {
     test('should pass state as the first reducer param', () => {
       const {
-        init, getStore, dispatch
+        init, dispatch
       } = require('../src')
 
 
@@ -193,20 +193,20 @@ describe('dispatch:', () => {
         },
       }
 
-      init({
+      const store = init({
         models: { count }
       })
 
       dispatch.count.doNothing()
 
-      expect(getStore().getState()).toEqual({
+      expect(store.getState()).toEqual({
         count: 0,
       })
     })
 
     test('should pass payload as the second param', () => {
       const {
-        init, getStore, dispatch
+        init, dispatch
       } = require('../src')
 
       const count = {
@@ -216,13 +216,13 @@ describe('dispatch:', () => {
         },
       }
 
-      init({
+      const store = init({
         models: { count }
       })
 
       dispatch.count.incrementBy(5)
 
-      expect(getStore().getState()).toEqual({
+      expect(store.getState()).toEqual({
         count: 6,
       })
     })

--- a/test/effects.test.js
+++ b/test/effects.test.js
@@ -47,7 +47,7 @@ describe('effects:', () => {
 
   test('second param should contain state', () => {
     const {
-      init, getStore, dispatch
+      init, dispatch
     } = require('../src')
 
     const count = {
@@ -63,13 +63,13 @@ describe('effects:', () => {
       },
     }
 
-    init({
+    const store = init({
       models: { count }
     })
 
     dispatch.count.makeCall(2)
 
-    expect(getStore().getState().count).toBe(15)
+    expect(store.getState().count).toBe(15)
   })
 
   // test('should create an effect', () => {
@@ -88,7 +88,7 @@ describe('effects:', () => {
 
   test('should be able to trigger another action', async () => {
     const {
-      init, dispatch, getStore
+      init, dispatch
     } = require('../src')
 
     const example = {
@@ -103,13 +103,13 @@ describe('effects:', () => {
       }
     }
 
-    init({
+    const store = init({
       models: { example }
     })
 
     await dispatch.example.asyncAddOneArrow()
 
-    expect(getStore().getState()).toEqual({
+    expect(store.getState()).toEqual({
       example: 1,
     })
   })
@@ -117,8 +117,8 @@ describe('effects:', () => {
   // currently no solution for arrow functions as they are often transpiled by Babel or Typescript
   // there is no clear way to detect arrow functions
   // xtest('should be able trigger a local reducer using arrow functions and `this`', async () => {
-  //   const { model, init, dispatch, getStore } = require('../src')
-  //   init()
+  //   const { model, init, dispatch } = require('../src')
+  //   const store = init()
   //
   //   model({
   //     name: 'example',
@@ -135,14 +135,14 @@ describe('effects:', () => {
   //
   //   await dispatch.example.asyncAddOneArrow()
   //
-  //   expect(getStore().getState()).toEqual({
+  //   expect(store.getState()).toEqual({
   //     example: 1,
   //   })
   // })
 
   test('should be able trigger a local reducer using functions and `this`', async () => {
     const {
-      init, dispatch, getStore
+      init, dispatch
     } = require('../src')
 
     const example = {
@@ -157,20 +157,20 @@ describe('effects:', () => {
       }
     }
 
-    init({
+    const store = init({
       models: { example }
     })
 
     await dispatch.example.asyncAddOne()
 
-    expect(getStore().getState()).toEqual({
+    expect(store.getState()).toEqual({
       example: 1,
     })
   })
 
   test('should be able trigger a local reducer using object function shorthand and `this`', async () => {
     const {
-      init, dispatch, getStore
+      init, dispatch
     } = require('../src')
 
     const example = {
@@ -185,20 +185,20 @@ describe('effects:', () => {
       }
     }
 
-    init({
+    const store = init({
       models: { example }
     })
 
     await dispatch.example.asyncAddOne()
 
-    expect(getStore().getState()).toEqual({
+    expect(store.getState()).toEqual({
       example: 1,
     })
   })
 
   test('should be able to trigger another action with a value', async () => {
     const {
-      init, dispatch, getStore
+      init, dispatch
     } = require('../src')
 
     const example = {
@@ -213,20 +213,20 @@ describe('effects:', () => {
       }
     }
 
-    init({
+    const store = init({
       models: { example }
     })
 
     await dispatch.example.asyncAddBy(5)
 
-    expect(getStore().getState()).toEqual({
+    expect(store.getState()).toEqual({
       example: 7,
     })
   })
 
   test('should be able to trigger another action w/ an object value', async () => {
     const {
-      init, dispatch, getStore
+      init, dispatch
     } = require('../src')
     
     const example = {
@@ -241,20 +241,20 @@ describe('effects:', () => {
       }
     }
 
-    init({
+    const store = init({
       models: { example }
     })
 
     await dispatch.example.asyncAddBy({ value: 6 })
 
-    expect(getStore().getState()).toEqual({
+    expect(store.getState()).toEqual({
       example: 9,
     })
   })
 
   test('should be able to trigger another action w/ another action', async () => {
     const {
-      init, dispatch, getStore
+      init, dispatch
     } = require('../src')
 
     const example = {
@@ -273,20 +273,20 @@ describe('effects:', () => {
       }
     }
 
-    init({
+    const store = init({
       models: { example }
     })
 
     await dispatch.example.asyncCallAddOne()
 
-    expect(getStore().getState()).toEqual({
+    expect(store.getState()).toEqual({
       example: 1,
     })
   })
 
   test('should be able to trigger another action w/ multiple actions', async () => {
     const {
-      init, dispatch, getStore
+      init, dispatch
     } = require('../src')
 
     const example = {
@@ -309,14 +309,14 @@ describe('effects:', () => {
       }
     }
 
-    init({
+    const store = init({
       models: { example }
     })
 
     await dispatch.example.asyncAddSome()
 
     await setTimeout(() => {
-      expect(getStore().getState()).toEqual({
+      expect(store.getState()).toEqual({
         example: 5,
       })
     })

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -4,16 +4,16 @@ beforeEach(() => {
 
 describe('init:', () => {
   test('no params should create store with state `{}`', () => {
-    const { init, getStore } = require('../src')
-    init()
+    const { init } = require('../src')
+    const store = init()
 
-    expect(getStore().getState()).toEqual({})
+    expect(store.getState()).toEqual({})
   })
 
   test('should create models', () => {
-    const { init, getStore } = require('../src')
+    const { init } = require('../src')
 
-    init({
+    const store = init({
       models: {
         app: {
           state: 'Hello, model 1',
@@ -24,16 +24,16 @@ describe('init:', () => {
       }
     })
 
-    expect(getStore().getState()).toEqual({
+    expect(store.getState()).toEqual({
       app: 'Hello, model 1',
       app2: 'Hello, model 2'
     })
   })
 
   test('should allow both init models & model models', () => {
-    const { init, model, getStore } = require('../src')
+    const { init, model } = require('../src')
 
-    init({
+    const store = init({
       models: {
         app: {
           state: 'Hello, model 1',
@@ -46,7 +46,7 @@ describe('init:', () => {
       state: 'Hello, model 2',
     })
 
-    expect(getStore().getState()).toEqual({
+    expect(store.getState()).toEqual({
       app: 'Hello, model 1',
       app2: 'Hello, model 2'
     })
@@ -66,50 +66,50 @@ describe('init:', () => {
   })
 
   test('init() & one model of state type `string`', () => {
-    const { model, init, getStore } = require('../src')
-    init()
+    const { model, init } = require('../src')
+    const store = init()
 
     model({
       name: 'app',
       state: 'Hello, world',
     })
 
-    expect(getStore().getState()).toEqual({
+    expect(store.getState()).toEqual({
       app: 'Hello, world',
     })
   })
 
   test('init() & one model of state type `number`', () => {
-    const { model, init, getStore } = require('../src')
-    init()
+    const { model, init } = require('../src')
+    const store = init()
 
     model({
       name: 'count',
       state: 99,
     })
 
-    expect(getStore().getState()).toEqual({
+    expect(store.getState()).toEqual({
       count: 99,
     })
   })
 
   test('init() & one model of state is 0', () => {
-    const { model, init, getStore } = require('../src')
-    init()
+    const { model, init } = require('../src')
+    const store = init()
 
     model({
       name: 'count',
       state: 0,
     })
 
-    expect(getStore().getState()).toEqual({
+    expect(store.getState()).toEqual({
       count: 0,
     })
   })
 
   test('init() & one model of state type `object`', () => {
-    const { model, init, getStore } = require('../src')
-    init()
+    const { model, init } = require('../src')
+    const store = init()
 
     model({
       name: 'todos',
@@ -121,7 +121,7 @@ describe('init:', () => {
       },
     })
 
-    expect(getStore().getState()).toEqual({
+    expect(store.getState()).toEqual({
       todos: {
         abc: {
           text: 'PRty down',
@@ -131,8 +131,8 @@ describe('init:', () => {
     })
   })
   test('init() & two models', () => {
-    const { model, init, getStore } = require('../src')
-    init()
+    const { model, init } = require('../src')
+    const store = init()
 
     model({
       name: 'app',
@@ -144,15 +144,15 @@ describe('init:', () => {
       state: 99,
     })
 
-    expect(getStore().getState()).toEqual({
+    expect(store.getState()).toEqual({
       app: 'Hello, world',
       count: 99,
     })
   })
 
   test('init() & three models', () => {
-    const { model, init, getStore } = require('../src')
-    init()
+    const { model, init } = require('../src')
+    const store = init()
 
     model({
       name: 'app',
@@ -174,7 +174,7 @@ describe('init:', () => {
       },
     })
 
-    expect(getStore().getState()).toEqual({
+    expect(store.getState()).toEqual({
       app: 'Hello, world',
       count: 99,
       todos: {

--- a/test/mergeConfig.test.js
+++ b/test/mergeConfig.test.js
@@ -95,6 +95,24 @@ describe('mergeConfig', () => {
       })
     })
 
+    test('should apply additional redux enhancers', () => {
+      const plugin = {
+        config: {
+          redux: {
+            enhancers: [3, 4]
+          }
+        }
+      }
+      const config = {
+        redux: {
+          enhancers: [1, 2]
+        },
+        plugins: [plugin]
+      }
+      const result = mergeConfig(config)
+      expect(result.redux.enhancers).toEqual([1, 2, 3, 4])
+    })
+
     test('config redux reducers should overwrite plugin reducers', () => {
       const plugin = {
         redux: {

--- a/test/overwrites.test.js
+++ b/test/overwrites.test.js
@@ -4,8 +4,8 @@ beforeEach(() => {
 
 describe('overwrites', () => {
   test('combineReducers should replace root', () => {
-    const { init, getStore } = require('../src')
-    init({
+    const { init } = require('../src')
+    const store = init({
       redux: {
         initialState: {},
         reducers: {
@@ -15,7 +15,7 @@ describe('overwrites', () => {
         combineReducers: () => () => 42,
       }
     })
-    expect(getStore().getState()).toBe(42)
+    expect(store.getState()).toBe(42)
   })
   test('should not accept invalid value as "overwrites.combineReducers"', () => {
     const { init } = require('../src')
@@ -27,8 +27,8 @@ describe('overwrites', () => {
   })
 
   test('combineReducers should replace root', () => {
-    const { init, getStore } = require('../src')
-    init({
+    const { init } = require('../src')
+    const store = init({
       redux: {
         initialState: {},
         createStore: () => ({
@@ -36,7 +36,7 @@ describe('overwrites', () => {
         }),
       }
     })
-    expect(getStore().getState()).toBe(42)
+    expect(store.getState()).toBe(42)
   })
 
   test('should not accept invalid value as "overwrites.createStore"', () => {

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -31,7 +31,7 @@ describe('plugins:', () => {
   })
 
   test('should add a model', () => {
-    const { init, getStore } = require('../src')
+    const { init } = require('../src')
     const a = {
       state: 0,
     }
@@ -40,14 +40,14 @@ describe('plugins:', () => {
         models: { a }
       }
     }
-    init({
+    const store = init({
       plugins: [plugin]
     })
-    expect(getStore().getState()).toEqual({ a: 0 })
+    expect(store.getState()).toEqual({ a: 0 })
   })
 
   test('should add multiple models', () => {
-    const { init, getStore } = require('../src')
+    const { init } = require('../src')
     const a = {
       state: 0,
     }
@@ -59,14 +59,14 @@ describe('plugins:', () => {
         models: { a, b }
       }
     }
-    init({
+    const store = init({
       plugins: [plugin]
     })
-    expect(getStore().getState()).toEqual({ a: 0, b: 0 })
+    expect(store.getState()).toEqual({ a: 0, b: 0 })
   })
 
   test('should merge plugin configs into configs', () => {
-    const { init, getStore } = require('../src')
+    const { init } = require('../src')
     const plugin1 = {
       config: {
         redux: {
@@ -76,9 +76,9 @@ describe('plugins:', () => {
         }
       },
     }
-    init({
+    const store = init({
       plugins: [plugin1],
     })
-    expect(getStore().getState()).toEqual({ app: 1 })
+    expect(store.getState()).toEqual({ app: 1 })
   })
 })

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -4,42 +4,42 @@ beforeEach(() => {
 
 describe('createStore:', () => {
   it('no params should create store with state `{}`', () => {
-    const { init, getStore } = require('../src')
-    init()
+    const { init } = require('../src')
+    const store = init()
 
-    expect(getStore().getState()).toEqual({})
+    expect(store.getState()).toEqual({})
   })
 
   it('initialState `null` should create store with state `null`', () => {
-    const { init, getStore } = require('../src')
-    init({
+    const { init } = require('../src')
+    const store = init({
       redux: {
         initialState: null,
       }
     })
 
-    expect(getStore().getState()).toEqual(null)
+    expect(store.getState()).toEqual(null)
   })
 
   it('initialState `{ app: "hello, world" }` should create store with state `{ app: "hello, world" }`', () => {
-    const { init, getStore } = require('../src')
-    init({
+    const { init } = require('../src')
+    const store = init({
       redux: {
         initialState: { app: 'hello, world' }
       }
     })
 
-    expect(getStore().getState()).toEqual({ app: 'hello, world' })
+    expect(store.getState()).toEqual({ app: 'hello, world' })
   })
 
   it('extraReducers should create store with extra reducers', () => {
-    const { init, getStore } = require('../src')
+    const { init } = require('../src')
     const reducers = { todos: (state = 999) => state }
-    init({
+    const store = init({
       redux: {
         reducers
       }
     })
-    expect(getStore().getState()).toEqual({ todos: 999 })
+    expect(store.getState()).toEqual({ todos: 999 })
   })
 })


### PR DESCRIPTION
closes #172.

### Breaking Changes

1. getGone, getStore

```
const store = init()
```

2. Plugin.onStoreCreated accepts store, rather getStore.


- [x] core
- [x] docs
- [x] plugins
- [x] tests