### PR TITLE
Reducers that can listen to other model actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,3 +42,23 @@ const model = {
   }
 }
 ```
+
+## [0.5.0] - 2017-03-05
+### Added
+- listen to actions from other models within your reducers
+
+```js
+const count2 = {
+  state: 0,
+  reducers: {
+    // listens for action from other reducer
+    'count1/increment': (state) => state + 1
+  }
+}
+```
+
+Note: not yet available for effects.
+
+
+### Deprecated
+- `getState` from core in 0.4.0 will be removed with v1.0.0.

--- a/docs/api.md
+++ b/docs/api.md
@@ -117,6 +117,16 @@ An object of functions that change the model's state. These functions take the m
 }
 ```
 
+Reducers may also listen to actions from other models by listing the 'model name' + 'action name' as the key.
+
+```js
+{
+  reducers: {
+    'otherModel/actionName': (state, payload) => state + payload,
+  }
+}
+```
+
 ### effects
 
 `effects: { [string]: (payload, rootState) }`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rematch/core",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -25,9 +25,9 @@
       }
     },
     "@types/jest": {
-      "version": "22.1.3",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-22.1.3.tgz",
-      "integrity": "sha512-qpbOiPE3iqeqnicgOVg6MBgtFMxe0Qd5PHtHp4Y7YGBWnNIgv7Mr2lx7ILEN6d7K+Fub9FW1S3Q2NKvbc+b+AA==",
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-22.2.0.tgz",
+      "integrity": "sha512-5DeGD46Goq6+GtEEB57hQzC/BbuEbEj0fUCDm7a5Fm9ZYLL3odPh1kYn9yMtQe1rKNg/BcVmadroBCyih6thtw==",
       "dev": true
     },
     "@types/node": {
@@ -43,9 +43,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
-      "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.0.tgz",
+      "integrity": "sha512-arn53F07VXmls4o4pUhSzBa4fvaagPRe7AVZ8l7NHxFWUie2DsuFSBMMNAkgzRlOhEhzAnxeKyaWVzOH4xqp/g==",
       "dev": true
     },
     "acorn-globals": {
@@ -54,7 +54,7 @@
       "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.4.1"
+        "acorn": "5.5.0"
       }
     },
     "ajv": {
@@ -345,13 +345,13 @@
       }
     },
     "babel-jest": {
-      "version": "22.2.2",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.2.2.tgz",
-      "integrity": "sha512-GOutNE3jhFj5WWLd09e9+kkPwzqOSWRj1J1YslVxnKkmgKaWjfvE9k3JGMf8MJYGzEZr6dVK5bg9RWRi/2tGiQ==",
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.4.1.tgz",
+      "integrity": "sha512-rEdN/jevSuX0IQKcUqwqOGa0gDNis4jGY52Rq53aizfDGPwQYNJq+f9NCMT1HUhtUZhYSjvfGUfHQWBRT1/icA==",
       "dev": true,
       "requires": {
         "babel-plugin-istanbul": "4.1.5",
-        "babel-preset-jest": "22.2.0"
+        "babel-preset-jest": "22.4.1"
       }
     },
     "babel-messages": {
@@ -375,9 +375,9 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "22.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.2.0.tgz",
-      "integrity": "sha512-NwicD5n1YQaj6sM3PVULdPBDk1XdlWvh8xBeUJg3nqZwp79Vofb8Q7GOVeWoZZ/RMlMuJMMrEAgSQl/p392nLA==",
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.1.tgz",
+      "integrity": "sha512-gmj5FvFflXSnRapWmF/jDjx5Lof1kX0OwXibCxMOx38V3CFMOnTxLTUrAFfLkhCey3FJvv0ACvv/+h4nzFRxhg==",
       "dev": true
     },
     "babel-plugin-syntax-object-rest-spread": {
@@ -409,12 +409,12 @@
       }
     },
     "babel-preset-jest": {
-      "version": "22.2.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.2.0.tgz",
-      "integrity": "sha512-p61cPMGYlSgfNScn1yQuVnLguWE4bjhB/br4KQDMbYZG+v6ryE5Ch7TKukjA6mRuIQj1zhyou7Sbpqrh4/N6Pg==",
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.4.1.tgz",
+      "integrity": "sha512-gW3+spyB8fkSAI9fX+41BQMwar5LjR+nyKa2QRvK22snxnI29+jJVAMfId+osucFJzJJvhlvzKWnfwX8Omodvg==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "22.2.0",
+        "babel-plugin-jest-hoist": "22.4.1",
         "babel-plugin-syntax-object-rest-spread": "6.13.0"
       }
     },
@@ -480,7 +480,7 @@
         "babylon": "6.18.0",
         "debug": "2.6.9",
         "globals": "9.18.0",
-        "invariant": "2.2.2",
+        "invariant": "2.2.3",
         "lodash": "4.17.5"
       }
     },
