### PR TITLE
Add action creators to redux-devtools

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -6,6 +6,7 @@ import corePlugins from './plugins'
 import { initReducers } from './redux/reducers'
 import { initStore } from './redux/store'
 import buildPlugins from './utils/buildPlugins'
+import getActionCreators from './utils/getActionCreators';
 import getExposed from './utils/getExposed'
 import getModels from './utils/getModels'
 import isObject from './utils/isObject'
@@ -13,7 +14,12 @@ import mergeConfig from './utils/mergeConfig'
 import validate from './utils/validate'
 
 const init = (config: Config | undefined = {}): Store<any> => {
-  config.redux = config.redux || {}
+  config = {
+    ...config,
+    models: config.models || {},
+    redux: config.redux || {},
+  };
+
   if (process.env.NODE_ENV !== 'production') {
     validate([
       [
@@ -48,7 +54,20 @@ const init = (config: Config | undefined = {}): Store<any> => {
       ],
     ])
   }
-  config.models = config.models || {}
+
+  config = {
+    ...config,
+    redux: {
+      ...config.redux,
+      devtoolOptions: {
+        // We use our devtool options before spreading the user's
+        // configured devtool options so that they can override ours
+        actionCreators: getActionCreators(config.models),
+        ...config.redux.devtoolOptions || {},
+      }
+    }
+  };
+
   const mergedConfig = mergeConfig(config)
   const pluginConfigs = corePlugins.concat(mergedConfig.plugins || [])
   const exposed: Exposed = getExposed(pluginConfigs)

--- a/src/utils/getActionCreators.ts
+++ b/src/utils/getActionCreators.ts
@@ -1,0 +1,25 @@
+import { Models } from '../../typings/rematch';
+import isListener from './isListener';
+
+export default (models: Models): { [key: string]: Function } =>
+    Object.keys(models).reduce((actionCreators, modelName) => {
+        const { reducers = {} } = models[modelName];
+
+        Object.keys(reducers)
+            .filter(reducerName => !isListener(reducerName))
+            .forEach(reducerName => {
+                const type = `${modelName}/${reducerName}`;
+
+                // We have to dynamically create the function like this,
+                // so that the argument name is not minified.
+                const createCreator = new Function('type', `
+                    return function(payload) {
+                        return { type, payload };
+                    }
+                `);
+
+                actionCreators[type] = createCreator(type);
+            });
+
+        return actionCreators;
+    }, {});


### PR DESCRIPTION
This PR adds action creators from each model to the Redux DevTools like so;

![Redux DevTools](https://user-images.githubusercontent.com/1843197/37316491-5b1ce856-2657-11e8-87b6-85c3441682a7.png)

The action creators are generated from the reducers on the model;

```JavaScript
init({
    models: {
        counter: {
            state: 0,
            reducers: {
                increment: (state, delta = 1) => state + delta,
                decrement: (state, delta = -1) => state - delta,
            }
        }
    }
});
```

This PR makes it so that we add an `actionCreators` property to `config.redux.devtoolOptions` (containing the action creators) if the `actionCreators` property isn't already defined.

Marked this as WIP as I'm looking for some feedback on the changes :smile:

