### PR TITLE
Change redux example in Purpose docs to use mapDispatchToProps shorthand

### DIFF
--- a/docs/purpose.md
+++ b/docs/purpose.md
@@ -102,13 +102,7 @@ const mapStateToProps = (state) => ({
   count: state.count,
 })
 
-const mapDispatchToProps = (dispatch) => ({
-  countUpBy(payload) {
-    dispatch(countUpBy(payload))
-  },
-})
-
-connect(mapStateToProps, mapDispatchToProps)(Component)
+connect(mapStateToProps, { countUpBy })(Component)
 ```
 
 ### Scoreboard


### PR DESCRIPTION
From redux api docs: https://github.com/reactjs/react-redux/blob/master/docs/api.md#inject-todos-and-specific-action-creators-addtodo-and-deletetodo-with-shorthand-syntax

Closes #253.