### PR TITLE
Fix the documentation for DevTools options

### DIFF
--- a/docs/recipes/devtools.md
+++ b/docs/recipes/devtools.md
@@ -12,7 +12,9 @@ Its also possible to add redux devtools [configuration options](https://github.c
 
 ```js
 init({
-  devtoolOptions: options,
+  redux: {
+    devtoolOptions: options,
+  },
 })
 ```
 


### PR DESCRIPTION
The options should be passed down to `redux` object. Not on `init` object.