### PR TITLE
 [typings] fix generic RematchDispatch

### DIFF
--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -55,18 +55,18 @@ export type ExtractRematchSelectorsFromModels<M extends Models, RootState = any>
 }
 
 export type RematchDispatcher<P = void, M = void> =
-  ((action: Action<P, M>) => Redux.Dispatch<Action<P, M>>)
-  &
-  (P extends void ? () => Action<void, void> :
-    M extends void ? (payload: P) => Action<P, void> :
+  ((action: Action<P, M>) => Redux.Dispatch<Action<P, M>>) &
+  ((action: Action<P, void>) => Redux.Dispatch<Action<P, void>>) &
+  (P extends void ? ((...args: any[]) => Action<any, any>) :
+    M extends void ? ((payload: P) => Action<P, void>) :
     (payload: P, meta: M) => Action<P, M>)
 
 export type RematchDispatcherAsync<P = void, M = void> =
-  ((action: Action<P, M>) => Promise<Redux.Dispatch<Action<P, M>>>)
-  &
-  (P extends void ? () => Promise<Action<void, void>> :
-    M extends void ? (payload?: P) => Promise<Action<P, void>> :
-    (payload?: P, meta?: M) => Promise<Action<P, M>>)
+  ((action: Action<P, M>) => Promise<Redux.Dispatch<Action<P, M>>>) &
+  ((action: Action<P, void>) => Promise<Redux.Dispatch<Action<P, void>>>) &
+  (P extends void ? ((...args: any[]) => Promise<Action<any, any>>) :
+    M extends void ? ((payload: P) => Promise<Action<P, void>>) :
+    (payload: P, meta: M) => Promise<Action<P, M>>)
 
 export type RematchDispatch<M extends Models | void = void> =
   (M extends Models


### PR DESCRIPTION
PS: Fix is on the [first commit](https://github.com/rematch/rematch/commit/43462e686b8347bf64558a206ca25399734f651d), the second one is just a refactoring (_I've split `ExtractRematchDispatchersFromModel` into smaller chunks_).

---

Fix error from #399:
`Argument of type 'number' is not assignable to parameter of type 'Action<void, void>'`

