### PR TITLE
feat(meta): pass meta as third parameter to reducers

### DIFF
--- a/src/plugins/effects.ts
+++ b/src/plugins/effects.ts
@@ -1,5 +1,5 @@
 import { Dispatch, MiddlewareAPI, Store } from 'redux'
-import { Action, Exposed, Model, Plugin, PluginCreator } from '../../typings/rematch'
+import { Action, Exposed, Model, Plugin, PluginCreator, ReducerContext } from '../../typings/rematch'
 
 const effectsPlugin: PluginCreator = {
   expose: {
@@ -29,9 +29,11 @@ const effectsPlugin: PluginCreator = {
       })
     },
     middleware: <S>(store: MiddlewareAPI<S>) => (next: Dispatch<S>) => async (action: Action) => {
-          // async/await acts as promise middleware
+        const reducerContext: ReducerContext = { action }
+
+        // async/await acts as promise middleware
         const result = (action.type in effects)
-          ? await effects[action.type](action.payload, store.getState())
+          ? await effects[action.type](action.payload, store.getState(), reducerContext)
           : await next(action)
         return result
     },

--- a/src/plugins/effects.ts
+++ b/src/plugins/effects.ts
@@ -1,5 +1,5 @@
 import { Dispatch, MiddlewareAPI, Store } from 'redux'
-import { Action, Exposed, Model, Plugin, PluginCreator, ReducerContext } from '../../typings/rematch'
+import { Action, Exposed, Model, Plugin, PluginCreator } from '../../typings/rematch'
 
 const effectsPlugin: PluginCreator = {
   expose: {
@@ -29,11 +29,9 @@ const effectsPlugin: PluginCreator = {
       })
     },
     middleware: <S>(store: MiddlewareAPI<S>) => (next: Dispatch<S>) => async (action: Action) => {
-        const reducerContext: ReducerContext = { action }
-
         // async/await acts as promise middleware
         const result = (action.type in effects)
-          ? await effects[action.type](action.payload, store.getState(), reducerContext)
+          ? await effects[action.type](action.payload, store.getState(), action.meta)
           : await next(action)
         return result
     },

--- a/src/redux/reducers.ts
+++ b/src/redux/reducers.ts
@@ -1,6 +1,6 @@
 /* eslint no-underscore-dangle: 0 */
 import { combineReducers, Reducer, ReducersMapObject} from 'redux'
-import { Action, ConfigRedux, Model, Reducers, RootReducers } from '../../typings/rematch'
+import { Action, ConfigRedux, EnhancedReducers, Model, ReducerContext, Reducers, RootReducers } from '../../typings/rematch'
 
 let combine = combineReducers
 
@@ -8,10 +8,11 @@ let allReducers: Reducers = {}
 
 // get reducer for given dispatch type
 // pass in (state, payload)
-export const getReducer = (reducer: Reducers, initialState: any) =>
+export const getReducer = (reducer: EnhancedReducers, initialState: any) =>
   (state: any = initialState, action: Action) => {
   if (typeof reducer[action.type] === 'function') {
-    return reducer[action.type](state, action.payload)
+    const reducerContext: ReducerContext = { action }
+    return reducer[action.type](state, action.payload, reducerContext)
   }
   return state
 }

--- a/src/redux/reducers.ts
+++ b/src/redux/reducers.ts
@@ -11,8 +11,7 @@ let allReducers: Reducers = {}
 export const getReducer = (reducer: EnhancedReducers, initialState: any) =>
   (state: any = initialState, action: Action) => {
   if (typeof reducer[action.type] === 'function') {
-    const { meta } = action
-    return reducer[action.type](state, action.payload, meta)
+    return reducer[action.type](state, action.payload, action.meta)
   }
   return state
 }

--- a/src/redux/reducers.ts
+++ b/src/redux/reducers.ts
@@ -1,6 +1,6 @@
 /* eslint no-underscore-dangle: 0 */
 import { combineReducers, Reducer, ReducersMapObject} from 'redux'
-import { Action, ConfigRedux, EnhancedReducers, Model, ReducerContext, Reducers, RootReducers } from '../../typings/rematch'
+import { Action, ConfigRedux, EnhancedReducers, Model, Reducers, RootReducers } from '../../typings/rematch'
 
 let combine = combineReducers
 