@@ -1149,16 +1149,16 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
-      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+      "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
       "dev": true,
       "requires": {
         "esprima": "3.1.3",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "optionator": "0.8.2",
-        "source-map": "0.5.7"
+        "source-map": "0.6.1"
       },
       "dependencies": {
         "esprima": {
@@ -1166,6 +1166,13 @@
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
           "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
           "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -1242,16 +1249,16 @@
       }
     },
     "expect": {
-      "version": "22.3.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-22.3.0.tgz",
-      "integrity": "sha512-woguB2yTY69vxUZoclqjPccHzUOd1s/mLx81kSSDg+7u6+2wfd5qh166DRoCq1KfaH/YXCTe+ogHgxj0i4LFPw==",
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-22.4.0.tgz",
+      "integrity": "sha512-Fiy862jT3qc70hwIHwwCBNISmaqBrfWKKrtqyMJ6iwZr+6KXtcnHojZFtd63TPRvRl8EQTJ+YXYy2lK6/6u+Hw==",
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
-        "jest-diff": "22.1.0",
+        "jest-diff": "22.4.0",
         "jest-get-type": "22.1.0",
-        "jest-matcher-utils": "22.2.0",
-        "jest-message-util": "22.2.0",
+        "jest-matcher-utils": "22.4.0",
+        "jest-message-util": "22.4.0",
         "jest-regex-util": "22.1.0"
       }
     },
@@ -1410,7 +1417,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.8.0",
+        "nan": "2.9.2",
         "node-pre-gyp": "0.6.39"
       },
       "dependencies": {
@@ -2679,9 +2686,9 @@
       "dev": true
     },
     "invariant": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.3.tgz",
