### PR TITLE
TypeScript: Add `this` typing for Model.effects

### DIFF
--- a/typings/rematch/index.d.ts
+++ b/typings/rematch/index.d.ts
@@ -119,7 +119,11 @@ export interface Model<S = any, SS = S> {
   state: S,
   reducers?: ModelReducers<S>,
   effects?: {
-    [key: string]: (payload: any, rootState: any) => void,
+    [key: string]: (
+      this: { [key: string]: (payload: any) => any },
+      payload: any,
+      rootState: any
+    ) => void,
   },
   selectors?: {
     [key: string]: (state: SS, ...args: any[]) => any,


### PR DESCRIPTION
Currently, the type of `this` in `effects` functions has the same type as the `effects` function itself, leading to false errors:

```ts
export const count = {
  state: 0,

  reducers: {
    increment(state, payload) {
      return state + payload
    }
  },

  effects: {
    async incrementAsync(payload, rootState) {
      await new Promise(resolve => setTimeout(resolve, 1000))
      this.increment(payload)  // error: parameters are incompatible with `(payload, rootState)`
    }
  }
}
```

This change adds an explicit `this` typing for `effects` so that the methods of `this` are assumed to be `(payload: any) => any`.

Ideally, the type of `this` would be so precise that it only has the methods of `reducers`, with the `state` argument removed, but I don't think this kind of recursive type definition is possible in TypeScript.