### PR TITLE
Upgrade to Redux 4.0. 

### DIFF
--- a/examples/ts/count/.gitignore
+++ b/examples/ts/count/.gitignore
@@ -2,4 +2,4 @@
 yarn-error.log*
 yarn.lock
 package-lock.json
-
+build

--- a/examples/ts/count/package.json
+++ b/examples/ts/count/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@rematch/core": "1.0.0-alpha.0",
+    "@rematch/core": "../../..",
     "react": "^16.3.1",
     "react-dom": "^16.3.1",
     "react-redux": "^5.0.7",
@@ -16,11 +16,11 @@
     "eject": "react-scripts-ts eject"
   },
   "devDependencies": {
-    "@types/jest": "^22.2.2",
-    "@types/node": "^9.6.2",
-    "@types/react": "^16.3.5",
-    "@types/react-dom": "^16.0.4",
-    "@types/react-redux": "^5.0.15",
+    "@types/jest": "^22.2.3",
+    "@types/node": "^9.6.6",
+    "@types/react": "^16.3.12",
+    "@types/react-dom": "^16.0.5",
+    "@types/react-redux": "^5.0.16",
     "typescript": "^2.8.1"
   }
 }

--- a/examples/ts/count/tsconfig.json
+++ b/examples/ts/count/tsconfig.json
@@ -13,9 +13,10 @@
     "noImplicitReturns": true,
     "noImplicitThis": false,
     "noImplicitAny": true,
-    "strictNullChecks": true,
+    "strictNullChecks": false,
     "suppressImplicitAnyIndexErrors": true,
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "baseUrl": "."
   },
   "exclude": [
     "node_modules",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,12 +24,6 @@
         "js-tokens": "3.0.2"
       }
     },
-    "@types/estree": {
-      "version": "0.0.38",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.38.tgz",
-      "integrity": "sha512-F/v7t1LwS4vnXuPooJQGBRKRGIoxWUTmA4VHfqjOccFsNDThD5bfUNpITive6s352O7o384wcpEaDV8rHCehDA==",
-      "dev": true
-    },
     "@types/jest": {
       "version": "22.2.3",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-22.2.3.tgz",
@@ -5810,14 +5804,10 @@
       }
     },
     "rollup": {
-      "version": "0.58.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.58.1.tgz",
-      "integrity": "sha512-m423aUHITpMlcqz0grLddNGxMpBC2yYmgKwSlKNXxEi8PfNKTknh69JDo1bB1T9ezJQeqAoyFo2+U3qMQ4/I6g==",
-      "dev": true,
-      "requires": {
-        "@types/estree": "0.0.38",
-        "@types/node": "9.6.6"
-      }
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.56.0.tgz",
+      "integrity": "sha512-/VSCYZl0Tn4f7e+Jlwzmx9cEMrDcQbHTHowPVnunzhmLW0fisG1LYovuR2sSVGOO5/+Esb1KUzJlyS4n1HcOsA==",
+      "dev": true
     },
     "rollup-plugin-commonjs": {
       "version": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -55,15 +55,14 @@
     "redux-persist": "^5.9.1",
     "reselect": "^3.0.1",
     "rimraf": "^2.6.2",
-    "rollup": "^0.58.1",
+    "rollup": "0.56.0",
     "rollup-plugin-commonjs": "^9.1.0",
     "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-replace": "^2.0.0",
     "rollup-plugin-uglify": "^3.0.0",
     "ts-jest": "^22.4.4",
     "tslint": "^5.9.1",
-    "typescript": "^2.8.3",
-    "uglify-es": "^3.3.10"
+    "typescript": "^2.8.3"
   },
   "jest": {
     "transform": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,8 +4,6 @@ import replace from 'rollup-plugin-replace'
 import uglify from 'rollup-plugin-uglify'
 import commonJs from 'rollup-plugin-commonjs'
 import resolve from 'rollup-plugin-node-resolve'
-
-import { minify } from 'uglify-es'
 // experimental minifier for ES modules
 // https://github.com/TrySound/rollup-plugin-uglify#warning
 
@@ -40,7 +38,7 @@ const production = {
       mangle: {
         reserved: ['payload', 'type', 'meta']
       }
-    }, minify)
+    })
   ],
 }
 


### PR DESCRIPTION
- [x] Fix typings for 4.0
- [x] Issue with Rollup build and Redux 4.0. See error:

```
lib/index.js → dist/umd/rematch.prod.min.js, dist/cjs/rematch.prod.min.js, dist/esm/rematch.prod.min.js...
(!) Missing exports
https://github.com/rollup/rollup/wiki/Troubleshooting#name-is-not-exported-by-module
commonjs-proxy:/Users/smckay/Demos/rematch/node_modules/redux/es/redux.js
default is not exported by node_modules/redux/es/redux.js
1: import * as redux from "/Users/smckay/Demos/rematch/node_modules/redux/es/redux.js"; export default ( redux && redux['default'] ) || redux;
```