### PR TITLE
fix(loadingEffectReturnValuePropagation): Propagate effect return value

### DIFF
--- a/plugins/loading/src/index.ts
+++ b/plugins/loading/src/index.ts
@@ -118,12 +118,15 @@ export default (config: LoadingConfig = {}): Plugin => {
 
         // create function with pre & post loading calls
         const effectWrapper = async (...props) => {
+          let effetResult
+
           try {
             this.dispatch.loading.show({ name, action })
-            await origEffect(...props)
+            effetResult = await origEffect(...props)
             // waits for dispatch function to finish before calling "hide"
           } finally {
             this.dispatch.loading.hide({ name, action })
+            return effetResult
           }
         }
 

--- a/plugins/loading/src/index.ts
+++ b/plugins/loading/src/index.ts
@@ -118,15 +118,15 @@ export default (config: LoadingConfig = {}): Plugin => {
 
         // create function with pre & post loading calls
         const effectWrapper = async (...props) => {
-          let effetResult
+          let effectResult
 
           try {
             this.dispatch.loading.show({ name, action })
-            effetResult = await origEffect(...props)
+            effectResult = await origEffect(...props)
             // waits for dispatch function to finish before calling "hide"
           } finally {
             this.dispatch.loading.hide({ name, action })
-            return effetResult
+            return effectResult
           }
         }
 

--- a/plugins/loading/test/loading-asBoolean.test.js
+++ b/plugins/loading/test/loading-asBoolean.test.js
@@ -288,4 +288,23 @@ describe('loading asBoolean', () => {
       throw err
     }
   })
+
+  test('should allow the propagation of the effect result', async () => {
+    const count2 = {
+      state: 0,
+      effects: {
+        doSomething() {
+          return 'foo'
+        }
+      }
+    }
+    const store = init({
+      models: { count: count2 },
+      plugins: [loadingPlugin()]
+    })
+
+    const effectResult = await store.dispatch.count.doSomething()
+
+    expect(effectResult).toEqual('foo')
+  })
 })

--- a/plugins/loading/test/loading-asNumber.test.js
+++ b/plugins/loading/test/loading-asNumber.test.js
@@ -307,4 +307,23 @@ describe('loading asNumbers', () => {
       throw err
     }
   })
+
+  test('should allow the propagation of the effect result', async () => {
+    const count2 = {
+      state: 0,
+      effects: {
+        doSomething() {
+          return 'foo'
+        }
+      }
+    }
+    const store = init({
+      models: { count: count2 },
+      plugins: [loadingPlugin({ asNumber: true })]
+    })
+
+    const effectResult = await store.dispatch.count.doSomething()
+
+    expect(effectResult).toEqual('foo')
+  })
 })


### PR DESCRIPTION
Fix loading plugin regression regarding the issue #208 