### PR TITLE
TypeScript improvements - Part 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ The **model** brings together state, reducers, async actions & action creators i
 
 #### models.js
 ```js
-export const count = {
+import { createModel } from '@rematch/core'
+
+export const count = createModel({
   state: 0, // initial state
   reducers: {
     // handle state changes with pure functions
@@ -112,7 +114,7 @@ export const count = {
       this.increment(payload)
     }
   }
-}
+})
 ```
 
 *See the [reducers docs](https://github.com/rematch/rematch/blob/master/docs/api.md#reducers) to learn more, including how to trigger actions from other models.*

--- a/examples/js/count/src/index.js
+++ b/examples/js/count/src/index.js
@@ -1,12 +1,12 @@
-import { init } from '@rematch/core'
+import { createModel, init } from '@rematch/core'
 import createView from './View'
 
-const count = {
+const count = createModel({
   state: 0,
   reducers: {
     addOne: state => state + 1
   }
-}
+})
 
 const store = init({
   models: { count }

--- a/examples/react/count/src/models.js
+++ b/examples/react/count/src/models.js
@@ -1,4 +1,6 @@
-export const count = {
+import { createModel } from '@rematch/core';
+
+export const count = createModel({
   state: 0,
   reducers: {
     increment: s => s + 1
@@ -11,4 +13,4 @@ export const count = {
       this.increment()
     }
   },
-}
+})

--- a/examples/react/multi-store/src/containers/left/store.js
+++ b/examples/react/multi-store/src/containers/left/store.js
@@ -1,13 +1,13 @@
-import { init } from '@rematch/core'
+import { createModel, init } from '@rematch/core'
 
-const count = {
+const count = createModel({
   state: 0,
   reducers: {
     increment(state) {
       return state + 1
     }
   }
-}
+})
 
 const store = init({
   name: 'left',

--- a/examples/react/multi-store/src/containers/right/store.js
+++ b/examples/react/multi-store/src/containers/right/store.js
@@ -1,13 +1,13 @@
-import { init } from '@rematch/core'
+import { createModel, init } from '@rematch/core'
 
-const count = {
+const count = createModel({
   state: 0,
   reducers: {
     increment(state) {
       return state + 1
     }
   }
-}
+})
 
 const store = init({
   name: 'right',

--- a/examples/ts/count/src/models/dolphins.ts
+++ b/examples/ts/count/src/models/dolphins.ts
@@ -1,8 +1,10 @@
+import { createModel } from '@rematch/core';
+
 import { delay } from '../helpers';
 
 export type DolphinsState = number;
 
-export const dolphins = {
+export const dolphins = createModel({
    state: 0,
    reducers: {
       increment: (state: DolphinsState) => state + 1,
@@ -13,4 +15,4 @@ export const dolphins = {
          this.increment();
       },
    },
-};
+});

--- a/examples/ts/count/src/models/sharks.ts
+++ b/examples/ts/count/src/models/sharks.ts
@@ -1,8 +1,10 @@
+import { createModel } from '@rematch/core';
+
 import { delay } from '../helpers';
 
 export type SharksState = number;
 
-export const sharks = {
+export const sharks = createModel({
   state: 0,
   reducers: {
     increment: (state: SharksState, payload: number): SharksState => state + payload,
@@ -19,4 +21,4 @@ export const sharks = {
       return state;
     }
   }
-};
+});

--- a/examples/ts/count/src/store.ts
+++ b/examples/ts/count/src/store.ts
@@ -1,14 +1,14 @@
-import _selectPlugin, { select as _select } from '@rematch/select';
-import { init, ExtractRematchSelectorsFromModels } from '@rematch/core';
+import selectPlugin, { getSelect } from '@rematch/select';
+import { init } from '@rematch/core';
 
 import * as models from './models';
+
 export { models };
 export type models = typeof models;
 
-export const select = _select as ExtractRematchSelectorsFromModels<models>;
-const selectPlugin = _selectPlugin();
+export const select = getSelect<models>();
 
 export const store = init({
-  plugins: [selectPlugin],
+  plugins: [selectPlugin()],
   models,
 });

--- a/plugins/select/README.md
+++ b/plugins/select/README.md
@@ -13,13 +13,13 @@ npm install @rematch/select
 ### Setup
 
 ```js
-import selectorsPlugin from '@rematch/select'
+import selectPlugin, { getSelect } from '@rematch/select'
 import { init } from '@rematch/core'
 
-const select = selectorsPlugin()
+export const select = getSelect();
 
 init({
-  plugins: [select]
+  plugins: [selectPlugin()]
 })
 ```
 

--- a/plugins/select/index.d.ts
+++ b/plugins/select/index.d.ts
@@ -1,6 +1,11 @@
 import index from './dist';
+import { ExtractRematchSelectorsFromModels, Models } from '../../typings/rematch/index'
 
 export const select = {}
+
+export function getSelect<M extends Models = Models>() {
+  return select as ExtractRematchSelectorsFromModels<M>
+}
 
 export * from './dist';
 export default index;

--- a/plugins/select/index.d.ts
+++ b/plugins/select/index.d.ts
@@ -1,4 +1,6 @@
 import index from './dist';
 
+export const select = {}
+
 export * from './dist';
 export default index;

--- a/plugins/select/src/index.ts
+++ b/plugins/select/src/index.ts
@@ -1,6 +1,10 @@
-import { Model, Plugin } from '../../../typings/rematch'
+import { ExtractRematchSelectorsFromModels, Model, Models, Plugin } from '../../../typings/rematch'
 
 export const select = {}
+
+export function getSelect<M extends Models = Models>() {
+  return select as ExtractRematchSelectorsFromModels<M>
+}
 
 export interface SelectConfig {
   sliceState?: any,

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,17 @@ export const getState = () => {
 }
 
 /**
+ * global getDispatch
+ *
+ * Usage: const dispatch = getDispatch<models>()
+ * this is for autocomplete purposes only
+ * returns the dispatch object with typings information
+ */
+export function getDispatch<M extends R.Models>() {
+  return dispatch as R.RematchDispatch<M>
+}
+
+/**
  * global createModel
  *
  * creates a model for the given object

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,17 @@ export const getState = () => {
 }
 
 /**
+ * global createModel
+ *
+ * creates a model for the given object
+ * this is for autocomplete purposes only
+ * returns the same object that was received as argument
+ */
+export function createModel<S = any, M extends R.Model<S> = any>(model: M) {
+  return model
+}
+
+/**
  * init
  *
  * generates a Rematch store

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -1,4 +1,4 @@
-const { init } = require('../src')
+const { createModel, init } = require('../src')
 
 describe('createStore:', () => {
   it('no params should create store with state `{}`', () => {
@@ -23,6 +23,18 @@ describe('createStore:', () => {
         initialState: { app: 'hello, world' }
       }
     })
+
+    expect(store.getState()).toEqual({ app: 'hello, world' })
+  })
+
+  it('supports createModel', () => {
+    const model = createModel({
+      redux: {
+        initialState: { app: 'hello, world' }
+      }
+    })
+
+    const store = init(model)
 
     expect(store.getState()).toEqual({ app: 'hello, world' })
   })

--- a/typings/rematch/index.d.ts
+++ b/typings/rematch/index.d.ts
@@ -44,29 +44,27 @@ export type ExtractRematchSelectorsFromModels<M extends Models, RootState = any>
   }
 }
 
-export type RematchDispatcher<P = any, M = any> = {
-  (action: Action<P, M>): Redux.Dispatch<Action<P, M>>;
-}
+export type RematchDispatcher<P = void, M = void> =
+  ((action: Action<P, M>) => Redux.Dispatch<Action<P, M>>)
   &
-    P extends void ? { (): Action<void, void>; } :
-    M extends void ? { (payload: P): Action<P, void>; } :
-    { (payload: P, meta: M): Action<P, M>; }
+  (P extends void ? () => Action<void, void> :
+    M extends void ? (payload: P) => Action<P, void> :
+    (payload: P, meta: M) => Action<P, M>)
 
-export type RematchDispatcherAsync<P = any, M = any> = {
-  (action: Action<P, M>): Promise<Redux.Dispatch<Action<P, M>>>;
-}
+export type RematchDispatcherAsync<P = void, M = void> =
+  ((action: Action<P, M>) => Promise<Redux.Dispatch<Action<P, M>>>)
   &
-    P extends void ? { (): Promise<Action<void, void>>; } :
-    M extends void ? { (payload?: P): Promise<Action<P, void>>; } :
-    { (payload?: P, meta?: M): Promise<Action<P, M>>; }
+  (P extends void ? () => Promise<Action<void, void>> :
+    M extends void ? (payload?: P) => Promise<Action<P, void>> :
+    (payload?: P, meta?: M) => Promise<Action<P, M>>)
 
 export type RematchDispatch<M extends Models | void = void> =
   (M extends Models
     ? ExtractRematchDispatchersFromModels<M>
     : {
-        [key: string]: {
-          [key:string]: RematchDispatcher | RematchDispatcherAsync;
-        }
+      [key: string]: {
+        [key: string]: RematchDispatcher | RematchDispatcherAsync;
+      }
     })
   & (RematchDispatcher | RematchDispatcherAsync)
   & (Redux.Dispatch<any>) // for library compatability

--- a/typings/rematch/index.d.ts
+++ b/typings/rematch/index.d.ts
@@ -27,20 +27,22 @@ export type ExtractRematchDispatcherAsyncFromEffect<E> =
   E extends (payload: infer P, meta: infer M) => Promise<void> ? RematchDispatcherAsync<P, M> :
   RematchDispatcherAsync<any, any>
 
-export type ExtractRematchDispatchersFromModels<M extends Models> = {
-  [modelKey in keyof M]: {
-    [reducerKey in keyof M[modelKey]['reducers']]:
-      ExtractRematchDispatcherFromReducer<M[modelKey]['reducers'][reducerKey]>
-  } & {
-    [effectKey in keyof M[modelKey]['effects']]:
-      ExtractRematchDispatcherAsyncFromEffect<M[modelKey]['effects'][effectKey]>
+export type ExtractRematchDispatchersFromModel<M extends Model> = {
+  [reducerKey in keyof M['reducers']]:
+  ExtractRematchDispatcherFromReducer<M['reducers'][reducerKey]>
+} & {
+    [effectKey in keyof M['effects']]:
+    ExtractRematchDispatcherAsyncFromEffect<M['effects'][effectKey]>
   }
+
+export type ExtractRematchDispatchersFromModels<M extends Models> = {
+  [modelKey in keyof M]: ExtractRematchDispatchersFromModel<M[modelKey]>
 }
 
 export type ExtractRematchSelectorsFromModels<M extends Models, RootState = any> = {
   [modelKey in keyof M]: {
     [reducerKey in keyof M[modelKey]['selectors']]:
-      (state: RematchRootState<M>, ...args:any[]) => ReturnType<M[modelKey]['selectors'][reducerKey]>
+    (state: RematchRootState<M>, ...args: any[]) => ReturnType<M[modelKey]['selectors'][reducerKey]>
   }
 }
 
@@ -123,7 +125,14 @@ export interface Model<S = any, SS = S> {
   state: S,
   reducers?: ModelReducers<S>,
   effects?: {
-    [key: string]: (payload: any, rootState: any) => void,
+    [key: string]: (
+      this: (
+        // ExtractRematchDispatchersFromModel<this> & // TODO: Make this work, if possible
+        { [key: string]: RematchDispatcher | RematchDispatcherAsync }
+      ),
+      payload: any,
+      rootState: any
+    ) => void
   },
   selectors?: {
     [key: string]: (state: SS, ...args: any[]) => any,

--- a/typings/rematch/index.d.ts
+++ b/typings/rematch/index.d.ts
@@ -76,6 +76,8 @@ export function init<M extends Models>(
   config: InitConfig<M> | undefined,
 ): RematchStore<M>
 
+export function getDispatch<M extends Models>(): RematchDispatch<M>
+
 export function createModel<S = any, M extends Model<S> = Model>(
   model: M,
 ): M

--- a/typings/rematch/index.d.ts
+++ b/typings/rematch/index.d.ts
@@ -151,7 +151,7 @@ export interface Plugin<M extends Models = Models, A extends Action = Action> {
   validate?(validations: Validation[]): void,
   storeDispatch?(action: Action, state: any): Redux.Dispatch<any> | undefined,
   storeGetState?(): any,
-  dispatch?: RematchDispatch<any>,
+  dispatch?: RematchDispatch<M>,
   effects?: Object,
   createDispatcher?(modelName: string, reducerName: string): void,
 }

--- a/typings/rematch/index.d.ts
+++ b/typings/rematch/index.d.ts
@@ -76,6 +76,10 @@ export function init<M extends Models>(
   config: InitConfig<M> | undefined,
 ): RematchStore<M>
 
+export function createModel<S = any, M extends Model<S> = Model>(
+  model: M,
+): M
+
 export namespace rematch {
   export let dispatch: RematchDispatch<any>;
   export function init<M extends Models>(config: InitConfig<M> | undefined): RematchStore<M>


### PR DESCRIPTION
- [API] New `createModel` function for autocomplete purposes (https://github.com/rematch/rematch/issues/361#issuecomment-392510274)
- [API] New `getSelect` function for autocomplete purposes (https://github.com/rematch/rematch/pull/364#issuecomment-392596145)
- [API] New `getDispatch` function for autocomplete purposes (https://github.com/rematch/rematch/pull/369#issuecomment-391211890)
- [TYPINGS] Fix `RematchDispatch` `no compatible call signature` error
- [TYPINGS] Support `this` inside effects (alternative to #382)

I could not reproduce #361.