### PR TITLE
TypeScript improvements on store object

### DIFF
--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -1,15 +1,20 @@
 # TypeScript
 
+### Examples
+
+- [Counter](../../examples/ts/count)
+
+### Changes
+
 Rematch can work with TypeScript with the following changes:
 
-##### Turn off "noImplicitThis".
+##### Turn off `noImplicitThis`.
 
 Rematch often specifies the context of `this`, leading to TS errors. 
 
 You can turn these off by specifying `noImplicitThis` as false in your "tsconfig.json".
 
-// tsconfig.json
-
+`tsconfig.json`
 ```json
 {
   "compilerOptions": {
@@ -17,6 +22,8 @@ You can turn these off by specifying `noImplicitThis` as false in your "tsconfig
   }
 }
 ```
+
+### Dependencies
 
 ##### Ensure `Redux@3.x` is not a dependency. 
 

--- a/examples/ts/count/src/App.tsx
+++ b/examples/ts/count/src/App.tsx
@@ -17,8 +17,8 @@ const mapDispatch = (dispatch: RematchDispatch<models>) => ({
   incrementSharksAsync2: () => dispatch({ type: 'sharks/incrementAsync', payload: 2 }),
 });
 
-interface CountProps
-  extends ReturnType<typeof mapState>, ReturnType<typeof mapDispatch> {}
+interface CountProps extends Partial<ReturnType<typeof mapState>>,
+Partial<ReturnType<typeof mapDispatch>> {}
 
 const Count: React.SFC<CountProps> = props => (
   <div style={{ display: 'flex', flexDirection: 'row' }}>

--- a/examples/ts/count/src/App.tsx
+++ b/examples/ts/count/src/App.tsx
@@ -4,12 +4,12 @@ import { RematchDispatch, RematchRootState } from '@rematch/core';
 
 import { models, select } from './store';
 
-const mapState = (state: RematchRootState<typeof models>) => ({
+const mapState = (state: RematchRootState<models>) => ({
   dolphins: state.dolphins,
   sharks: select.sharks.total(state),
 });
 
-const mapDispatch = (dispatch: RematchDispatch<typeof models>) => ({
+const mapDispatch = (dispatch: RematchDispatch<models>) => ({
   incrementDolphins: dispatch.dolphins.increment,
   incrementDolphinsAsync: dispatch.dolphins.incrementAsync,
   incrementSharks: () => dispatch.sharks.increment(1),

--- a/examples/ts/count/src/App.tsx
+++ b/examples/ts/count/src/App.tsx
@@ -39,4 +39,4 @@ const Count: React.SFC<CountProps> = props => (
   </div>
 );
 
-export default connect(mapState, mapDispatch)(Count);
+export default connect(mapState as any, mapDispatch as any)(Count);

--- a/examples/ts/count/src/store.ts
+++ b/examples/ts/count/src/store.ts
@@ -3,8 +3,9 @@ import { init, ExtractRematchSelectorsFromModels } from '@rematch/core';
 
 import * as models from './models';
 export { models };
+export type models = typeof models;
 
-export const select = _select as ExtractRematchSelectorsFromModels<typeof models>;
+export const select = _select as ExtractRematchSelectorsFromModels<models>;
 const selectPlugin = _selectPlugin();
 
 export const store = init({

--- a/typings/rematch/index.d.ts
+++ b/typings/rematch/index.d.ts
@@ -68,7 +68,7 @@ export type RematchDispatch<M extends Models | void = void> =
           [key:string]: RematchDispatcher | RematchDispatcherAsync;
         }
     })
-  & ((action: Action) => Promise<Redux.Dispatch<Action>>)
+  & (RematchDispatcher | RematchDispatcherAsync)
   & (Redux.Dispatch<any>) // for library compatability
 
 export let dispatch: RematchDispatch<any>;

--- a/typings/rematch/index.d.ts
+++ b/typings/rematch/index.d.ts
@@ -74,19 +74,20 @@ export type RematchDispatch<M extends Models | void = void> =
 export let dispatch: RematchDispatch<any>;
 export function init<M extends Models>(
   config: InitConfig<M> | undefined,
-): Redux.Store<RematchRootState<M>>
+): RematchStore<M>
 
 export namespace rematch {
   export let dispatch: RematchDispatch<any>;
-  export function init<M extends Models>(config: InitConfig<M> | undefined): Redux.Store<RematchRootState<M>>
+  export function init<M extends Models>(config: InitConfig<M> | undefined): RematchStore<M>
 }
 
-export interface RematchStore {
-  replaceReducer(nextReducer: Redux.Reducer<any, Action>): void,
-  dispatch(action: Action): RematchDispatch<any>,
-  getState(): any,
+export interface RematchStore<M extends Models = Models, A extends Action = Action>
+  extends Redux.Store<RematchRootState<M>, A> {
+  replaceReducer(nextReducer: Redux.Reducer<RematchRootState<M>, A>): void,
+  dispatch: RematchDispatch<M>,
+  getState(): RematchRootState<M>,
   model(model: Model): void,
-  subscribe(listener: () => void): void,
+  subscribe(listener: () => void): Redux.Unsubscribe,
 }
 
 export type Action<P = any, M = any> = {
@@ -132,10 +133,10 @@ export interface PluginFactory extends Plugin {
   create(plugin: Plugin): Plugin,
 }
 
-export interface Plugin {
-  config?: InitConfig<any>,
+export interface Plugin<M extends Models = Models, A extends Action = Action> {
+  config?: InitConfig<M>,
   onInit?: () => void,
-  onStoreCreated?: (store: Redux.Store<any>) => void,
+  onStoreCreated?: (store: RematchStore<M, A>) => void,
   onModel?: ModelHook,
   middleware?: Middleware,
 

--- a/typings/rematch/index.d.ts
+++ b/typings/rematch/index.d.ts
@@ -72,11 +72,13 @@ export type RematchDispatch<M extends Models | void = void> =
   & (Redux.Dispatch<any>) // for library compatability
 
 export let dispatch: RematchDispatch<any>;
-export function init(config: InitConfig | undefined): Redux.Store<any>
+export function init<M extends Models>(
+  config: InitConfig<M> | undefined,
+): Redux.Store<RematchRootState<M>>
 
 export namespace rematch {
   export let dispatch: RematchDispatch<any>;
-  export function init(config: InitConfig | undefined): Redux.Store<any>
+  export function init<M extends Models>(config: InitConfig<M> | undefined): Redux.Store<RematchRootState<M>>
 }
 
 export interface RematchStore {
@@ -131,7 +133,7 @@ export interface PluginFactory extends Plugin {
 }
 
 export interface Plugin {
-  config?: InitConfig,
+  config?: InitConfig<any>,
   onInit?: () => void,
   onStoreCreated?: (store: Redux.Store<any>) => void,
   onModel?: ModelHook,
@@ -153,8 +155,8 @@ export interface RootReducers {
   [type: string]: Redux.Reducer<any, Action>,
 }
 
-export interface InitConfigRedux {
-  initialState?: any,
+export interface InitConfigRedux<S = any> {
+  initialState?: S,
   reducers?: ModelReducers,
   enhancers?: Redux.StoreEnhancer<any>[],
   middlewares?: Middleware[],
@@ -164,16 +166,16 @@ export interface InitConfigRedux {
   devtoolOptions?: Object,
 }
 
-export interface InitConfig {
+export interface InitConfig<M extends Models = Models> {
   name?: string,
-  models?: Models,
+  models?: M,
   plugins?: Plugin[],
   redux?: InitConfigRedux,
 }
 
-export interface Config {
+export interface Config<M extends Models = Models> {
   name: string,
-  models: Models,
+  models: M,
   plugins: Plugin[],
   redux: ConfigRedux,
 }


### PR DESCRIPTION
Continuation of #357

Just a few more typescript improvements:

- Autocompletes store.dispatch
- Autocompletes store.getState() response
- Fixes store.subscribe return type
- Decrease the need of writing `typeof` everywhere
- Add link to counter example on TypeScript receipt