### PR TITLE
Add support for Immutable JS in selector plugin.

### DIFF
--- a/plugins/select/README.md
+++ b/plugins/select/README.md
@@ -79,7 +79,7 @@ The `selectorPlugin()` method will accept a configuration object with the follow
 
 An option that allows the user to specify how the state will be sliced before being passed to the selectors.
 The function takes the `rootState` as the first parameter and the `model` corresponding to the selector as the
-second parameter.  It should return the desited state slice required by the selector.
+second parameter.  It should return the desired state slice required by the selector.
 
 The default is to return the slice of the state that corresponds to the owning model's name,
 but this assumes the store is a Javascript object. Most of the time the default should be used.

--- a/plugins/select/README.md
+++ b/plugins/select/README.md
@@ -42,7 +42,8 @@ Selectors are read-only snippets of state.
 }
 ```
 
-> note: selector state does not refer to the complete state, only the state within the model
+> note: By default, the selector state does not refer to the complete state, only the state within the model.
+To change this behavior, use the sliceState configuration option described below.
 
 Selectors can be called anywhere within your app.
 
@@ -67,3 +68,41 @@ import { createSelector } from 'reselect'
   }
 }
 ```
+
+### Configuration Options
+
+The `selectorPlugin()` method will accept a configuration object with the following property.
+
+#### sliceState:
+
+`sliceState: (rootState, model) => any`
+
+An option that allows the user to specify how the state will be sliced before being passed to the selectors.
+The function takes the `rootState` as the first parameter and the `model` corresponding to the selector as the
+second parameter.  It should return the desited state slice required by the selector.
+
+The default is to return the slice of the state that corresponds to the owning model's name,
+but this assumes the store is a Javascript object. Most of the time the default should be used.
+However, there are some cases where one may want to specify the `sliceState` function.
+
+##### Example 1 - Use the root state in selectors as opposed to a slice:
+
+This can easily be accomplished by returning the `rootState` in the `getState` config:
+
+```js
+const select = selectorsPlugin({ sliceState: rootState => rootState });
+```
+
+Now the `state` parameter that is passed to all of the selectors will be the root state.
+
+##### Example 2 - Use an Immutable JS object as the store
+
+If you are using an [Immutable.js](https://facebook.github.io/immutable-js/) Map as your store, you will need to slice
+the state using [Map.get()](http://facebook.github.io/immutable-js/docs/#/Map/get):
+
+```js
+const select = selectorsPlugin({ sliceState: (rootState, model) => rootState.get(model.name) })
+```
+
+Now you can use an [Immutable.js Map](http://facebook.github.io/immutable-js/docs/#/Map) as your store and access the
+appropriate slice of the state in each of your selectors.

--- a/plugins/select/package-lock.json
+++ b/plugins/select/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rematch/select",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -140,6 +140,26 @@
         "for-in": "1.0.2"
       }
     },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
@@ -158,6 +178,22 @@
       "requires": {
         "is-glob": "2.0.1"
       }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -259,9 +295,9 @@
       "dev": true
     },
     "lodash-es": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.5.tgz",
-      "integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw==",
+      "version": "4.17.8",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.8.tgz",
+      "integrity": "sha512-I9mjAxengFAleSThFhhAhvba6fsO0hunb9/0sQ6qQihSZsJRBofv2rYH58WXaOb/O++eUmYpCLywSQ22GfU+sA==",
       "dev": true
     },
     "loose-envify": {
@@ -274,9 +310,9 @@
       }
     },
     "magic-string": {
-      "version": "0.22.4",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.4.tgz",
-      "integrity": "sha512-kxBL06p6iO2qPBHsqGK2b3cRwiRGpnmSuVWNhwHcMX7qJOUr1HvricYP1LZOCdkQBUp0jiWg2d6WJwR3vYgByw==",
+      "version": "0.22.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+      "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
       "dev": true,
       "requires": {
         "vlq": "0.2.3"
@@ -331,6 +367,15 @@
         "is-extendable": "0.1.1"
       }
     },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