@@ -11,8 +11,8 @@ let allReducers: Reducers = {}
 export const getReducer = (reducer: EnhancedReducers, initialState: any) =>
   (state: any = initialState, action: Action) => {
   if (typeof reducer[action.type] === 'function') {
-    const reducerContext: ReducerContext = { action }
-    return reducer[action.type](state, action.payload, reducerContext)
+    const { meta } = action
+    return reducer[action.type](state, action.payload, meta)
   }
   return state
 }

--- a/test/dispatch.test.js
+++ b/test/dispatch.test.js
@@ -227,6 +227,28 @@ describe('dispatch:', () => {
       })
     })
 
+    test('should pass a reducer context as the third param', async () => {
+          const {
+              init, dispatch
+          } = require('../src')
+
+          const count = {
+              state: 1,
+              reducers: {
+                  incrementBy: (state, payload, context) => {
+                      expect(context.action.meta).toEqual({ metaProperty: false })
+                      return state + payload
+                  },
+              },
+          }
+
+          const store = init({
+              models: { count }
+          })
+
+          await dispatch.count.incrementBy(5, { metaProperty: false })
+      })
+
     test('should use second param as action meta', (done) => {
       const {
         init, dispatch

--- a/test/dispatch.test.js
+++ b/test/dispatch.test.js
@@ -227,7 +227,7 @@ describe('dispatch:', () => {
       })
     })
 
-    test('should pass a reducer context as the third param', async () => {
+    test('should pass the meta object as the third param', async () => {
           const {
               init, dispatch
           } = require('../src')
@@ -235,8 +235,8 @@ describe('dispatch:', () => {
           const count = {
               state: 1,
               reducers: {
-                  incrementBy: (state, payload, context) => {
-                      expect(context.action.meta).toEqual({ metaProperty: false })
+                  incrementBy: (state, payload, meta) => {
+                      expect(meta).toEqual({ metaProperty: false })
                       return state + payload
                   },
               },

--- a/typings/rematch/index.d.ts
+++ b/typings/rematch/index.d.ts
@@ -2,7 +2,7 @@
 // Project: Rematch
 // Definitions by: Shawn McKay https://github.com/shmck
 
-import { Dispatch, MiddlewareAPI, Middleware, Reducer, ReducersMapObject, Store, StoreCreator, StoreEnhancer } from 'redux'
+import { AnyAction, Dispatch, MiddlewareAPI, Middleware, Reducer, ReducersMapObject, Store, StoreCreator, StoreEnhancer } from 'redux'
 
 export as namespace rematch
 
@@ -20,6 +20,16 @@ export type Action = {
   type: string,
   payload?: any,
   meta?: any,
+}
+
+export type ReducerContext = {
+    action: AnyAction,
+}
+
+export type EnhancedReducer<S> = (state: S, payload: object, context: ReducerContext) => S;
+
+export type EnhancedReducers = {
+    [key: string]: EnhancedReducer<any>,
 }
 
 export type Reducers = {

--- a/typings/rematch/index.d.ts
+++ b/typings/rematch/index.d.ts
@@ -22,11 +22,7 @@ export type Action = {
   meta?: any,
 }
 
-export type ReducerContext = {
-    action: AnyAction,
-}
-
-export type EnhancedReducer<S> = (state: S, payload: object, context: ReducerContext) => S;
+export type EnhancedReducer<S> = (state: S, payload: object, meta: object) => S;
 
 export type EnhancedReducers = {
     [key: string]: EnhancedReducer<any>,


### PR DESCRIPTION
## Motivation
rematch reducers signature is (state, payload) => state, 
whilst regular redux reducers signature is (state, action) => state

That make impossible for rematch reducers to access the 'meta' property of an action, a functionality that may be required in advanced scenarios (example: dynamic state paths)

## Possible solution
A backward compatible solution could be, to pass a third parameter 'ReducerContext' to rematch reducers.
Initially, the ReducerContext include just whole action object, but in the future maybe it could host additional informations.
What do you think?

Thank you