### PR TITLE
v1 - Feature/add store name to devtools

### DIFF
--- a/examples/ts/count/src/App.tsx
+++ b/examples/ts/count/src/App.tsx
@@ -34,9 +34,9 @@ const mapState = (state: any) => ({
 });
 
 const mapDispatch = (dispatch: any) => ({
-  incrementSharks: dispatch.sharks.increment,
+  incrementSharks: () => dispatch.sharks.increment(1),
   incrementDolphins: dispatch.dolphins.increment,
-  incrementSharksAsync: dispatch.sharks.incrementAsync,
+  incrementSharksAsync: () => dispatch.sharks.incrementAsync(1),
   incrementDolphinsAsync: dispatch.dolphins.incrementAsync,
 });
 

--- a/examples/ts/count/src/models/sharks.tsx
+++ b/examples/ts/count/src/models/sharks.tsx
@@ -4,11 +4,11 @@ export interface SharkReducers {
 export default {
   state: 0,
   reducers: {
-    increment: (state: any) => state + 1
+    increment: (state: any, payload: number) => state + payload
   },
   effects: {
     async incrementAsync() {
-        this.increment();
+        this.increment(1);
     }
   }
 };

--- a/src/utils/mergeConfig.ts
+++ b/src/utils/mergeConfig.ts
@@ -14,7 +14,7 @@ const isObject = (obj: object): boolean => (Array.isArray(obj) || typeof obj !==
  */
 export default (initConfig: R.InitConfig): R.Config => {
   const config: R.Config = {
-    name: initConfig.name || '0', // unnecessary
+    name: initConfig.name,
     models: {},
     plugins: [],
     ...initConfig,
@@ -24,6 +24,10 @@ export default (initConfig: R.InitConfig): R.Config => {
       enhancers: [],
       middlewares: [],
       ...initConfig.redux,
+      devtoolOptions: {
+        name: initConfig.name,
+        ...(initConfig.redux && initConfig.redux.devtoolOptions ? initConfig.redux.devtoolOptions : {}),
+      },
     },
   }
 
@@ -61,7 +65,7 @@ export default (initConfig: R.InitConfig): R.Config => {
   }
 
   // defaults
-  for (const plugin of config.plugins || []) {
+  for (const plugin of config.plugins) {
     if (plugin.config) {
 
       // models


### PR DESCRIPTION
Automatically adds store name to devtools. Largely for use with multiple stores.

```js
const store = init({
  name: 'store-name',
})
```

Uses store.name as devtools.name
