### PR TITLE
add example with vuejs-redux

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Rematch is Redux best practices without the boilerplate. No more action types, a
 * Recipes
   * [Devtools](./docs/recipes/devtools.md)
   * [React](./docs/recipes/react.md)
+  * [Vue](./docs/recipes/vue.md)
 * Plugins
   * [Subscriptions](./plugins/subscriptions/README.md)
   * [Selectors](./plugins/select/README.md)

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Dispatch can be called directly, or with the `dispatch[model][action](payload)` 
 
 ## Examples
 
-- Count: [JS](https://codepen.io/Sh_McK/pen/BJMmXx?editors=1010) | [React](https://codesandbox.io/s/3kpyz2nnz6) | [Vue](https://codesandbox.io/s/6j1vvnl20k) | [Angular](https://stackblitz.com/edit/rematch-angular-5-count) | [Vuejs-Redux](https://codesandbox.io/s/n3373olqo0)
+- Count: [JS](https://codepen.io/Sh_McK/pen/BJMmXx?editors=1010) | [React](https://codesandbox.io/s/3kpyz2nnz6) | [Vue](https://codesandbox.io/s/n3373olqo0) | [Angular](https://stackblitz.com/edit/rematch-angular-5-count)
 - Todos: [React](https://codesandbox.io/s/92mk9n6vww)
 
 ```jsx

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Dispatch can be called directly, or with the `dispatch[model][action](payload)` 
 
 ## Examples
 
-- Count: [JS](https://codepen.io/Sh_McK/pen/BJMmXx?editors=1010) | [React](https://codesandbox.io/s/3kpyz2nnz6) | [Vue](https://codesandbox.io/s/6j1vvnl20k) | [Angular](https://stackblitz.com/edit/rematch-angular-5-count)
+- Count: [JS](https://codepen.io/Sh_McK/pen/BJMmXx?editors=1010) | [React](https://codesandbox.io/s/3kpyz2nnz6) | [Vue](https://codesandbox.io/s/6j1vvnl20k) | [Angular](https://stackblitz.com/edit/rematch-angular-5-count) | [Vuejs-Redux](https://codesandbox.io/s/n3373olqo0)
 - Todos: [React](https://codesandbox.io/s/92mk9n6vww)
 
 ```jsx

--- a/docs/recipes/vue.md
+++ b/docs/recipes/vue.md
@@ -1,6 +1,6 @@
 # Vue
 
-You can use rematch with Vue the same way you have been using it with Vue, Redux and vuejs-redux.
+You can use rematch with Vue the same way you have been using it with Vue, Redux and [vuejs-redux](https://github.com/titouancreach/vuejs-redux).
 Instead of high order component, we create a container component that is responsible to connect the child component.
 
 See an example below:

--- a/docs/recipes/vue.md
+++ b/docs/recipes/vue.md
@@ -24,11 +24,11 @@ CounterContainer.vue
   import Counter from './Counter.vue';
 
   // Every provider components need the store. To connect the components to the same instance of
-  // the store, it's recommanded to export the instance of the store in another file and import it
+  // the store, it's recommended to export the instance of the store in another file and import it
   // in the container components.
   const store = init();
 
-  // It's recommanded to declare mapState and mapDispatch outside the component (as pure function)
+  // It's recommended to declare mapState and mapDispatch outside the component (as pure function)
   // for easier tests.
   const mapState = state => ({
     count: state.count,

--- a/docs/recipes/vue.md
+++ b/docs/recipes/vue.md
@@ -1,0 +1,68 @@
+# Vue
+
+You can use rematch with Vue the same way you have been using it with Vue, Redux and vuejs-redux.
+Instead of high order component, we create a container component that is responsible to connect the child component.
+
+See an example below:
+
+CounterContainer.vue
+```vue
+<template>
+  <Provider
+    :store="store" 
+    :mapDispatch="mapDispatch" 
+    :mapState="mapState">
+    <template slot-scope="{ count, increment }">
+      <Counter :count="count" :increment="increment"/>
+    </template>
+  </Provider>
+</template>
+
+<script>
+  import Provider from 'vuejs-redux';
+  import { init } from '@rematch/core';
+  import Counter from './Counter.vue';
+
+  // Every provider components need the store. To connect the components to the same instance of
+  // the store, it's recommanded to export the instance of the store in another file and import it
+  // in the container components.
+  const store = init();
+
+  // It's recommanded to declare mapState and mapDispatch outside the component (as pure function)
+  // for easier tests.
+  const mapState = state => ({
+    count: state.count,
+  });
+
+  const mapDispatch = dispatch => ({
+    increment: () => dispatch.count.increment(),
+  })
+
+  export default {
+    data: () => ({
+      store // make it accessible in the template
+    }),
+
+    methods: {
+      mapDispatch,
+      mapState
+    }
+  }
+</script>
+```
+
+Counter.vue
+```vue
+<template>
+  <div>
+    <h2>Count: {{ count }}</h2>
+    <button @click="increment" />
+  </div>
+</template>
+
+<script>
+export default {
+  props: ['count', 'increment']
+};
+</script>
+```


### PR DESCRIPTION
Hi,

I am the creator of [vuejs-redux](https://github.com/titouancreach/vuejs-redux). Vue/Redux binding that use scoped slots (native and documented feature of Vue). I forked the and edited the codesandbox to use my plugin and I added it in the readme. I'm not sure of the best integration in it.