@@ -342,6 +387,12 @@
         "is-extglob": "1.0.0",
         "is-glob": "2.0.1"
       }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.5",
@@ -403,7 +454,7 @@
       "dev": true,
       "requires": {
         "lodash": "4.17.5",
-        "lodash-es": "4.17.5",
+        "lodash-es": "4.17.8",
         "loose-envify": "1.3.1",
         "symbol-observable": "1.2.0"
       }
@@ -436,12 +487,21 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.6.0.tgz",
+      "integrity": "sha512-mw7JQNu5ExIkcw4LPih0owX/TZXjD/ZUF/ZQ/pDnkw3ZKhDcZZw5klmBlj6gVMwjQ3Pz5Jgu7F3d0jcDVuEWdw==",
       "dev": true,
       "requires": {
         "path-parse": "1.0.5"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
       }
     },
     "rollup": {
@@ -457,8 +517,8 @@
       "dev": true,
       "requires": {
         "estree-walker": "0.5.1",
-        "magic-string": "0.22.4",
-        "resolve": "1.5.0",
+        "magic-string": "0.22.5",
+        "resolve": "1.6.0",
         "rollup-pluginutils": "2.0.1"
       }
     },
@@ -468,7 +528,7 @@
       "integrity": "sha512-pK9mTd/FNrhtBxcTBXoh0YOwRIShV0gGhv9qvUtNcXHxIMRZMXqfiZKVBmCRGp8/2DJRy62z2JUE7/5tP6WxOQ==",
       "dev": true,
       "requires": {
-        "magic-string": "0.22.4",
+        "magic-string": "0.22.5",
         "minimatch": "3.0.4",
         "rollup-pluginutils": "2.0.1"
       }
@@ -526,6 +586,12 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
       "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     }
   }

--- a/plugins/select/package.json
+++ b/plugins/select/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@rematch/core": "^0.3.0",
+    "rimraf": "^2.6.2",
     "rollup": "^0.56.5",
     "rollup-plugin-commonjs": "^9.1.0",
     "rollup-plugin-replace": "^2.0.0",

--- a/plugins/select/package.json
+++ b/plugins/select/package.json
@@ -13,7 +13,10 @@
     "url": "https://github.com/rematch/rematch/issues"
   },
   "license": "ISC",
-  "author": "Blair Bodnar <blairbodnar@gmail.com> (https://github.com/blairbodnar)",
+  "authors": [
+    "Blair Bodnar <blairbodnar@gmail.com> (https://github.com/blairbodnar)",
+    "Tom Aranda (https://github.com/taranda)"
+  ],
   "files": [
     "dist"
   ],

