### PR TITLE
Fix RematchDispatch typings

### DIFF
--- a/typings/rematch/index.d.ts
+++ b/typings/rematch/index.d.ts
@@ -8,7 +8,7 @@ export as namespace rematch
 
 export interface RematchDispatcher {
   (action: Action): Promise<Redux.Dispatch<any>>;
-  (payload?: any): any;
+  (payload?: any, meta?: any): Promise<Redux.Dispatch<any>>;
 }
 
 export type RematchDispatch = {

--- a/typings/rematch/index.d.ts
+++ b/typings/rematch/index.d.ts
@@ -6,11 +6,16 @@ import * as Redux from 'redux'
 
 export as namespace rematch
 
+export interface RematchDispatcher {
+  (action: Action): Promise<Redux.Dispatch<any>>;
+  (payload?: any): any;
+}
+
 export type RematchDispatch = {
   [key: string]: {
-    [key:string]: (action: Action) => Promise<Redux.Dispatch<any>>
+    [key:string]: RematchDispatcher;
   }
-} | ((action: Action) => Promise<Redux.Dispatch<any>>)
+} & ((action: Action) => Promise<Redux.Dispatch<any>>)
 
 export let dispatch: RematchDispatch;
 export function init(config: InitConfig | undefined): Redux.Store<any>


### PR DESCRIPTION
This PR fixes the signature of `RematchDispatch`.

Using union types is good for input, e.g. your function takes `number | string` as an argument.
But with polymorphic code that has overloads, the correct would be using intersection types.

In this case, the `dispatch` is both a dictionary with keys to model -> reducer, as well as a function that can take `Action` object. The typings fixes that, so now `dispatch.counter.increment(1);` compiles without errors 😉 