+      "integrity": "sha512-7Z5PPegwDTyjbaeCnV0efcyS6vdKAU51kpEmS7QFib3P4822l8ICYyMn7qvJnc+WzLoDsuI9gPMKbJ8pCu8XtA==",
       "dev": true,
       "requires": {
         "loose-envify": "1.3.1"
@@ -3025,19 +3032,19 @@
       }
     },
     "jest": {
-      "version": "22.3.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-22.3.0.tgz",
-      "integrity": "sha512-LT4VWb2N5ZjLs6+UaI+6k0lyH8jlI+Mhb7nfWG6dLgUDhD4rFXQjMRL8owehZz46ODTWZ4eVe3fEMrKRp4Fing==",
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-22.4.2.tgz",
+      "integrity": "sha512-wD7dXWtfaQAgbNVsjFqzmuhg6nzwGsTRVea3FpSJ7GURhG+J536fw4mdoLB01DgiEozDDeF1ZMR/UlUszTsCrg==",
       "dev": true,
       "requires": {
         "import-local": "1.0.0",
-        "jest-cli": "22.3.0"
+        "jest-cli": "22.4.2"
       },
       "dependencies": {
         "jest-cli": {
-          "version": "22.3.0",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.3.0.tgz",
-          "integrity": "sha512-CiUADkEcYuRdy3A3AXPpyK4hKq8UfM6M5vKmPSQSMLa7TWUDcB+NmIz5UAFYXnNdw4osNnEzTpsGBYeZLq3UZA==",
+          "version": "22.4.2",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.4.2.tgz",
+          "integrity": "sha512-ebo6ZWK2xDSs7LGnLvM16SZOIJ2dj0B6/oERmGcal32NHkks450nNfGrGTyOSPgJDgH8DFhVdBXgSamN7mtZ0Q==",
           "dev": true,
           "requires": {
             "ansi-escapes": "3.0.0",
@@ -3052,17 +3059,18 @@
             "istanbul-lib-instrument": "1.9.2",
             "istanbul-lib-source-maps": "1.2.3",
             "jest-changed-files": "22.2.0",
-            "jest-config": "22.3.0",
-            "jest-environment-jsdom": "22.3.0",
+            "jest-config": "22.4.2",
+            "jest-environment-jsdom": "22.4.1",
             "jest-get-type": "22.1.0",
-            "jest-haste-map": "22.3.0",
-            "jest-message-util": "22.2.0",
+            "jest-haste-map": "22.4.2",
+            "jest-message-util": "22.4.0",
             "jest-regex-util": "22.1.0",
             "jest-resolve-dependencies": "22.1.0",
-            "jest-runner": "22.3.0",
-            "jest-runtime": "22.3.0",
-            "jest-snapshot": "22.2.0",
-            "jest-util": "22.3.0",
+            "jest-runner": "22.4.2",
+            "jest-runtime": "22.4.2",
+            "jest-snapshot": "22.4.0",
+            "jest-util": "22.4.1",
+            "jest-validate": "22.4.2",
             "jest-worker": "22.2.2",
             "micromatch": "2.3.11",
             "node-notifier": "5.2.1",
@@ -3087,64 +3095,64 @@
       }
     },
     "jest-config": {
-      "version": "22.3.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.3.0.tgz",
-      "integrity": "sha512-/T3AyDY4FsRaqIsKk+oIItb5mePgIiyh12++fKt8ueISu7jwWf6Y9saodynQaZKtbWcJMDwgTfKz44DylDb1zA==",
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.4.2.tgz",
+      "integrity": "sha512-oG31qYO73/3vj/Q8aM2RgzmHndTkz9nRk8ISybfuJqqbf0RW7OUjHVOZPLOUiwLWtz52Yq2HkjIblsyhbA7vrg==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
         "glob": "7.1.2",
-        "jest-environment-jsdom": "22.3.0",
-        "jest-environment-node": "22.3.0",
+        "jest-environment-jsdom": "22.4.1",
+        "jest-environment-node": "22.4.1",
         "jest-get-type": "22.1.0",
-        "jest-jasmine2": "22.3.0",
+        "jest-jasmine2": "22.4.2",
         "jest-regex-util": "22.1.0",
-        "jest-resolve": "22.3.0",
-        "jest-util": "22.3.0",
-        "jest-validate": "22.2.2",
-        "pretty-format": "22.1.0"
+        "jest-resolve": "22.4.2",
+        "jest-util": "22.4.1",
+        "jest-validate": "22.4.2",
+        "pretty-format": "22.4.0"
       }
     },
     "jest-diff": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.1.0.tgz",
-      "integrity": "sha512-lowdbU/dzXh+2/MR5QcvU5KPNkO4JdAEYw0PkQCbIQIuy5+g3QZBuVhWh8179Fmpg4CQrz1WgoK/yQHDCHbqqw==",
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.4.0.tgz",
+      "integrity": "sha512-+/t20WmnkOkB8MOaGaPziI8zWKxquMvYw4Ub+wOzi7AUhmpFXz43buWSxVoZo4J5RnCozpGbX3/FssjJ5KV9Nw==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
         "diff": "3.4.0",
         "jest-get-type": "22.1.0",
-        "pretty-format": "22.1.0"
+        "pretty-format": "22.4.0"
       }
     },
     "jest-docblock": {
-      "version": "22.2.2",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.2.2.tgz",
-      "integrity": "sha512-ymqH4vzNMA0BrRfbDfQ6+b/AI0FLwuEAjBa87HUcuIz0UN76zH+Qw7lpDvhELzNmxu1EfxP9cxMRnVgkHZ7vyA==",
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.4.0.tgz",
+      "integrity": "sha512-lDY7GZ+/CJb02oULYLBDj7Hs5shBhVpDYpIm8LUyqw9X2J22QRsM19gmGQwIFqGSJmpc/LRrSYudeSrG510xlQ==",
       "dev": true,
       "requires": {
         "detect-newline": "2.1.0"
       }
     },
     "jest-environment-jsdom": {
-      "version": "22.3.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.3.0.tgz",
-      "integrity": "sha512-3AwJ1qECmaiq52sn1ZEGJR0O8ZXfE3jWLYcUW+PcGMPcc+k3jFhCHYeUp7VK3njpFB6lmOIbsZs40S0kyMPDyA==",
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.4.1.tgz",
+      "integrity": "sha512-x/JzAoH+dWPBnIMv5OQKiIR0TYf6UvbRjsIuDZ11yDFXkHKGJZg6jNnLAsokAm3cq9kUa2hH5BPUC9XU4n1ELQ==",
       "dev": true,
       "requires": {
         "jest-mock": "22.2.0",
-        "jest-util": "22.3.0",
+        "jest-util": "22.4.1",
         "jsdom": "11.6.2"
       }
     },
     "jest-environment-node": {
-      "version": "22.3.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.3.0.tgz",
-      "integrity": "sha512-Pmpcm5n2YFzruhbAdV5RmEO0xoSnZVw326RLHoCIYhxcm7Vxacb8YKvRv9CbFbXgyQdwuamtaKENQz6yj35b9Q==",
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.4.1.tgz",
+      "integrity": "sha512-wj9+zzfRgnUbm5VwFOCGgG1QmbucUyrjPKBKUJdLW8K5Ss5zrNc1k+v6feZhFg6sS3ZGnjgtIyklaxEARxu+LQ==",
       "dev": true,
       "requires": {
         "jest-mock": "22.2.0",
-        "jest-util": "22.3.0"
+        "jest-util": "22.4.1"
       }
     },
     "jest-get-type": {
@@ -3154,62 +3162,63 @@
       "dev": true
     },
     "jest-haste-map": {
-      "version": "22.3.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.3.0.tgz",
-      "integrity": "sha512-eCU0/07j5lDnk6NldfZVv0ul1PqkOFjKwcLpzcj1BBEDYmWoXi8z+3Qoikl0/UM3pjbaVfQOgLZEgCzmzHfwdQ==",
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.4.2.tgz",
+      "integrity": "sha512-EdQADHGXRqHJYAr7q9B9YYHZnrlcMwhx1+DnIgc9uN05nCW3RvGCxJ91MqWXcC1AzatLoSv7SNd0qXMp2jKBDA==",
       "dev": true,
       "requires": {
         "fb-watchman": "2.0.0",
         "graceful-fs": "4.1.11",
-        "jest-docblock": "22.2.2",
+        "jest-docblock": "22.4.0",
+        "jest-serializer": "22.4.0",
         "jest-worker": "22.2.2",
         "micromatch": "2.3.11",
         "sane": "2.4.1"
       }
     },
     "jest-jasmine2": {
-      "version": "22.3.0",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.3.0.tgz",
-      "integrity": "sha512-m88tD8usgYJJErO7KEr0FqDDyiYCElaWbKqKLstsm/0mFANslhHYFFgIBM3uY+OT9v90mS40DBNMVwWRTpAxJA==",
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.4.2.tgz",
+      "integrity": "sha512-KZaIHpXQ0AIlvQJFCU0uoXxtz5GG47X14r9upMe7VXE55UazoMZBFnQb9TX2HoYX2/AxJYnjHuvwKVCFqOrEtw==",
       "dev": true,
       "requires": {
-        "callsites": "2.0.0",
         "chalk": "2.3.0",
         "co": "4.6.0",
-        "expect": "22.3.0",
+        "expect": "22.4.0",
         "graceful-fs": "4.1.11",
         "is-generator-fn": "1.0.0",
-        "jest-diff": "22.1.0",
-        "jest-matcher-utils": "22.2.0",
-        "jest-message-util": "22.2.0",
-        "jest-snapshot": "22.2.0",
+        "jest-diff": "22.4.0",
+        "jest-matcher-utils": "22.4.0",
+        "jest-message-util": "22.4.0",
+        "jest-snapshot": "22.4.0",
+        "jest-util": "22.4.1",
         "source-map-support": "0.5.3"
       }
     },
     "jest-leak-detector": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.1.0.tgz",
