### PR TITLE
Add stateSlice method to react-navigation plugin config.

### DIFF
--- a/plugins/react-navigation/package-lock.json
+++ b/plugins/react-navigation/package-lock.json
@@ -13,6 +13,12 @@
         "redux": "3.7.2"
       }
     },
+    "@types/react": {
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.1.0.tgz",
+      "integrity": "sha512-gXrB20mWBLrYGtkdf5fA6wL3FEXpY2Nz8OOgVn1qonp66JE4mqFXUigKD8CVDofQu+EsSy8G4UFRJAshFWMOvA==",
+      "dev": true
+    },
     "arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",

--- a/plugins/react-navigation/package.json
+++ b/plugins/react-navigation/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@rematch/core": "^0.1.6",
+    "@types/react": "^16.1.0",
     "react": "^16.0.0",
     "react-navigation": "^1.0.0",
     "react-redux": "^5.0.6",

--- a/plugins/react-navigation/src/Navigator.tsx
+++ b/plugins/react-navigation/src/Navigator.tsx
@@ -8,9 +8,9 @@ type Props = {
   nav: any,
 }
 
-export default (Routes, addListener) => {
+export default (Routes, addListener, sliceState) => {
   class Navigator extends React.Component<Props> {
-    private render() {
+    render() {
       return (
         <Routes navigation={addNavigationHelpers({
           addListener,
@@ -22,7 +22,7 @@ export default (Routes, addListener) => {
   }
 
   const mapToProps = (state, props) => ({
-    nav: state.nav,
+    nav: sliceState(state),
   })
 
   return connect(mapToProps)(Navigator)

--- a/plugins/react-navigation/src/index.ts
+++ b/plugins/react-navigation/src/index.ts
@@ -3,18 +3,21 @@ import { NavigationActions } from 'react-navigation'
 import createNavigator from './Navigator'
 import createReduxSetup from './redux'
 
-const reactNavigationPlugin = ({ Routes, initialScreen }) => {
+const reactNavigationPlugin = ({ Routes, initialScreen, sliceState = state => state.nav }) => {
   if (!Routes) {
     throw new Error('Rematch React Navigation requires app routes.')
   }
   if (!initialScreen) {
     throw new Error('Rematch React Navigation requires an initial screen name. For example, "Login"')
   }
+  if (typeof sliceState !== 'function') {
+    throw new Error('Rematch React Naviagtion requires sliceState config to be a function.')
+  }
 
-  const { addListener, navMiddleware, navReducer } = createReduxSetup(Routes, initialScreen)
+  const { addListener, navMiddleware, navReducer } = createReduxSetup(Routes, initialScreen, sliceState)
 
   return {
-    Navigator: createNavigator(Routes, addListener),
+    Navigator: createNavigator(Routes, addListener, sliceState),
     reactNavigationPlugin: {
       config: {
         redux: {

--- a/plugins/react-navigation/src/redux.ts
+++ b/plugins/react-navigation/src/redux.ts
@@ -3,7 +3,7 @@ import {
   createReduxBoundAddListener,
 } from 'react-navigation-redux-helpers'
 
-export default (Routes, initialScreen) => {
+export default (Routes, initialScreen, sliceState) => {
   const { router } = Routes
   const initialState = router.getStateForAction(router.getActionForPathAndParams(initialScreen))
 
@@ -17,7 +17,7 @@ export default (Routes, initialScreen) => {
   // middleware
   const navMiddleware = createReactNavigationReduxMiddleware(
     'root',
-    (state) => state.nav,
+    (state) => sliceState(state),
   )
 
   const addListener = createReduxBoundAddListener('root')


### PR DESCRIPTION
This PR makes the react-navigation plugin compatible with Immutable JS.   The `sliceState` config  allows the user to configure how the navigation state can be found.  It also includes an example of how to use this plugin with Immutable JS.  There are no tests for this plugin but I did test the Immutable JS functionality on my own React Native app.

I would recommend testing for regression before merging.

It may just be my dev environment, but I could not get the package to compile without adding `"@types/react": "^16.1.0"`  to my `package.json` and removing `private` from the `Navigator` component's `render` method.   Those changes are not part of making this work for Immutable JS, but I could not compile without them.   Feel free to redact them if you see fit. 