--- a/plugins/select/package.json
+++ b/plugins/select/package.json
@@ -15,7 +15,7 @@
   "license": "ISC",
   "authors": [
     "Blair Bodnar <blairbodnar@gmail.com> (https://github.com/blairbodnar)",
-    "Tom Aranda (https://github.com/taranda)"
+    "Tom Aranda <tga@arandacybersolutions.com> (https://github.com/taranda)"
   ],
   "files": [
     "dist"

--- a/plugins/select/package.json
+++ b/plugins/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rematch/select",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Selectors plugin for Rematch",
   "keywords": [
     "plugin",

--- a/plugins/select/src/index.ts
+++ b/plugins/select/src/index.ts
@@ -11,28 +11,24 @@ const selectPlugin = ({
 }: selectConfig = {}): PluginCreator => ({
   expose: { select },
   init: ({ validate }) => {
-    if (process.env.NODE_ENV !== 'production') {
-      validate([
-       [
-          typeof sliceState !== 'function',
-          `The selectPlugin's getState config must be a function. Instead got type ${typeof sliceState}.`,
-        ],
-      ])
-    }
+    validate([
+     [
+        typeof sliceState !== 'function',
+        `The selectPlugin's getState config must be a function. Instead got type ${typeof sliceState}.`,
+      ],
+    ])
 
     return {
       onModel(model: Model) {
         select[model.name] = {}
 
         Object.keys(model.selectors || {}).forEach((selectorName: string) => {
-          if (process.env.NODE_ENV !== 'production') {
-            validate([
-              [
-                typeof model.selectors[selectorName] !== 'function',
-                `Selector (${model.name}/${selectorName}) must be a function`,
-              ],
-            ])
-          }
+          validate([
+            [
+              typeof model.selectors[selectorName] !== 'function',
+              `Selector (${model.name}/${selectorName}) must be a function`,
+            ],
+          ])
           select[model.name][selectorName] = (state: any, ...args) =>
             model.selectors[selectorName](
               sliceState(state, model),

--- a/plugins/select/src/index.ts
+++ b/plugins/select/src/index.ts
@@ -11,25 +11,28 @@ const selectPlugin = ({
 }: selectConfig = {}): PluginCreator => ({
   expose: { select },
   init: ({ validate }) => {
-    validate([
-      [
-        typeof sliceState !== 'function',
-        `The selectPlugin's getState config must be a function. Instead got type ${typeof sliceState}.`,
-      ]
-    ]);
+    if (process.env.NODE_ENV !== 'production') {
+      validate([
+       [
+          typeof sliceState !== 'function',
+          `The selectPlugin's getState config must be a function. Instead got type ${typeof sliceState}.`,
+        ],
+      ])
+    }
 
     return {
       onModel(model: Model) {
         select[model.name] = {}
 
         Object.keys(model.selectors || {}).forEach((selectorName: string) => {
-          validate([
-            [
-              typeof model.selectors[selectorName] !== 'function',
-              `Selector (${model.name}/${selectorName}) must be a function`,
-            ],
-
-          ])
+          if (process.env.NODE_ENV !== 'production') {
+            validate([
+              [
+                typeof model.selectors[selectorName] !== 'function',
+                `Selector (${model.name}/${selectorName}) must be a function`,
+              ],
+            ])
+          }
           select[model.name][selectorName] = (state: any, ...args) =>
             model.selectors[selectorName](
               sliceState(state, model),

--- a/plugins/select/test/select.test.js
+++ b/plugins/select/test/select.test.js
@@ -196,6 +196,49 @@ describe('select:', () => {
       const result = outsideSelector(state)
       expect(result).toBe(27)
     })
+
+
+  })
+
+  describe('sliceState config: ', () => {
+    test('should throw if sliceState config is not a function', () => {
+      const selectPlugin = require('../src').default
+      const { init } = require('../../../src')
+
+      const start = () => {
+        init({ plugins: [ selectPlugin({ sliceState: 'error' }) ] });
+      }
+
+      expect(start).toThrow();
+    })
+
+    it('should allow access to the global state with a property configured sliceState method', () => {
+      const selectPlugin = require('../src').default
+      const { select } = require('../src')
+      const { init } = require('../../../src')
+
+      const countA = {
+        state: 2,
+        selectors: {
+          double: state => state.countB * 2,
+        }
+      }
+      const countB = {
+        state: 10,
+        selectors: {
+          double: state => state.countA * 2
+        }
+      }
+
+      const store = init({
+        models: { countA, countB },
+        plugins: [selectPlugin({ sliceState: (rootState) => rootState })]
+      })
+
+      const state = store.getState()
+      const result = select.countB.double(state)
+      expect(result).toBe(4)
+    })
   })
 })
 


### PR DESCRIPTION
This PR allows the `select` plugin to be compatible with an Immutable JS store. As a side effect, it also allows the user to pass the root state to the selectors if desired.

This PR adds a config option to the `select` plugin allowing the user to specify how to slice the root state before being passed to the selectors  The default preserves current functionality so this change is complete backward compatible.  However, by opening up this config, a user can configure this plugin to support Immutable JS or another type of store.

This PR partially addresses Issue #270 and Issue #302.