### PR TITLE
Add logic to create simple default reducers if none are provided

### DIFF
--- a/src/redux/reducers.ts
+++ b/src/redux/reducers.ts
@@ -1,6 +1,13 @@
 /* eslint no-underscore-dangle: 0 */
-import { combineReducers, Reducer, ReducersMapObject} from 'redux'
-import { Action, ConfigRedux, EnhancedReducers, Model, Reducers, RootReducers } from '../../typings/rematch'
+import { combineReducers, Reducer, ReducersMapObject } from 'redux'
+import {
+	Action,
+	ConfigRedux,
+	EnhancedReducers,
+	Model,
+	Reducers,
+	RootReducers,
+} from '../../typings/rematch'
 import isListener from '../utils/isListener'
 
 let combine = combineReducers
@@ -9,58 +16,76 @@ let allReducers: Reducers = {}
 
 // create reducer for given dispatch type
 // pass in (state, payload)
-export const createReducer = (reducer: EnhancedReducers, initialState: any) =>
-  (state: any = initialState, action: Action) => {
-  // handle effects
-  if (typeof reducer[action.type] === 'function') {
-    return reducer[action.type](state, action.payload, action.meta)
-  }
-  return state
+export const createReducer = (reducer: EnhancedReducers, initialState: any) => (
+	state: any = initialState,
+	action: Action
+) => {
+	// handle effects
+	if (typeof reducer[action.type] === 'function') {
+		return reducer[action.type](state, action.payload, action.meta)
+	}
+	return state
 }
 
 // creates a reducer out of "reducers" keys and values
 export const createModelReducer = ({ name, reducers, state }: Model) => {
-  const modelReducers: Reducers = {}
-  Object.keys(reducers || {})
-    .forEach((reducer) => {
-      const action = isListener(reducer) ? reducer : `${name}/${reducer}`
-      modelReducers[action] = reducers[reducer]
-    })
-  return {
-    [name]: createReducer(modelReducers, state),
-  }
+	const upperCaseFirst = (str: String) => {
+		const [first, ...rest] = Array.from(str)
+		return `${first.toUpperCase()}${rest.join('')}`
+	}
+
+	const modelReducers: Reducers = {}
+	Object.keys(state || {}).forEach(key => {
+		const reducerName = `set${upperCaseFirst(key)}`
+		const defaultReducer = (state, payload) => ({ ...state, [key]: payload })
+		modelReducers[reducerName] = defaultReducer
+	})
+	Object.keys(reducers || {}).forEach(reducer => {
+		const action = isListener(reducer) ? reducer : `${name}/${reducer}`
+		modelReducers[action] = reducers[reducer]
+	})
+	return {
+		[name]: createReducer(modelReducers, state),
+	}
 }
 
 // uses combineReducers to merge new reducers into existing reducers
 export const mergeReducers = (nextReducers: Reducers = {}) => {
-  allReducers = { ...allReducers, ...nextReducers }
-  if (!Object.keys(allReducers).length) {
-    return (state: any) => state
-  }
-  return combine(allReducers)
+	allReducers = { ...allReducers, ...nextReducers }
+	if (!Object.keys(allReducers).length) {
+		return (state: any) => state
+	}
+	return combine(allReducers)
 }
 
 export const initReducers = (models: Model[], redux: ConfigRedux): void => {
-  // optionally overwrite combineReducers on init
-  combine = redux.combineReducers || combine
+	// optionally overwrite combineReducers on init
+	combine = redux.combineReducers || combine
 
-  // combine existing reducers, redux.reducers & model.reducers
-  mergeReducers(models.reduce((reducers, model) => ({
-    ...createModelReducer(model),
-    ...reducers,
-  }), redux.reducers))
+	// combine existing reducers, redux.reducers & model.reducers
+	mergeReducers(
+		models.reduce(
+			(reducers, model) => ({
+				...createModelReducer(model),
+				...reducers,
+			}),
+			redux.reducers
+		)
+	)
 }
 
-export const createRootReducer = (rootReducers: RootReducers = {}): Reducer<any> => {
-  const mergedReducers: Reducer<any> = mergeReducers()
-  if (Object.keys(rootReducers).length) {
-    return (state, action) => {
-      const rootReducerAction = rootReducers[action.type]
-      if (rootReducers[action.type]) {
-        return mergedReducers(rootReducerAction(state, action), action)
-      }
-      return mergedReducers(state, action)
-    }
-  }
-  return mergedReducers
+export const createRootReducer = (
+	rootReducers: RootReducers = {}
+): Reducer<any> => {
+	const mergedReducers: Reducer<any> = mergeReducers()
+	if (Object.keys(rootReducers).length) {
+		return (state, action) => {
+			const rootReducerAction = rootReducers[action.type]
+			if (rootReducers[action.type]) {
+				return mergedReducers(rootReducerAction(state, action), action)
+			}
+			return mergedReducers(state, action)
+		}
+	}
+	return mergedReducers
 }


### PR DESCRIPTION
I've noticed that many models end up having a bunch of boilerplate, simple reducers of the form:

```javascript
setFoo: (state, foo) => ({
  ...state,
  foo
})
```

So I thought, "why not eliminate this boilerplate as well?" by using a simple convention. This PR makes it so that all keys in a model's state get a default reducer. The naming convention is to prepend "set" and uppercase the first letter of the key name. So, state.isLoggedIn would get a reducer named setIsLoggedIn. If the user provides a custom reducer, then this overrides the default.

Sorry about the formatting issues. I don't know why prettier is freaking out, but we can definitely get it straightened out if you guys decide you want to merge this PR. I figure I may as well get it out there early and get feedback since the basic concept is fairly simple.