### PR TITLE
loading plugin counts the number of outstanding effects per effect, module, and global

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4400,6 +4400,11 @@
         "symbol-observable": "1.2.0"
       }
     },
+    "redux-persist": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-5.9.1.tgz",
+      "integrity": "sha512-WIaLCd975R16W7nD1wqUPLcqeLztIRvsSSNZdblEjtihL1wz+NSOq9nYUSvsdoWJOtfm9RbDF4IVd0a3VOtZcw=="
+    },
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1850,8 +1850,7 @@
         "jsbn": {
           "version": "0.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "json-schema": {
           "version": "0.2.3",
@@ -4428,7 +4427,8 @@
     "redux-persist": {
       "version": "5.9.1",
       "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-5.9.1.tgz",
-      "integrity": "sha512-WIaLCd975R16W7nD1wqUPLcqeLztIRvsSSNZdblEjtihL1wz+NSOq9nYUSvsdoWJOtfm9RbDF4IVd0a3VOtZcw=="
+      "integrity": "sha512-WIaLCd975R16W7nD1wqUPLcqeLztIRvsSSNZdblEjtihL1wz+NSOq9nYUSvsdoWJOtfm9RbDF4IVd0a3VOtZcw==",
+      "dev": true
     },
     "regenerator-runtime": {
       "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "gitbook-plugin-github": "^3.0.0",
     "gitbook-plugin-prism": "^2.3.0",
     "jest": "^22.3.0",
+    "redux-persist": "^5.9.1",
     "reselect": "^3.0.1",
     "rimraf": "^2.6.2",
     "rollup": "^0.56.2",

--- a/plugins/loading/README.md
+++ b/plugins/loading/README.md
@@ -62,11 +62,16 @@ init({
 
 ## Options
 
+### asNumber
+
+```js
+{ asNumber: true }
+
+The loading state values are a "counter", returns a number (eg. `store.getState().loading.global === 5`).
+
+Defaults to `false`, returns a boolean (eg. `store.getState().loading.global === true`)
+
 ### name
-
-The loading reducer defaults to the name of "loading".
-
-If you would like to change this, use the `name` option.
 
 ```js
 { name: 'load' }
@@ -74,9 +79,11 @@ If you would like to change this, use the `name` option.
 
 In which case, loading can be accessed from `state.load.global`.
 
+Defaults to the name of `loading` (eg. `state.loading.global`).
+
 ### whitelist
 
-A shortlist of actions. Named with "modelName" & "actionName".
+A shortlist of actions. Named with "modelName" / "actionName".
 
 ```js
 { whitelist: ['count/addOne'] })

--- a/plugins/loading/examples/react-loading-example/src/App.js
+++ b/plugins/loading/examples/react-loading-example/src/App.js
@@ -37,9 +37,9 @@ const App = ({ submit, loading }) => (
       Submit Async
     </button>
     <div style={styles.container}>
-      <Loading label='loading.global' show={loading.global} />
-      <Loading label='loading.models.form' show={loading.model} />
-      <Loading label='loading.effects.form.submit' show={loading.effect} />
+      <Loading label='loading.global' show={loading.global > 0} />
+      <Loading label='loading.models.form' show={loading.model > 0} />
+      <Loading label='loading.effects.form.submit' show={loading.effect > 0} />
     </div>
   </div>
 )

--- a/plugins/loading/examples/react-loading-example/src/example.js
+++ b/plugins/loading/examples/react-loading-example/src/example.js
@@ -1,5 +1,4 @@
-const asyncDelay = (time) => new Promise((resolve) =>
-  setTimeout(() => resolve(), time))
+const asyncDelay = ms => new Promise(r => setTimeout(r, ms))
 
 // example model
 export default {

--- a/plugins/loading/examples/react-loading-example/src/index.js
+++ b/plugins/loading/examples/react-loading-example/src/index.js
@@ -6,7 +6,7 @@ import createLoadingPlugin from '@rematch/loading'
 import App from './App'
 import example from './example'
 
-const loadingPlugin = createLoadingPlugin()
+const loadingPlugin = createLoadingPlugin({ asNumber: true })
 
 const store = init({
   plugins: [loadingPlugin],

--- a/plugins/loading/src/index.ts
+++ b/plugins/loading/src/index.ts
@@ -1,29 +1,28 @@
 import { Action, Model, PluginCreator } from '@rematch/core'
 
-const createLoadingAction = (show) => (state, { name, action }: any) => ({
-  ...state,
-  global: state.global + (show ? 1 : -1),
-  models: {
-    ...state.models,
-    [name]: state.models[name] + (show ? 1 : -1),
-  },
-  effects: {
-    ...state.effects,
-    [name]: {
-      ...state.effects[name],
-      [action]: state.effects[name][action] + (show ? 1 : -1),
-    },
-  },
-})
-
 interface LoadingConfig {
   name?: string,
   whitelist?: string[],
   blacklist?: string[],
 }
 
-const loadingPlugin = (config: LoadingConfig = {}): any => {
-  // validate config
+const createLoadingAction = val => (state, { name, action }: any) => ({
+  ...state,
+  global: state.global + val,
+  models: {
+    ...state.models,
+    [name]: state.models[name] + val,
+  },
+  effects: {
+    ...state.effects,
+    [name]: {
+      ...state.effects[name],
+      [action]: state.effects[name][action] + val,
+    },
+  },
+})
+
+const validateConfig = config => {
   if (config.name && typeof config.name !== 'string') {
     throw new Error('loading plugin config name must be a string')
   }
@@ -36,18 +35,26 @@ const loadingPlugin = (config: LoadingConfig = {}): any => {
   if (config.whitelist && config.blacklist) {
     throw new Error('loading plugin config cannot have both a whitelist & a blacklist')
   }
+}
+
+export default (config: LoadingConfig = {}): any => {
+  validateConfig(config)
 
   const loadingModelName = config.name || 'loading'
+
+  const hide = createLoadingAction(-1)
+  const show = createLoadingAction(1)
+
   const loading: Model = {
     name: loadingModelName,
     reducers: {
-      hide: createLoadingAction(false),
-      show: createLoadingAction(true),
+      hide,
+      show,
     },
     state: {
-      effects: {},
       global: 0,
       models: {},
+      effects: {},
     },
   }
 
@@ -107,5 +114,3 @@ const loadingPlugin = (config: LoadingConfig = {}): any => {
     }),
   }
 }
-
-export default loadingPlugin

--- a/plugins/loading/test/loading-asBoolean.test.js
+++ b/plugins/loading/test/loading-asBoolean.test.js
@@ -1,6 +1,6 @@
 const delay = ms => new Promise(r => setTimeout(r, ms))
 
-describe('loading', () => {
+describe('loading asBoolean', () => {
   let count, init, dispatch, loadingPlugin
 
   beforeEach(() => {
@@ -35,7 +35,7 @@ describe('loading', () => {
     })
 
     dispatch.count.addOne()
-    expect(store.getState().loading.global).toBe(0)
+    expect(store.getState().loading.global).toBe(false)
   })
 
   test('loading.global should be 1 for a dispatched effect', () => {
@@ -45,7 +45,7 @@ describe('loading', () => {
     })
 
     dispatch.count.timeout()
-    expect(store.getState().loading.global).toBe(1)
+    expect(store.getState().loading.global).toBe(true)
   })
 
   test('loading.global should be 2 for two dispatched effects', () => {
@@ -56,10 +56,10 @@ describe('loading', () => {
 
     dispatch.count.timeout()
     dispatch.count.timeout()
-    expect(store.getState().loading.global).toBe(2)
+    expect(store.getState().loading.global).toBe(true)
   })
 
-  test('should set loading.models[name] to 0', () => {
+  test('should set loading.models[name] to false', () => {
     const {
       init
     } = require('../../../src')
@@ -68,20 +68,20 @@ describe('loading', () => {
       plugins: [loadingPlugin()]
     })
 
-    expect(store.getState().loading.models.count).toBe(0)
+    expect(store.getState().loading.models.count).toBe(false)
   })
 
-  test('should change the loading.models to 1', () => {
+  test('should change the loading.models to true', () => {
     const store = init({
       models: { count },
       plugins: [loadingPlugin()]
     })
 
     dispatch.count.timeout()
-    expect(store.getState().loading.models.count).toBe(1)
+    expect(store.getState().loading.models.count).toBe(true)
   })
 
-  test('should change the loading.models to 2', () => {
+  test('should change the loading.models to true (double dispatch)', () => {
     const store = init({
       models: { count },
       plugins: [loadingPlugin()]
@@ -89,7 +89,7 @@ describe('loading', () => {
 
     dispatch.count.timeout()
     dispatch.count.timeout()
-    expect(store.getState().loading.models.count).toBe(2)
+    expect(store.getState().loading.models.count).toBe(true)
   })
 
   test('should set loading.effects[name] to object of effects', () => {
@@ -97,20 +97,20 @@ describe('loading', () => {
       models: { count },
       plugins: [loadingPlugin()]
     })
-    expect(store.getState().loading.effects.count.timeout).toBe(0)
+    expect(store.getState().loading.effects.count.timeout).toBe(false)
   })
 
-  test('should change the loading.effects to 1', () => {
+  test('should change the loading.effects to true', () => {
     const store = init({
       models: { count },
       plugins: [loadingPlugin()]
     })
 
     dispatch.count.timeout()
-    expect(store.getState().loading.effects.count.timeout).toBe(1)
+    expect(store.getState().loading.effects.count.timeout).toBe(true)
   })
 
-  test('should change the loading.effects to 2', () => {
+  test('should change the loading.effects to true (double dispatch)', () => {
     const store = init({
       models: { count },
       plugins: [loadingPlugin()]
@@ -118,7 +118,7 @@ describe('loading', () => {
 
     dispatch.count.timeout()
     dispatch.count.timeout()
-    expect(store.getState().loading.effects.count.timeout).toBe(2)
+    expect(store.getState().loading.effects.count.timeout).toBe(true)
   })
 
   test('should capture all model and global loading for simultaneous effects', async () => {
@@ -143,22 +143,22 @@ describe('loading', () => {
     const effect2 = dispatch.count.timeout2()
 
     const ld = () => store.getState().loading
-    expect(ld().effects.count.timeout1).toBe(1)
-    expect(ld().effects.count.timeout2).toBe(1)
-    expect(ld().models.count).toBe(2)
-    expect(ld().global).toBe(2)
+    expect(ld().effects.count.timeout1).toBe(true)
+    expect(ld().effects.count.timeout2).toBe(true)
+    expect(ld().models.count).toBe(true)
+    expect(ld().global).toBe(true)
 
     await effect1
-    expect(ld().effects.count.timeout1).toBe(0)
-    expect(ld().effects.count.timeout2).toBe(1)
-    expect(ld().models.count).toBe(1)
-    expect(ld().global).toBe(1)
+    expect(ld().effects.count.timeout1).toBe(false)
+    expect(ld().effects.count.timeout2).toBe(true)
+    expect(ld().models.count).toBe(true)
+    expect(ld().global).toBe(true)
 
     await effect2
-    expect(ld().effects.count.timeout1).toBe(0)
-    expect(ld().effects.count.timeout2).toBe(0)
-    expect(ld().models.count).toBe(0)
-    expect(ld().global).toBe(0)
+    expect(ld().effects.count.timeout1).toBe(false)
+    expect(ld().effects.count.timeout2).toBe(false)
+    expect(ld().models.count).toBe(false)
+    expect(ld().global).toBe(false)
   })
 
   test('should configure the loading name to "foobar"', () => {
@@ -168,7 +168,7 @@ describe('loading', () => {
     })
 
     dispatch.count.addOne()
-    expect(store.getState().foobar.global).toBe(0)
+    expect(store.getState().foobar.global).toBe(false)
   })
 
   test('should throw if loading name is not a string', () => {
@@ -189,7 +189,7 @@ describe('loading', () => {
     })
 
     dispatch.count.timeout()
-    expect(store.getState().loading.models.count).toBe(0)
+    expect(store.getState().loading.models.count).toBe(false)
   })
 
   test('should block items if in blacklist', () => {
@@ -201,7 +201,7 @@ describe('loading', () => {
     })
 
     dispatch.count.timeout()
-    expect(store.getState().loading.models.count).toBe(0)
+    expect(store.getState().loading.models.count).toBe(false)
   })
 
   test('should throw if whitelist is not an array', () => {
@@ -255,7 +255,7 @@ describe('loading', () => {
     try {
       await dispatch.count.throwError()
     } catch (err) {
-      expect(store.getState().loading.global).toBe(0)
+      expect(store.getState().loading.global).toBe(false)
     }
   })
 

--- a/plugins/loading/test/loading-asNumber.test.js
+++ b/plugins/loading/test/loading-asNumber.test.js
@@ -1,0 +1,327 @@
+const delay = ms => new Promise(r => setTimeout(r, ms))
+
+describe('loading asNumbers', () => {
+  let count, init, dispatch, loadingPlugin
+
+  beforeEach(() => {
+    loadingPlugin = require('../src').default
+
+    const rm = require('../../../src')
+    init = rm.init
+    dispatch = rm.dispatch
+
+    count = {
+      state: 0,
+      reducers: {
+        addOne: s => s + 1
+      },
+      effects: {
+        async timeout() {
+          await delay(200)
+          this.addOne()
+        }
+      }
+    }
+  })
+
+  afterEach(() => {
+    jest.resetModules()
+  })
+
+  test('loading.global should be 0 for normal dispatched action', () => {
+    const store = init({
+      models: { count },
+      plugins: [loadingPlugin({ asNumber: true })]
+    })
+
+    dispatch.count.addOne()
+    expect(store.getState().loading.global).toBe(0)
+  })
+
+  test('loading.global should be 1 for a dispatched effect', () => {
+    const store = init({
+      models: { count },
+      plugins: [loadingPlugin({ asNumber: true })]
+    })
+
+    dispatch.count.timeout()
+    expect(store.getState().loading.global).toBe(1)
+  })
+
+  test('loading.global should be 2 for two dispatched effects', () => {
+    const store = init({
+      models: { count },
+      plugins: [loadingPlugin({ asNumber: true })]
+    })
+
+    dispatch.count.timeout()
+    dispatch.count.timeout()
+    expect(store.getState().loading.global).toBe(2)
+  })
+
+  test('should set loading.models[name] to 0', () => {
+    const {
+      init
+    } = require('../../../src')
+    const store = init({
+      models: { count },
+      plugins: [loadingPlugin({ asNumber: true })]
+    })
+
+    expect(store.getState().loading.models.count).toBe(0)
+  })
+
+  test('should change the loading.models to 1', () => {
+    const store = init({
+      models: { count },
+      plugins: [loadingPlugin({ asNumber: true })]
+    })
+
+    dispatch.count.timeout()
+    expect(store.getState().loading.models.count).toBe(1)
+  })
+
+  test('should change the loading.models to 2', () => {
+    const store = init({
+      models: { count },
+      plugins: [loadingPlugin({ asNumber: true })]
+    })
+
+    dispatch.count.timeout()
+    dispatch.count.timeout()
+    expect(store.getState().loading.models.count).toBe(2)
+  })
+
+  test('should set loading.effects[name] to object of effects', () => {
+    const store = init({
+      models: { count },
+      plugins: [loadingPlugin({ asNumber: true })]
+    })
+    expect(store.getState().loading.effects.count.timeout).toBe(0)
+  })
+
+  test('should change the loading.effects to 1', () => {
+    const store = init({
+      models: { count },
+      plugins: [loadingPlugin({ asNumber: true })]
+    })
+
+    dispatch.count.timeout()
+    expect(store.getState().loading.effects.count.timeout).toBe(1)
+  })
+
+  test('should change the loading.effects to 2', () => {
+    const store = init({
+      models: { count },
+      plugins: [loadingPlugin({ asNumber: true })]
+    })
+
+    dispatch.count.timeout()
+    dispatch.count.timeout()
+    expect(store.getState().loading.effects.count.timeout).toBe(2)
+  })
+
+  test('should capture all model and global loading for simultaneous effects', async () => {
+    count = {
+      state: 0,
+      effects: {
+        async timeout1() {
+          await delay(200)
+        },
+        async timeout2() {
+          await delay(200)
+        }
+      }
+    }
+    const store = init({
+      models: { count },
+      plugins: [loadingPlugin({ asNumber: true })]
+    })
+
+    const effect1 = dispatch.count.timeout1()
+    await delay(100)
+    const effect2 = dispatch.count.timeout2()
+
+    const ld = () => store.getState().loading
+    expect(ld().effects.count.timeout1).toBe(1)
+    expect(ld().effects.count.timeout2).toBe(1)
+    expect(ld().models.count).toBe(2)
+    expect(ld().global).toBe(2)
+
+    await effect1
+    expect(ld().effects.count.timeout1).toBe(0)
+    expect(ld().effects.count.timeout2).toBe(1)
+    expect(ld().models.count).toBe(1)
+    expect(ld().global).toBe(1)
+
+    await effect2
+    expect(ld().effects.count.timeout1).toBe(0)
+    expect(ld().effects.count.timeout2).toBe(0)
+    expect(ld().models.count).toBe(0)
+    expect(ld().global).toBe(0)
+  })
+
+  test('should configure the loading name to "foobar"', () => {
+    const store = init({
+      models: { count },
+      plugins: [loadingPlugin({ asNumber: true, name: 'foobar' })]
+    })
+
+    dispatch.count.addOne()
+    expect(store.getState().foobar.global).toBe(0)
+  })
+
+  test('should throw if loading name is not a string', () => {
+    const createStore = () => init({
+      models: { count },
+      plugins: [loadingPlugin({
+        asNumber: true,
+        name: 42
+      })]
+    })
+
+    expect(createStore).toThrow()
+  })
+
+  test('should block items if not in whitelist', () => {
+    const store = init({
+      models: { count },
+      plugins: [loadingPlugin({
+        asNumber: true,
+        whitelist: ['some/action'],
+      })]
+    })
+
+    dispatch.count.timeout()
+    expect(store.getState().loading.models.count).toBe(0)
+  })
+
+  test('should block items if in blacklist', () => {
+    const store = init({
+      models: { count },
+      plugins: [loadingPlugin({
+        asNumber: true,
+        blacklist: ['count/timeout'],
+      })]
+    })
+
+    dispatch.count.timeout()
+    expect(store.getState().loading.models.count).toBe(0)
+  })
+
+  test('should throw if whitelist is not an array', () => {
+    const createStore = () => init({
+      models: { count },
+      plugins: [loadingPlugin({
+        asNumber: true,
+        whitelist: 'some/action',
+      })]
+    })
+
+    expect(createStore).toThrow()
+  })
+
+  test('should throw if blacklist is not an array', () => {
+    const createStore = () => init({
+      models: { count },
+      plugins: [loadingPlugin({
+        asNumber: true,
+        blacklist: 'some/action',
+      })]
+    })
+
+    expect(createStore).toThrow()
+  })
+
+  test('should throw if contains both a whitelist & blacklist', () => {
+    const createStore = () => init({
+      models: { count },
+      plugins: [loadingPlugin({
+        asNumber: true,
+        whitelist: ['some/action'],
+        blacklist: ['some/action'],
+      })]
+    })
+
+    expect(createStore).toThrow()
+  })
+
+  test('should handle "hide" if effect throws', async () => {
+    count = {
+      state: 0,
+      effects: {
+        throwError() {
+          throw new Error('effect error')
+        }
+      }
+    }
+    const store = init({
+      models: { count },
+      plugins: [loadingPlugin({ asNumber: true })]
+    })
+
+    try {
+      await dispatch.count.throwError()
+    } catch (err) {
+      expect(store.getState().loading.global).toBe(0)
+    }
+  })
+
+  test('should trigger three actions', async () => {
+    let actions = []
+    const store = init({
+      models: { count },
+      plugins: [loadingPlugin({ asNumber: true })],
+      redux: {
+        middlewares: [() => () => action => {
+          actions.push(action.type)
+        }]
+      }
+    })
+
+    await dispatch.count.timeout()
+    expect(actions).toEqual(['loading/show', 'count/addOne', 'loading/hide'])
+  })
+
+  test('should allow the propagation of the error', async () => {
+    count = {
+        state: 0,
+        effects: {
+            throwError() {
+                throw new Error('effect error')
+            }
+        }
+    }
+    const store = init({
+        models: { count },
+        plugins: [loadingPlugin({ asNumber: true })]
+    })
+
+    try {
+        await dispatch.count.throwError()
+    } catch (err) {
+        expect(err.message).toBe('effect error')
+    }
+  })
+
+  test('should allow the propagation of the meta object', async () => {
+    count = {
+      state: 0,
+      effects: {
+        doSomething(payload, state, meta) {
+          expect(meta).toEqual({ metaProp: 1 })
+        }
+      }
+    }
+    const store = init({
+      models: { count },
+      plugins: [loadingPlugin({ asNumber: true })]
+    })
+
+    try {
+      await dispatch.count.doSomething(null, { metaProp: 1 })
+    } catch (err) {
+      throw err
+    }
+  })
+})

--- a/plugins/loading/test/loading.test.js
+++ b/plugins/loading/test/loading.test.js
@@ -121,7 +121,7 @@ describe('loading', () => {
     expect(store.getState().loading.effects.count.timeout).toBe(2)
   })
 
-  test('should capture all global loading for simultaneous diffrent effects', () => {
+  test('should capture all model and global loading for simultaneous effects', async () => {
     count = {
       state: 0,
       effects: {
@@ -138,21 +138,37 @@ describe('loading', () => {
       plugins: [loadingPlugin()]
     })
 
-    dispatch.count.timeout1()
-    dispatch.count.timeout2()
-    expect(store.getState().loading.effects.count.timeout1).toBe(1)
-    expect(store.getState().loading.effects.count.timeout2).toBe(1)
-    expect(store.getState().loading.global).toBe(2)
+    const effect1 = dispatch.count.timeout1()
+    await delay(100)
+    const effect2 = dispatch.count.timeout2()
+
+    const ld = () => store.getState().loading
+    expect(ld().effects.count.timeout1).toBe(1)
+    expect(ld().effects.count.timeout2).toBe(1)
+    expect(ld().models.count).toBe(2)
+    expect(ld().global).toBe(2)
+
+    await effect1
+    expect(ld().effects.count.timeout1).toBe(0)
+    expect(ld().effects.count.timeout2).toBe(1)
+    expect(ld().models.count).toBe(1)
+    expect(ld().global).toBe(1)
+
+    await effect2
+    expect(ld().effects.count.timeout1).toBe(0)
+    expect(ld().effects.count.timeout2).toBe(0)
+    expect(ld().models.count).toBe(0)
+    expect(ld().global).toBe(0)
   })
 
-  test('should configure the loading name to "load"', () => {
+  test('should configure the loading name to "foobar"', () => {
     const store = init({
       models: { count },
-      plugins: [loadingPlugin({ name: 'load' })]
+      plugins: [loadingPlugin({ name: 'foobar' })]
     })
 
     dispatch.count.addOne()
-    expect(store.getState().load.global).toBe(0)
+    expect(store.getState().foobar.global).toBe(0)
   })
 
   test('should throw if loading name is not a string', () => {

--- a/plugins/loading/test/loading.test.js
+++ b/plugins/loading/test/loading.test.js
@@ -1,185 +1,216 @@
-beforeEach(() => {
-  jest.resetModules()
-})
-
-const count = {
-  state: 0,
-  reducers: {
-    addOne: s => s + 1
-  },
-  effects: {
-    async timeout() {
-      await setTimeout(() => {}, 1000)
-      this.addOne()
-    }
-  }
-}
+const delay = ms => new Promise(r => setTimeout(r, ms))
 
 describe('loading', () => {
-  test('loading.global should be false for normal dispatched action', () => {
-    const {
-      init, dispatch
-    } = require('../../../src')
-    const loadingPlugin = require('../src').default
+  let count, init, dispatch, loadingPlugin
+
+  beforeEach(() => {
+    loadingPlugin = require('../src').default
+
+    const rm = require('../../../src')
+    init = rm.init
+    dispatch = rm.dispatch
+
+    count = {
+      state: 0,
+      reducers: {
+        addOne: s => s + 1
+      },
+      effects: {
+        async timeout() {
+          await delay(200)
+          this.addOne()
+        }
+      }
+    }
+  })
+
+  afterEach(() => {
+    jest.resetModules()
+  })
+
+  test('loading.global should be 0 for normal dispatched action', () => {
     const store = init({
       models: { count },
       plugins: [loadingPlugin()]
     })
+
     dispatch.count.addOne()
-    expect(store.getState().loading.global).toBe(false)
+    expect(store.getState().loading.global).toBe(0)
   })
 
-  test('loading.global should be true for dispatched effect', () => {
-    const {
-      init, dispatch
-    } = require('../../../src')
-    const loadingPlugin = require('../src').default
+  test('loading.global should be 1 for a dispatched effect', () => {
     const store = init({
       models: { count },
       plugins: [loadingPlugin()]
     })
+
     dispatch.count.timeout()
-    expect(store.getState().loading.global).toBe(true)
+    expect(store.getState().loading.global).toBe(1)
   })
 
-  test('should set loading.models[name] to false', () => {
+  test('loading.global should be 2 for two dispatched effects', () => {
+    const store = init({
+      models: { count },
+      plugins: [loadingPlugin()]
+    })
+
+    dispatch.count.timeout()
+    dispatch.count.timeout()
+    expect(store.getState().loading.global).toBe(2)
+  })
+
+  test('should set loading.models[name] to 0', () => {
     const {
       init
     } = require('../../../src')
-    const loadingPlugin = require('../src').default
     const store = init({
       models: { count },
       plugins: [loadingPlugin()]
     })
-    expect(store.getState().loading.models.count).toBe(false)
+
+    expect(store.getState().loading.models.count).toBe(0)
   })
 
-  test('should change the loading.models', () => {
-    const {
-      init, dispatch
-    } = require('../../../src')
-    const loadingPlugin = require('../src').default
+  test('should change the loading.models to 1', () => {
     const store = init({
       models: { count },
       plugins: [loadingPlugin()]
     })
+
     dispatch.count.timeout()
-    expect(store.getState().loading.models.count).toBe(true)
+    expect(store.getState().loading.models.count).toBe(1)
+  })
+
+  test('should change the loading.models to 2', () => {
+    const store = init({
+      models: { count },
+      plugins: [loadingPlugin()]
+    })
+
+    dispatch.count.timeout()
+    dispatch.count.timeout()
+    expect(store.getState().loading.models.count).toBe(2)
   })
 
   test('should set loading.effects[name] to object of effects', () => {
-    const {
-      init
-    } = require('../../../src')
-    const loadingPlugin = require('../src').default
     const store = init({
       models: { count },
       plugins: [loadingPlugin()]
     })
-    expect(store.getState().loading.effects.count.timeout).toBe(false)
+    expect(store.getState().loading.effects.count.timeout).toBe(0)
   })
 
-  test('should change the loading.effects', () => {
-    const {
-      init, dispatch
-    } = require('../../../src')
-    const loadingPlugin = require('../src').default
+  test('should change the loading.effects to 1', () => {
     const store = init({
       models: { count },
       plugins: [loadingPlugin()]
     })
+
     dispatch.count.timeout()
-    expect(store.getState().loading.effects.count.timeout).toBe(true)
+    expect(store.getState().loading.effects.count.timeout).toBe(1)
   })
 
-  test('should configure the loading name', () => {
-    const {
-      init, dispatch
-    } = require('../../../src')
-    const loadingPlugin = require('../src').default
+  test('should change the loading.effects to 2', () => {
+    const store = init({
+      models: { count },
+      plugins: [loadingPlugin()]
+    })
+
+    dispatch.count.timeout()
+    dispatch.count.timeout()
+    expect(store.getState().loading.effects.count.timeout).toBe(2)
+  })
+
+  test('should capture all global loading for simultaneous diffrent effects', () => {
+    count = {
+      state: 0,
+      effects: {
+        async timeout1() {
+          await delay(200)
+        },
+        async timeout2() {
+          await delay(200)
+        }
+      }
+    }
+    const store = init({
+      models: { count },
+      plugins: [loadingPlugin()]
+    })
+
+    dispatch.count.timeout1()
+    dispatch.count.timeout2()
+    expect(store.getState().loading.effects.count.timeout1).toBe(1)
+    expect(store.getState().loading.effects.count.timeout2).toBe(1)
+    expect(store.getState().loading.global).toBe(2)
+  })
+
+  test('should configure the loading name to "load"', () => {
     const store = init({
       models: { count },
       plugins: [loadingPlugin({ name: 'load' })]
     })
+
     dispatch.count.addOne()
-    expect(store.getState().load.global).toBe(false)
+    expect(store.getState().load.global).toBe(0)
   })
 
   test('should throw if loading name is not a string', () => {
-    const {
-      init, dispatch
-    } = require('../../../src')
-    const loadingPlugin = require('../src').default
     const createStore = () => init({
       models: { count },
       plugins: [loadingPlugin({ name: 42 })]
     })
+
     expect(createStore).toThrow()
   })
 
   test('should block items if not in whitelist', () => {
-    const {
-      init, dispatch
-    } = require('../../../src')
-    const loadingPlugin = require('../src').default
     const store = init({
       models: { count },
       plugins: [loadingPlugin({
         whitelist: ['some/action'],
       })]
     })
+
     dispatch.count.timeout()
-    expect(store.getState().loading.models.count).toBe(false)
+    expect(store.getState().loading.models.count).toBe(0)
   })
 
   test('should block items if in blacklist', () => {
-    const {
-      init, dispatch
-    } = require('../../../src')
-    const loadingPlugin = require('../src').default
     const store = init({
       models: { count },
       plugins: [loadingPlugin({
         blacklist: ['count/timeout'],
       })]
     })
+
     dispatch.count.timeout()
-    expect(store.getState().loading.models.count).toBe(false)
+    expect(store.getState().loading.models.count).toBe(0)
   })
 
   test('should throw if whitelist is not an array', () => {
-    const {
-      init, dispatch
-    } = require('../../../src')
-    const loadingPlugin = require('../src').default
     const createStore = () => init({
       models: { count },
       plugins: [loadingPlugin({
         whitelist: 'some/action',
       })]
     })
+
     expect(createStore).toThrow()
   })
 
   test('should throw if blacklist is not an array', () => {
-    const {
-      init, dispatch
-    } = require('../../../src')
-    const loadingPlugin = require('../src').default
     const createStore = () => init({
       models: { count },
       plugins: [loadingPlugin({
         blacklist: 'some/action',
       })]
     })
+
     expect(createStore).toThrow()
   })
 
   test('should throw if contains both a whitelist & blacklist', () => {
-    const {
-      init, dispatch
-    } = require('../../../src')
-    const loadingPlugin = require('../src').default
     const createStore = () => init({
       models: { count },
       plugins: [loadingPlugin({
@@ -187,15 +218,12 @@ describe('loading', () => {
         blacklist: ['some/action'],
       })]
     })
+
     expect(createStore).toThrow()
   })
 
   test('should handle "hide" if effect throws', async () => {
-    const {
-      init, dispatch
-    } = require('../../../src')
-    const loadingPlugin = require('../src').default
-    const count = {
+    count = {
       state: 0,
       effects: {
         throwError() {
@@ -207,21 +235,16 @@ describe('loading', () => {
       models: { count },
       plugins: [loadingPlugin()]
     })
+
     try {
       await dispatch.count.throwError()
     } catch (err) {
-      expect(store.getState().loading.global).toBe(false)
+      expect(store.getState().loading.global).toBe(0)
     }
   })
 
   test('should trigger three actions', async () => {
-    const {
-      init, dispatch
-    } = require('../../../src')
-    const loadingPlugin = require('../src').default
-
     let actions = []
-
     const store = init({
       models: { count },
       plugins: [loadingPlugin()],
@@ -233,16 +256,11 @@ describe('loading', () => {
     })
 
     await dispatch.count.timeout()
-
     expect(actions).toEqual(['loading/show', 'count/addOne', 'loading/hide'])
   })
 
   test('should allow the propagation of the error', async () => {
-    const {
-        init, dispatch
-    } = require('../../../src')
-    const loadingPlugin = require('../src').default
-    const count = {
+    count = {
         state: 0,
         effects: {
             throwError() {
@@ -254,6 +272,7 @@ describe('loading', () => {
         models: { count },
         plugins: [loadingPlugin()]
     })
+
     try {
         await dispatch.count.throwError()
     } catch (err) {
@@ -262,11 +281,7 @@ describe('loading', () => {
   })
 
   test('should allow the propagation of the meta object', async () => {
-    const {
-      init, dispatch
-    } = require('../../../src')
-    const loadingPlugin = require('../src').default
-    const count = {
+    count = {
       state: 0,
       effects: {
         doSomething(payload, state, meta) {


### PR DESCRIPTION
I was having problems with the loading module resolving a pending effect too early, because out of a batch of dispatched effects, the first completed one set the loading state to `false`.

This implements an integer counter instead of a boolean value.

Also cleaned up the plugin tests slightly.