-      "integrity": "sha512-8QsCWkncWAqdvrXN4yXQp9vgWF6CT3RkRey+d06SIHX913uXzAJhJdZyo6eE+uHVYMxUbxqW93npbUFhAR0YxA==",
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.4.0.tgz",
+      "integrity": "sha512-r3NEIVNh4X3fEeJtUIrKXWKhNokwUM2ILp5LD8w1KrEanPsFtZmYjmyZYjDTX2dXYr33TW65OvbRE3hWFAyq6g==",
       "dev": true,
       "requires": {
-        "pretty-format": "22.1.0"
+        "pretty-format": "22.4.0"
       }
     },
     "jest-matcher-utils": {
-      "version": "22.2.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.2.0.tgz",
-      "integrity": "sha512-jO0cnQ93mR4on+nbmEeK4bChCvLeMFN1bP2qjRjwFv5KzQt34y5SmUq9FgzKjZQZG8zUmaQN+/pHJMUQ0xAcgQ==",
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.0.tgz",
+      "integrity": "sha512-03m3issxUXpWMwDYTfmL8hRNewUB0yCRTeXPm+eq058rZxLHD9f5NtSSO98CWHqe4UyISIxd9Ao9iDVjHWd2qg==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
         "jest-get-type": "22.1.0",
-        "pretty-format": "22.1.0"
+        "pretty-format": "22.4.0"
       }
     },
     "jest-message-util": {
-      "version": "22.2.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.2.0.tgz",
-      "integrity": "sha512-LHPYu5kyA07FZK2CpvJ0xBE+gqy+dW30sFU3oep78lmscyc27mVOWDVwzmROhUeY8LlYpW3mcpRB/w5ibD6ZkA==",
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.4.0.tgz",
+      "integrity": "sha512-eyCJB0T3hrlpFF2FqQoIB093OulP+1qvATQmD3IOgJgMGqPL6eYw8TbC5P/VCWPqKhGL51xvjIIhow5eZ2wHFw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0-beta.40",
@@ -3232,9 +3241,9 @@
       "dev": true
     },
     "jest-resolve": {
-      "version": "22.3.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.3.0.tgz",
-      "integrity": "sha512-OQzPRNCBw3KRPzDTJhuW9eXLrlsnv6tY5ArmKSKsDMA5t6EcYv1W/6DrNYqiIVi7Zcx4P+1hssFeWVZWp9TnDg==",
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.4.2.tgz",
+      "integrity": "sha512-P1hSfcc2HJYT5t+WPu/11OfFMa7m8pBb2Gf2vm6W9OVs7YTXQ5RCC3nDqaYZQaTqxEM1ZZaTcQGcE6U2xMOsqQ==",
       "dev": true,
       "requires": {
         "browser-resolve": "1.11.2",
@@ -3251,42 +3260,43 @@
       }
     },
     "jest-runner": {
-      "version": "22.3.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.3.0.tgz",
-      "integrity": "sha512-ch48IjHcOj+mIV9iMJsK4c0OcVd6OOKX6ggwttYJorypu+rEpgmpPXfucAh8q8F9SFt8nKByfjD6iHOWtd27sA==",
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.4.2.tgz",
+      "integrity": "sha512-W4vwgiVQS0NyXt8hgpw7i0YUtsfoChiQcoHWBJeq2ocV4VF2osEZx8HYgpH5HfNe1Cb5LZeZWxX8Dr3hesbGFg==",
       "dev": true,
       "requires": {
         "exit": "0.1.2",
-        "jest-config": "22.3.0",
-        "jest-docblock": "22.2.2",
-        "jest-haste-map": "22.3.0",
-        "jest-jasmine2": "22.3.0",
-        "jest-leak-detector": "22.1.0",
-        "jest-message-util": "22.2.0",
-        "jest-runtime": "22.3.0",
-        "jest-util": "22.3.0",
+        "jest-config": "22.4.2",
+        "jest-docblock": "22.4.0",
+        "jest-haste-map": "22.4.2",
+        "jest-jasmine2": "22.4.2",
+        "jest-leak-detector": "22.4.0",
+        "jest-message-util": "22.4.0",
+        "jest-runtime": "22.4.2",
+        "jest-util": "22.4.1",
         "jest-worker": "22.2.2",
         "throat": "4.1.0"
       }
     },
     "jest-runtime": {
-      "version": "22.3.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.3.0.tgz",
-      "integrity": "sha512-e0BO1/by3bi0d7vMN7afVVD9kD9NEzmHrZgpJtTyxTN4qyL94iJyiPEd7WZxDySSNvA6Fd43LS7AbkMGhOaVJg==",
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.4.2.tgz",
+      "integrity": "sha512-9/Fxbj99cqxI7o2nTNzevnI38eDBstkwve8ZeaAD/Kz0fbU3i3eRv2QPEmzbmyCyBvUWxCT7BzNLTzTqH1+pyA==",
       "dev": true,
       "requires": {
         "babel-core": "6.26.0",
-        "babel-jest": "22.2.2",
+        "babel-jest": "22.4.1",
         "babel-plugin-istanbul": "4.1.5",
         "chalk": "2.3.0",
         "convert-source-map": "1.5.1",
         "exit": "0.1.2",
         "graceful-fs": "4.1.11",
-        "jest-config": "22.3.0",
-        "jest-haste-map": "22.3.0",
+        "jest-config": "22.4.2",
+        "jest-haste-map": "22.4.2",
         "jest-regex-util": "22.1.0",
-        "jest-resolve": "22.3.0",
-        "jest-util": "22.3.0",
+        "jest-resolve": "22.4.2",
+        "jest-util": "22.4.1",
+        "jest-validate": "22.4.2",
         "json-stable-stringify": "1.0.1",
         "micromatch": "2.3.11",
         "realpath-native": "1.0.0",
@@ -3304,45 +3314,60 @@
         }
       }
     },
