### PR TITLE
add basic demo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Dispatch can be called directly, or with the `dispatch.model.action(payload)` sh
 
 **React** | Vue | AngularJS | Angular 2
 
+- [Count Demo](https://www.webpackbin.com/bins/-L1cbpl4_RgEeGN1YkPS)
+
 ```jsx
 import React from 'react'
 import ReactDOM from 'react-dom'


### PR DESCRIPTION
A working demo on WebpackBin: https://www.webpackbin.com/bins/-L1cbpl4_RgEeGN1YkPS.

Still not sure if this is the best place to host a demo. I had issues previously with CodePen, but now I realize that was due to a bundling issue.
