### PR TITLE
add whitelist & blacklist to loading plugin

### DIFF
--- a/plugins/loading/README.md
+++ b/plugins/loading/README.md
@@ -70,7 +70,24 @@ The loading reducer defaults to the name of "loading".
 If you would like to change this, use the `name` option.
 
 ```js
-const loading = createLoadingPlugin({ name: 'load' })
+{ name: 'load' }
 ```
 
 In which case, loading can be accessed from `state.load.global`.
+
+### whitelist
+
+A shortlist of actions. Named with "modelName" & "actionName".
+
+```js
+{ whitelist: ['count/addOne'] })
+```
+
+
+### blacklist
+
+A shortlist of actions to exclude from loading indicators.
+
+```js
+{ blacklist: ['count/addOne'] })
+```

--- a/plugins/loading/package-lock.json
+++ b/plugins/loading/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@rematch/loading",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@rematch/core": {
-      "version": "0.1.0-beta.8",
-      "resolved": "https://registry.npmjs.org/@rematch/core/-/core-0.1.0-beta.8.tgz",
-      "integrity": "sha512-z6QN4tHEYSHbuqRL9xq8fC5nouttwKe37It27m49aFIyqUmVp1rgoaHVLWrToPaxU+he2tg5cYFnAa9g7EvNGA==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@rematch/core/-/core-0.1.1.tgz",
+      "integrity": "sha512-lnk+RWlkbmLDJ8vwmpb6kcJdS8oZgvgHd9w8/Y2mIIUGymMEQ87GcWTp7zlvbW5f6o2nxKy0p1mhMY5+s7nTag==",
       "dev": true,
       "requires": {
         "redux": "3.7.2"

--- a/plugins/loading/package.json
+++ b/plugins/loading/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rematch/loading",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Loading indicator plugin for Rematch",
   "keywords": [
     "@rematch",
@@ -26,9 +26,9 @@
   },
   "devDependencies": {
     "redux": "^3.0.0",
-    "@rematch/core": "^0.1.0-beta.8"
+    "@rematch/core": "^0.1.1"
   },
   "peerDependencies": {
-    "@rematch/core": "^0.1.0-beta.8"
+    "@rematch/core": "^0.1.1"
   }
 }

--- a/plugins/loading/test/loading.test.js
+++ b/plugins/loading/test/loading.test.js
@@ -104,6 +104,91 @@ describe('loading', () => {
     expect(store.getState().load.global).toBe(false)
   })
 
+  test('should throw if loading name is not a string', () => {
+    const {
+      init, dispatch
+    } = require('../../../src')
+    const loadingPlugin = require('../src').default
+    const createStore = () => init({
+      models: { count },
+      plugins: [loadingPlugin({ name: 42 })]
+    })
+    expect(createStore).toThrow()
+  })
+
+  test('should block items if not in whitelist', () => {
+    const {
+      init, dispatch
+    } = require('../../../src')
+    const loadingPlugin = require('../src').default
+    const store = init({
+      models: { count },
+      plugins: [loadingPlugin({
+        whitelist: ['some/action'],
+      })]
+    })
+    dispatch.count.timeout()
+    expect(store.getState().loading.models.count).toBe(false)
+  })
+
+  test('should block items if in blacklist', () => {
+    const {
+      init, dispatch
+    } = require('../../../src')
+    const loadingPlugin = require('../src').default
+    const store = init({
+      models: { count },
+      plugins: [loadingPlugin({
+        blacklist: ['count/timeout'],
+      })]
+    })
+    dispatch.count.timeout()
+    expect(store.getState().loading.models.count).toBe(false)
+  })
+
+  test('should throw if whitelist is not an array', () => {
+    const {
+      init, dispatch
+    } = require('../../../src')
+    const loadingPlugin = require('../src').default
+    const createStore = () => init({
+      models: { count },
+      plugins: [loadingPlugin({
+        whitelist: 'some/action',
+      })]
+    })
+    expect(createStore).toThrow()
+  })
+
+  test('should throw if blacklist is not an array', () => {
+    const {
+      init, dispatch
+    } = require('../../../src')
+    const loadingPlugin = require('../src').default
+    const createStore = () => init({
+      models: { count },
+      plugins: [loadingPlugin({
+        blacklist: 'some/action',
+      })]
+    })
+    expect(createStore).toThrow()
+  })
+
+  test('should throw if contains both a whitelist & blacklist', () => {
+    const {
+      init, dispatch
+    } = require('../../../src')
+    const loadingPlugin = require('../src').default
+    const createStore = () => init({
+      models: { count },
+      plugins: [loadingPlugin({
+        whitelist: ['some/action'],
+        blacklist: ['some/action'],
+      })]
+    })
+    expect(createStore).toThrow()
+  })
+
   // test('should handle "hide" if effect throws', () => {
   //   const {
   //     init, dispatch


### PR DESCRIPTION
Can optimize loading plugin by specifying which actions to add show/hide indicators to.

Docs:

### whitelist

A shortlist of actions. Named with "modelName" & "actionName".

```js
{ whitelist: ['count/addOne'] })
```


### blacklist

A shortlist of actions to exclude from loading indicators.

```js
{ blacklist: ['count/addOne'] })
```
