### PR TITLE
[TypeScript] Add independent selector state type parameter to Model<S>

### DIFF
--- a/typings/rematch/index.d.ts
+++ b/typings/rematch/index.d.ts
@@ -114,7 +114,7 @@ export type ModelHook = (model: Model) => void
 
 export type Validation = [boolean | undefined, string]
 
-export interface Model<S = any> {
+export interface Model<S = any, SS = S> {
   name?: string,
   state: S,
   reducers?: ModelReducers<S>,
@@ -122,7 +122,7 @@ export interface Model<S = any> {
     [key: string]: (payload: any, rootState: any) => void,
   },
   selectors?: {
-    [key: string]: (state: S, ...args: any[]) => any,
+    [key: string]: (state: SS, ...args: any[]) => any,
   },
   subscriptions?: {
     [matcher: string]: (action: Action) => void,


### PR DESCRIPTION
Due to the `sliceState` feature of `@rematch/select`, the state passed to selectors might be different from the model state, so it needs to be possible to define the shape of the selector input state separately.

For this reason, this changes the `Model<S = any>` type to `Model<S = any, SS = S>` and defines the selectors as `(state: SS, ...args: any[]) => any`.