### PR TITLE
Update pluginsApi.md

### DIFF
--- a/docs/pluginsApi.md
+++ b/docs/pluginsApi.md
@@ -9,7 +9,6 @@ There are plenty of examples to base your next plugin on. After all, in Rematch,
 
 - [config](#config)
 - [expose](#expose)
-- [models](#models)
 - [init](#init)
   - [onModel](#onmodel)
   - [middleware](#middleware)
@@ -48,20 +47,6 @@ const selectors = {
 ```
 
 See "dispatch", "select" as an example.
-
-## models
-
-```js
-{
-  models: {
-    [string]: model
-  }
-}
-```
-
-Use this when adding models to the plugin.
-
-See "loading" as an example.
 
 ## init
 


### PR DESCRIPTION
 `models` is no longer part of the top level plugin API. We now handle it in `config`:  

`{ config: { models: ... } }`

Loading plugin:
https://github.com/rematch/rematch/blob/master/plugins/loading/src/index.ts#L81-L85

Updated plugin:
https://github.com/rematch/rematch/blob/master/plugins/updated/src/index.ts#L23-L27