+    "jest-serializer": {
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-22.4.0.tgz",
+      "integrity": "sha512-dnqde95MiYfdc1ZJpjEiHCRvRGGJHPsZQARJFucEGIaOzxqqS9/tt2WzD/OUSGT6kxaEGLQE92faVJGdoCu+Rw==",
+      "dev": true
+    },
     "jest-snapshot": {
-      "version": "22.2.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.2.0.tgz",
-      "integrity": "sha512-nc4hOfENTO/09NWJDz6ojf5zdAGPutQ4ZKmidWuEirTyBwhndxBlckO8ZaiQk9NDfDUeoVNptd6zJW84GWPRKw==",
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.4.0.tgz",
+      "integrity": "sha512-6Zz4F9G1Nbr93kfm5h3A2+OkE+WGpgJlskYE4iSNN2uYfoTL5b9W6aB9Orpx+ueReHyqmy7HET7Z3EmYlL3hKw==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
-        "jest-diff": "22.1.0",
-        "jest-matcher-utils": "22.2.0",
+        "jest-diff": "22.4.0",
+        "jest-matcher-utils": "22.4.0",
         "mkdirp": "0.5.1",
         "natural-compare": "1.4.0",
-        "pretty-format": "22.1.0"
+        "pretty-format": "22.4.0"
       }
     },
     "jest-util": {
-      "version": "22.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.3.0.tgz",
-      "integrity": "sha512-c/YVsxOI2tSwXqb19/3gnzBDVsrTG4D3dAJzHpdROxZdJ2dpI/zYKEdLDS2CSKDTbjftoeiW9PrOYiDGF2UKfw==",
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.4.1.tgz",
+      "integrity": "sha512-9ySBdJY2qVWpg0OvZbGcFXE2NgwccpZVj384E9bx7brKFc7l5anpqah15mseWcz7FLDk7/N+LyYgqFme7Rez2Q==",
       "dev": true,
       "requires": {
         "callsites": "2.0.0",
         "chalk": "2.3.0",
         "graceful-fs": "4.1.11",
         "is-ci": "1.1.0",
-        "jest-message-util": "22.2.0",
-        "jest-validate": "22.2.2",
-        "mkdirp": "0.5.1"
+        "jest-message-util": "22.4.0",
+        "mkdirp": "0.5.1",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "jest-validate": {
-      "version": "22.2.2",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.2.2.tgz",
-      "integrity": "sha512-YcZlnHYqQqLqSTj/E+mDkriqVmGOATTzseV+JFWa0XJ4Tpxji6+M66TcTl1PlbvQTMo+iVvvRixnPkF1mqNFjg==",
+      "version": "22.4.2",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.4.2.tgz",
+      "integrity": "sha512-TLOgc/EULFBjMCAqZp5OdVvjxV16DZpfthd/UyPzM6lRmgWluohNVemAdnL3JvugU1s2Q2npcIqtbOtiPjaZ0A==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
+        "jest-config": "22.4.2",
         "jest-get-type": "22.1.0",
         "leven": "2.1.0",
-        "pretty-format": "22.1.0"
+        "pretty-format": "22.4.0"
       }
     },
     "jest-worker": {
@@ -3383,7 +3408,7 @@
       "dev": true,
       "requires": {
         "abab": "1.0.4",
-        "acorn": "5.4.1",
+        "acorn": "5.5.0",
         "acorn-globals": "4.1.0",
         "array-equal": "1.0.0",
         "browser-process-hrtime": "0.1.2",
@@ -3391,7 +3416,7 @@
         "cssom": "0.3.2",
         "cssstyle": "0.2.37",
         "domexception": "1.0.1",
-        "escodegen": "1.9.0",
+        "escodegen": "1.9.1",
         "html-encoding-sniffer": "1.0.2",
         "left-pad": "1.2.0",
         "nwmatcher": "1.4.3",
@@ -3406,7 +3431,7 @@
         "webidl-conversions": "4.0.2",
         "whatwg-encoding": "1.0.3",
         "whatwg-url": "6.4.0",
-        "ws": "4.0.0",
+        "ws": "4.1.0",
         "xml-name-validator": "3.0.0"
       }
     },
@@ -3720,7 +3745,7 @@
       "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.4"
+        "readable-stream": "2.3.5"
       },
       "dependencies": {
         "isarray": {
@@ -3730,9 +3755,9 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
-          "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+          "version": "2.3.5",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -3840,9 +3865,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+      "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
       "dev": true,
       "optional": true
     },
@@ -3885,7 +3910,7 @@
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
         "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.1"
+        "validate-npm-package-license": "3.0.3"
       }
     },
     "normalize-path": {
@@ -4185,9 +4210,9 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.1.0.tgz",
-      "integrity": "sha512-0HHR5hCmjDGU4sez3w5zRDAAwn7V0vT4SgPiYPZ1XDm5sT3Icb+Bh+fsOP3+Y3UwPjMr7TbRj+L7eQyMkPAxAw==",
+      "version": "22.4.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.0.tgz",
+      "integrity": "sha512-pvCxP2iODIIk9adXlo4S3GRj0BrJiil68kByAa1PrgG97c1tClh9dLMgp3Z6cHFZrclaABt0UH8PIhwHuFLqYA==",
       "dev": true,
       "requires": {
         "ansi-regex": "3.0.0",
@@ -4344,7 +4369,7 @@
       "requires": {
         "graceful-fs": "4.1.11",
         "minimatch": "3.0.4",
-        "readable-stream": "2.3.4",
+        "readable-stream": "2.3.5",
         "set-immediate-shim": "1.0.1"
       },
       "dependencies": {
@@ -4355,9 +4380,9 @@
           "dev": true
         },
         "readable-stream": {
-          "version": "2.3.4",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
-          "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+          "version": "2.3.5",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+          "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
           "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
@@ -4715,18 +4740,17 @@
       }
     },
     "rollup": {
-      "version": "0.56.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.56.2.tgz",
-      "integrity": "sha512-vZIn0P+xA1glmc4DwRsUC9ce6SSE5gZT2YKaRiSYHwJXHcRtXWHOvrY2NtUR8Gk+EoszyyoXMfw9OrYCCKCYCA==",
+      "version": "0.56.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.56.4.tgz",
+      "integrity": "sha512-Ja1ph+tZSE9sY5/WURJCuhaU2+2LTKKmhvxG7Smunn37s7aESLDFUj5XMnSYMypytwxeTvpy8ZzFfEeFiYMyug==",
       "dev": true
     },
     "rollup-plugin-commonjs": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.3.0.tgz",
-      "integrity": "sha512-PYs3OiYgENFYEmI3vOEm5nrp3eY90YZqd5vGmQqeXmhJsAWFIrFdROCvOasqJ1HgeTvqyYo9IGXnFDyoboNcgQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.0.0.tgz",
+      "integrity": "sha512-4wYwVu3wm39bGrOturXtUDfASt/OVh1UTxAukDMLbJnjCMM0i2nMRhLiutU2ZRXkYySq1Vn01Tw+l/AcJtZpkQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.4.1",
         "estree-walker": "0.5.1",
         "magic-string": "0.22.4",
         "resolve": "1.5.0",
@@ -4925,24 +4949,35 @@
       }
     },
     "spdx-correct": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
       }
     },
