### PR TITLE
Update misleading store import example

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,8 @@ Understanding models is as simple as answering a few questions:
 **dispatch** is how we trigger reducers & effects in your models. Dispatch standardizes your actions without the need for writing action types or action creators.
 
 ```js
-import store from './index'
+import { dispatch } from '@rematch/core'
 
-const { dispatch } = store
                                                   // state = { count: 0 }
 // reducers
 dispatch({ type: 'count/increment', payload: 1 }) // state = { count: 1 }


### PR DESCRIPTION
Importing the store to access the dispatch method would create circular imports in real life case, we should import the `dispatch` function from rematch directly.