### PR TITLE
root reducers receive initial state as third argument

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -3,6 +3,7 @@ import { ModelHook, Plugin } from './typings/rematch'
 
 export const modelHooks: ModelHook[] = []
 export const pluginMiddlewares: Middleware[] = []
+export const initialState = {}
 
 export const preStore = (plugins: Plugin[]) => {
   plugins.forEach((plugin: Plugin) => {

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,4 +1,4 @@
-import { modelHooks } from './core'
+import { initialState, modelHooks } from './core'
 import { createReducersAndUpdateStore } from './redux/store'
 import { Model } from './typings/rematch'
 import validate from './utils/validate'
@@ -14,6 +14,7 @@ const addModel = (model: Model) => {
   ])
   // run plugin model subscriptions
   modelHooks.forEach((modelHook) => modelHook(model))
+  initialState[model.name] = model.state
 }
 
 // main model import method

--- a/src/redux/reducers.ts
+++ b/src/redux/reducers.ts
@@ -1,5 +1,6 @@
 /* eslint no-underscore-dangle: 0 */
-import { combineReducers, Reducer, ReducersMapObject} from 'redux'
+import { combineReducers, Reducer} from 'redux'
+import { initialState } from '../core'
 import { Action, ConfigRedux, Model, Reducers, RootReducers } from '../typings/rematch'
 
 let combine = combineReducers
@@ -53,7 +54,7 @@ export const createRootReducer = (rootReducers: RootReducers = {}): Reducer<any>
     return (state, action) => {
       const rootReducerAction = rootReducers[action.type]
       if (rootReducers[action.type]) {
-        return mergedReducers(rootReducerAction(state, action), action)
+        return mergedReducers(rootReducerAction(state, action, initialState), action)
       }
       return mergedReducers(state, action)
     }

--- a/src/typings/rematch/index.d.ts
+++ b/src/typings/rematch/index.d.ts
@@ -72,7 +72,7 @@ export interface PluginCreator {
 }
 
 export interface RootReducers {
-  [type: string]: Reducer<any>,
+  [type: string]: (state: any, action: Action, initialState: any) => any
 }
 
 export interface ConfigRedux {

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -129,4 +129,26 @@ describe('createStore:', () => {
     expect(store.getState()).toEqual({ countA: 0, countB: 0, countC: 0 })
   })
 
+  test('root reducer should receive initial state as third argument', () => {
+    const { init, dispatch, model } = require('../src')
+    const store = init({
+        models: {
+          countA: { state: 0, reducers: { up: s => s + 1 } },
+          countB: { state: 0 }
+        },
+        redux: {
+        rootReducers: {
+          '@@RESET': (state, action, initialState) => {
+            return initialState
+          },
+        }
+      }
+    })
+
+    dispatch.countA.up()
+    dispatch({ type: '@@RESET' })
+
+    expect(store.getState()).toEqual({ countA: 0, countB: 0 })
+  })
+
 })


### PR DESCRIPTION
No need to accept this PR - We can kill it. I just thought I'd share an idea for a way to pass initialState as a third arg to the root reducer as discussed in #181 