-    "spdx-expression-parse": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+    "spdx-exceptions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
       "dev": true
     },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
+      }
+    },
     "spdx-license-ids": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
       "dev": true
     },
     "split": {
@@ -5197,20 +5232,19 @@
       "dev": true
     },
     "ts-jest": {
-      "version": "22.0.4",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-22.0.4.tgz",
-      "integrity": "sha512-cQlgWYCakArbHW5B5RgZvmBomepOuIBLCR972AdWuaK6VmLxbmCh8OCaGGcBChf7dv/8YNACYvC6jeebQDKgyA==",
+      "version": "22.4.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-22.4.1.tgz",
+      "integrity": "sha512-6D3rWDiIuuRmtnoxDK0s69VK8Zw+JTdOkG9KeqQJF1U4ODlvAXg7ZLHfjZTmRFEshitFFeSmJ/reKzufYeibWA==",
       "dev": true,
       "requires": {
         "babel-core": "6.26.0",
         "babel-plugin-istanbul": "4.1.5",
         "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-preset-jest": "22.2.0",
+        "babel-preset-jest": "22.4.1",
         "cpx": "1.5.0",
         "fs-extra": "4.0.3",
-        "jest-config": "22.3.0",
+        "jest-config": "22.4.2",
         "pkg-dir": "2.0.0",
-        "source-map-support": "0.5.3",
         "yargs": "11.0.0"
       },
       "dependencies": {
@@ -5361,12 +5395,6 @@
       "dev": true,
       "optional": true
     },
-    "ultron": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
-      "dev": true
-    },
     "universalify": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
