### PR TITLE
React: explain destructuring dispatchers

### DIFF
--- a/docs/recipes/react.md
+++ b/docs/recipes/react.md
@@ -22,6 +22,8 @@ const mapState = (state, ownProps) => ({
 const mapDispatch = dispatch => ({
   increment: () => dispatch.count.increment(),
 })
+// You can also use destructuring
+const mapDispatchWithDestructure = ({count: {increment}}) => ({increment})
 
 export default connect(mapState, mapDispatch)(Counter)
 ```


### PR DESCRIPTION
Since the created dispatchers don't rely on `this`, this works fine.