### PR TITLE
getState in dispatch

### DIFF
--- a/src/plugins/dispatch.ts
+++ b/src/plugins/dispatch.ts
@@ -8,7 +8,13 @@ import * as R from '../../typings/rematch'
 const dispatchPlugin: R.Plugin = {
   exposed: {
     // required as a placeholder for store.dispatch
-    storeDispatch: (action: R.Action) => console.warn('Warning: store not yet loaded'),
+    storeDispatch(action: R.Action) {
+      console.warn('Warning: store not yet loaded')
+    },
+
+    storeGetState() {
+      console.warn('Warning: store not yet loaded')
+    },
 
     /**
      * dispatch
@@ -16,8 +22,8 @@ const dispatchPlugin: R.Plugin = {
      * both a function (dispatch) and an object (dispatch[modelName][actionName])
      * @param action R.Action
      */
-    dispatch(action: R.Action) {
-      return this.storeDispatch(action)
+    dispatch(action: R.Action, state: any) {
+      return this.storeDispatch(action, state)
     },
 
     /**
@@ -36,6 +42,11 @@ const dispatchPlugin: R.Plugin = {
         if (typeof meta !== 'undefined') {
           action.meta = meta
         }
+        if (this.dispatch[modelName][reducerName].isEffect) {
+          // ensure that effect state is captured on dispatch
+          // to avoid possible mutations and warnings
+          return this.dispatch(action, this.storeGetState())
+        }
         return this.dispatch(action)
       }
     },
@@ -44,6 +55,7 @@ const dispatchPlugin: R.Plugin = {
   // access store.dispatch after store is created
   onStoreCreated(store: any) {
     this.storeDispatch = store.dispatch
+    this.storeGetState = store.getState
   },
 
   // generate action creators for all model.reducers

--- a/src/plugins/effects.ts
+++ b/src/plugins/effects.ts
@@ -40,11 +40,11 @@ const effectsPlugin: R.Plugin = {
 
   // process async/await actions
   middleware(store) {
-    return (next) => async (action: R.Action) => {
+    return (next) => async (action: R.Action, state: any) => {
       // async/await acts as promise middleware
       if (action.type in this.effects) {
         await next(action)
-        return this.effects[action.type](action.payload, store.getState(), action.meta)
+        return this.effects[action.type](action.payload, state, action.meta)
       } else {
         return next(action)
       }

--- a/typings/rematch/index.d.ts
+++ b/typings/rematch/index.d.ts
@@ -135,14 +135,15 @@ export interface Plugin {
   onInit?: () => void,
   onStoreCreated?: (store: Redux.Store<any>) => void,
   onModel?: ModelHook,
-  middleware?: <S>(store: Redux.MiddlewareAPI) => (next: Redux.Dispatch) => (action: Action) => any,
+  middleware?: Middleware,
 
   // exposed
   exposed?: {
     [key: string]: any,
   },
   validate?(validations: Validation[]): void,
-  storeDispatch?(action: Action): Redux.Dispatch<any> | undefined,
+  storeDispatch?(action: Action, state: any): Redux.Dispatch<any> | undefined,
+  storeGetState?(): any,
   dispatch?: RematchDispatch<any>,
   effects?: Object,
   createDispatcher?(modelName: string, reducerName: string): void,
@@ -156,7 +157,7 @@ export interface InitConfigRedux {
   initialState?: any,
   reducers?: ModelReducers,
   enhancers?: Redux.StoreEnhancer<any>[],
-  middlewares?: Redux.Middleware[],
+  middlewares?: Middleware[],
   rootReducers?: RootReducers,
   combineReducers?: (reducers: Redux.ReducersMapObject) => Redux.Reducer<any, Action>,
   createStore?: Redux.StoreCreator,
@@ -177,11 +178,15 @@ export interface Config {
   redux: ConfigRedux,
 }
 
+export interface Middleware<DispatchExt = {}, S = any, D extends Redux.Dispatch = Redux.Dispatch> {
+  (api: Redux.MiddlewareAPI<D, S>): (next: Redux.Dispatch<Action>) => (action: any, state?: any) => any;
+}
+
 export interface ConfigRedux {
   initialState?: any,
   reducers: ModelReducers,
   enhancers: Redux.StoreEnhancer<any>[],
-  middlewares: Redux.Middleware[],
+  middlewares: Middleware[],
   rootReducers?: RootReducers,
   combineReducers?: (reducers: Redux.ReducersMapObject) => Redux.Reducer<any, Action>,
   createStore?: Redux.StoreCreator,


### PR DESCRIPTION
Closes #331.

Resolves an issue with @rematch/core v1.0.0-alpha.0+ where a warning would arise from Redux v4.

This was caused by an effect calling `getState` after it has been called. It could possibly lead to mutations, or async related issues.

Now getState for effects will be calculated on dispatch.