@@ -5399,13 +5427,13 @@
       }
     },
     "validate-npm-package-license": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
       "dev": true,
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
       }
     },
     "verror": {
@@ -5574,14 +5602,13 @@
       }
     },
     "ws": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-4.0.0.tgz",
-      "integrity": "sha512-QYslsH44bH8O7/W2815u5DpnCpXWpEK44FmaHffNwgJI4JMaSZONgPBTOfrxJ29mXKbXak+LsJ2uAkDTYq2ptQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+      "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
       "dev": true,
       "requires": {
         "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "ultron": "1.1.1"
+        "safe-buffer": "5.1.1"
       }
     },
     "xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rematch/core",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "A Redux Framework",
   "keywords": [
     "@rematch",
@@ -42,22 +42,22 @@
     "redux": "^3.7.2"
   },
   "devDependencies": {
-    "@types/jest": "^22.1.3",
+    "@types/jest": "^22.2.0",
     "@types/node": "^9.4.6",
     "coveralls": "^3.0.0",
     "cross-env": "^5.1.3",
     "gitbook-plugin-edit-link": "^2.0.2",
     "gitbook-plugin-github": "^3.0.0",
     "gitbook-plugin-prism": "^2.3.0",
-    "jest": "^22.3.0",
+    "jest": "^22.4.2",
     "reselect": "^3.0.1",
     "rimraf": "^2.6.2",
-    "rollup": "^0.56.2",
-    "rollup-plugin-commonjs": "^8.3.0",
+    "rollup": "^0.56.4",
+    "rollup-plugin-commonjs": "^9.0.0",
     "rollup-plugin-node-resolve": "^3.0.3",
     "rollup-plugin-replace": "^2.0.0",
     "rollup-plugin-uglify": "^3.0.0",
-    "ts-jest": "^22.0.4",
+    "ts-jest": "^22.4.1",
     "tslint": "^5.9.1",
     "typescript": "^2.7.2",
     "uglify-es": "^3.3.10"
@@ -86,7 +86,6 @@
       "/dist",
       ".mock.js"
     ],
