### PR TITLE
Enable "esModuleInterop" TypeScript setting

### DIFF
--- a/plugins/immer/tsconfig.json
+++ b/plugins/immer/tsconfig.json
@@ -6,7 +6,8 @@
     "lib": ["es2017"],
     "moduleResolution": "node",
     "declaration": true,
-    "declarationDir": "./dist"
+    "declarationDir": "./dist",
+    "esModuleInterop": true
   },
   "files": [
     "src/index.ts"


### PR DESCRIPTION
Fixes #349.

See https://github.com/rematch/rematch/issues/349#issuecomment-389695117 for a better description of how this works.

I've run the unit tests against the module and it still seems to run fine.

I have not tested if this change affect the CommonJS and ES Module versions of the build, but it seems to fix the issue with the UMD version.