-    "mapCoverage": true,
     "testPathIgnorePatterns": [
       "/_book/",
       "/lib/",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,14 @@ import init from './init'
 import { createModel as model } from './model'
 import dispatchPlugin from './plugins/dispatch'
 import { store } from './redux/store'
+import deprecate from './utils/deprecate'
 
 const { expose: { dispatch } } = dispatchPlugin
 
-const getState = () => store.getState()
+const getState = () => {
+  deprecate('getState import will be removed in @rematch/core@v1.0.0')
+  return store.getState()
+}
 
 export default {
   dispatch,

--- a/src/plugins/dispatch.ts
+++ b/src/plugins/dispatch.ts
@@ -28,7 +28,7 @@ const dispatchPlugin: PluginCreator = {
         if (process.env.NODE_ENV !== 'production') {
           validate([
             [
-              !!reducerName.match(/\//),
+              !!reducerName.match(/\/.+\//),
               `Invalid reducer name (${model.name}/${reducerName})`,
             ],
             [

--- a/src/redux/reducers.ts
+++ b/src/redux/reducers.ts
@@ -6,24 +6,29 @@ let combine = combineReducers
 
 let allReducers: Reducers = {}
 
-// get reducer for given dispatch type
+// create reducer for given dispatch type
 // pass in (state, payload)
-export const getReducer = (reducer: EnhancedReducers, initialState: any) =>
+export const createReducer = (reducer: EnhancedReducers, initialState: any) =>
   (state: any = initialState, action: Action) => {
+  // handle effects
   if (typeof reducer[action.type] === 'function') {
     return reducer[action.type](state, action.payload, action.meta)
   }
   return state
 }
 
+const isListener = (reducer: string): boolean => reducer.includes('/')
+
 // creates a reducer out of "reducers" keys and values
 export const createModelReducer = ({ name, reducers, state }: Model) => {
-  const modelReducers: Reducers = Object.keys(reducers || {}).reduce((acc, reducer) => ({
-    [`${name}/${reducer}`]: reducers[reducer],
-    ...acc,
-  }), {})
+  const modelReducers: Reducers = {}
+  Object.keys(reducers || {})
+    .forEach((reducer) => {
+      const action = isListener(reducer) ? reducer : `${name}/${reducer}`
+      modelReducers[action] = reducers[reducer]
+    })
   return {
-    [name]: getReducer(modelReducers, state),
+    [name]: createReducer(modelReducers, state),
   }
 }
 

--- a/src/redux/reducers.ts
+++ b/src/redux/reducers.ts
@@ -1,6 +1,7 @@
 /* eslint no-underscore-dangle: 0 */
 import { combineReducers, Reducer, ReducersMapObject} from 'redux'
 import { Action, ConfigRedux, EnhancedReducers, Model, Reducers, RootReducers } from '../../typings/rematch'
+import isListener from '../utils/isListener'
 
 let combine = combineReducers
 
@@ -16,8 +17,6 @@ export const createReducer = (reducer: EnhancedReducers, initialState: any) =>
   }
   return state
 }
-
-const isListener = (reducer: string): boolean => reducer.includes('/')
 
 // creates a reducer out of "reducers" keys and values
 export const createModelReducer = ({ name, reducers, state }: Model) => {

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -21,6 +21,7 @@ export const initStore = ({ redux }: Config): Store<any> => {
   return store
 }
 
+// allows for "model" to dynamically update the reducers/store
 export const createReducersAndUpdateStore = (model: Model): void => {
   mergeReducers(createModelReducer(model))
   store.replaceReducer(createRootReducer(rootReducers))

--- a/src/utils/deprecate.ts
+++ b/src/utils/deprecate.ts
@@ -1,0 +1,5 @@
+export default (warning) => {
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn(warning)
+  }
+}

--- a/src/utils/isListener.ts
+++ b/src/utils/isListener.ts
@@ -1,0 +1,1 @@
+export default (reducer: string): boolean => reducer.includes('/')

--- a/test/dispatch.test.js
+++ b/test/dispatch.test.js
@@ -159,7 +159,7 @@ describe('dispatch:', () => {
       name: 'a',
       state: 42,
       reducers: {
-        'invalid/name': () => 43
+        'model/invalid/name': () => 43
       },
     })).toThrow()
   })

--- a/test/listener.test.js
+++ b/test/listener.test.js
@@ -1,18 +1,18 @@
 describe('listener', () => {
-  test('should trigger state changes on another model', () => {
+  test('should trigger state changes on another models reducers', () => {
     const { init, dispatch } = require('../src')
     
     const count1 = {
       state: 0,
       reducers: {
-        increment: state => state + 1,
+        increment: (state, payload) => state + payload,
       }
     }
 
     const count2 = {
       state: 0,
       reducers: {
-        'count1/increment': state => state + 1
+        'count1/increment': (state, payload) => state + payload
       }
     }
 
@@ -20,7 +20,7 @@ describe('listener', () => {
       models: { count1, count2 }
     })
 
-    dispatch.count1.increment()
+    dispatch.count1.increment(1)
 
     expect(store.getState()).toEqual({ count1: 1, count2: 1 })
   })

--- a/test/listener.test.js
+++ b/test/listener.test.js
@@ -1,0 +1,27 @@
+describe('listener', () => {
+  test('should trigger state changes on another model', () => {
+    const { init, dispatch } = require('../src')
+    
+    const count1 = {
+      state: 0,
+      reducers: {
+        increment: state => state + 1,
+      }
+    }
+
+    const count2 = {
+      state: 0,
+      reducers: {
+        'count1/increment': state => state + 1
+      }
+    }
+
+    const store = init({
+      models: { count1, count2 }
+    })
+
+    dispatch.count1.increment()
+
+    expect(store.getState()).toEqual({ count1: 1, count2: 1 })
+  })
+})

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -129,7 +129,7 @@ describe('createStore:', () => {
     expect(store.getState()).toEqual({ countA: 0, countB: 0, countC: 0 })
   })
 
-  test.only('should allow users to import { getState } directly', () => {
+  test('should allow users to import { getState } directly', () => {
     const { init, getState } = require('../src')
     const store = init({
       models: {


### PR DESCRIPTION
Closes #231. A question turned into a proposal.

Listeners should be able to capture actions for other models directly within reducers.

The implementation can change, it is still up for discussion and debate, just getting the ball rolling.