### PR TITLE
Strict null check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,9 +14,9 @@ const dispatches = {}
  * @param action
  */
 export const dispatch = (action: R.Action) => {
-  for (const storeName of Object.keys(stores)) {
-    stores[storeName].dispatch(action)
-  }
+	for (const storeName of Object.keys(stores)) {
+		stores[storeName].dispatch(action)
+	}
 }
 
 /**
@@ -26,11 +26,11 @@ export const dispatch = (action: R.Action) => {
  * returns an object with key: storeName, value: store.getState()
  */
 export const getState = () => {
-  const state = {}
-  for (const name of Object.keys(stores)) {
-    state[name] = stores[name].getState()
-  }
-  return state
+	const state = {}
+	for (const name of Object.keys(stores)) {
+		state[name] = stores[name].getState()
+	}
+	return state
 }
 
 /**
@@ -41,7 +41,7 @@ export const getState = () => {
  * returns the dispatch object with typings information
  */
 export function getDispatch<M extends R.Models>() {
-  return dispatch as R.RematchDispatch<M>
+	return dispatch as R.RematchDispatch<M>
 }
 
 /**
@@ -51,8 +51,8 @@ export function getDispatch<M extends R.Models>() {
  * this is for autocomplete purposes only
  * returns the same object that was received as argument
  */
-export function createModel<S = any, M extends R.Model<S> = any>(model: M) {
-  return model
+export function createModel<S = any, M extends R.ModelConfig<S> = any>(model: M) {
+	return model
 }
 
 /**
@@ -63,16 +63,16 @@ export function createModel<S = any, M extends R.Model<S> = any>(model: M) {
  * @param config
  */
 export const init = (initConfig: R.InitConfig = {}): R.RematchStore => {
-  const name = initConfig.name || Object.keys(stores).length.toString()
-  const config: R.Config = mergeConfig({ ...initConfig, name })
-  const store = new Rematch(config).init()
-  stores[name] = store
-  for (const modelName of Object.keys(store.dispatch)) {
-    if (!dispatch[modelName]) {
-      dispatch[modelName] = {}
-    }
-    for (const actionName of Object.keys(store.dispatch[modelName])) {
-      if (!isListener(actionName)) {
+	const name = initConfig.name || Object.keys(stores).length.toString()
+	const config: R.Config = mergeConfig({ ...initConfig, name })
+	const store = new Rematch(config).init()
+	stores[name] = store
+	for (const modelName of Object.keys(store.dispatch)) {
+		if (!dispatch[modelName]) {
+			dispatch[modelName] = {}
+		}
+		for (const actionName of Object.keys(store.dispatch[modelName])) {
+			if (!isListener(actionName)) {
 				const action = store.dispatch[modelName][actionName]
 				if (!dispatches[modelName]) {
 					dispatches[modelName] = {}

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -45,7 +45,7 @@ export type ExtractRematchDispatchersFromReducersObject<reducers extends ModelRe
 }
 
 export type ExtractRematchDispatchersFromReducers<reducers extends Model['reducers']> =
-  ExtractRematchDispatchersFromReducersObject<reducers>
+  ExtractRematchDispatchersFromReducersObject<reducers & {}>
 
 export type ExtractRematchDispatchersFromModel<M extends Model> = 
   ExtractRematchDispatchersFromReducers<M['reducers']> &
@@ -58,7 +58,10 @@ export type ExtractRematchDispatchersFromModels<M extends Models> = {
 export type ExtractRematchSelectorsFromModels<M extends Models, RootState = any> = {
   [modelKey in keyof M]: {
     [reducerKey in keyof M[modelKey]['selectors']]:
-    (state: RematchRootState<M>, ...args: any[]) => ReturnType<M[modelKey]['selectors'][reducerKey]>
+    (state: RematchRootState<M>, ...args: any[]) =>
+      M[modelKey]['selectors'][reducerKey] extends ((...args: any[]) => any)
+        ? ReturnType<M[modelKey]['selectors'][reducerKey]>
+        : {}
   }
 }
 

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -147,7 +147,12 @@ export type ModelHook = (model: Model) => void
 
 export type Validation = [boolean | undefined, string]
 
-export interface Model<S = any, SS = S> {
+export interface Model<S = any, SS = S> extends ModelConfig {
+  name: string,
+  reducers: ModelReducers<S>,
+}
+
+export interface ModelConfig<S = any, SS = S> {
   name?: string,
   state: S,
   reducers?: ModelReducers<S>,
@@ -205,7 +210,7 @@ export interface InitConfig<M extends Models = Models> {
   redux?: InitConfigRedux,
 }
 
-export interface Config<M extends Models = Models> {
+export interface Config<M extends Models = Models> extends InitConfig {
   name: string,
   models: M,
   plugins: Plugin[],

--- a/src/utils/mergeConfig.ts
+++ b/src/utils/mergeConfig.ts
@@ -2,17 +2,18 @@ import * as R from '../typings'
 import validate from './validate'
 
 const merge = (original: any, next: any): any => {
-	return (next) ? { ...next, ...(original || {}) } : original || {}
+	return next ? { ...next, ...(original || {}) } : original || {}
 }
 
-const isObject = (obj: object): boolean => (Array.isArray(obj) || typeof obj !== 'object')
+const isObject = (obj: object): boolean =>
+	Array.isArray(obj) || typeof obj !== 'object'
 
 /**
  * mergeConfig
  *
  * merge init configs together
  */
-export default (initConfig: R.InitConfig): R.Config => {
+export default (initConfig: R.Config): R.Config => {
 	const config: R.Config = {
 		name: initConfig.name,
 		models: {},
@@ -26,21 +27,17 @@ export default (initConfig: R.InitConfig): R.Config => {
 			...initConfig.redux,
 			devtoolOptions: {
 				name: initConfig.name,
-				...(initConfig.redux && initConfig.redux.devtoolOptions ? initConfig.redux.devtoolOptions : {}),
+				...(initConfig.redux && initConfig.redux.devtoolOptions
+					? initConfig.redux.devtoolOptions
+					: {}),
 			},
 		},
 	}
 
 	if (process.env.NODE_ENV !== 'production') {
 		validate([
-			[
-				!Array.isArray(config.plugins),
-				'init config.plugins must be an array',
-			],
-			[
-				isObject(config.models),
-				'init config.models must be an object',
-			],
+			[!Array.isArray(config.plugins), 'init config.plugins must be an array'],
+			[isObject(config.models), 'init config.models must be an object'],
 			[
 				isObject(config.redux.reducers),
 				'init config.redux.reducers must be an object',
@@ -54,11 +51,13 @@ export default (initConfig: R.InitConfig): R.Config => {
 				'init config.redux.enhancers must be an array of functions',
 			],
 			[
-				config.redux.combineReducers && typeof config.redux.combineReducers !== 'function',
+				config.redux.combineReducers &&
+					typeof config.redux.combineReducers !== 'function',
 				'init config.redux.combineReducers must be a function',
 			],
 			[
-				config.redux.createStore && typeof config.redux.createStore !== 'function',
+				config.redux.createStore &&
+					typeof config.redux.createStore !== 'function',
 				'init config.redux.createStore must be a function',
 			],
 		])
@@ -67,23 +66,39 @@ export default (initConfig: R.InitConfig): R.Config => {
 	// defaults
 	for (const plugin of config.plugins) {
 		if (plugin.config) {
-
 			// models
-			config.models =
-				merge(config.models, plugin.config.models) as typeof config.models // FIXME: not sure how to avoid this
+			const models: R.Models = merge(config.models, plugin.config.models)
+			config.models = models
 
 			// plugins
 			config.plugins = [...config.plugins, ...(plugin.config.plugins || [])]
 
 			// redux
 			if (plugin.config.redux) {
-				config.redux.initialState = merge(config.redux.initialState, plugin.config.redux.initialState)
-				config.redux.reducers = merge(config.redux.reducers, plugin.config.redux.reducers)
-				config.redux.rootReducers = merge(config.redux.rootReducers, plugin.config.redux.reducers)
-				config.redux.enhancers = [...config.redux.enhancers, ...(plugin.config.redux.enhancers || [])]
-				config.redux.middlewares = [...config.redux.middlewares, ...(plugin.config.redux.middlewares || [])]
-				config.redux.combineReducers = config.redux.combineReducers || plugin.config.redux.combineReducers
-				config.redux.createStore = config.redux.createStore || plugin.config.redux.createStore
+				config.redux.initialState = merge(
+					config.redux.initialState,
+					plugin.config.redux.initialState
+				)
+				config.redux.reducers = merge(
+					config.redux.reducers,
+					plugin.config.redux.reducers
+				)
+				config.redux.rootReducers = merge(
+					config.redux.rootReducers,
+					plugin.config.redux.reducers
+				)
+				config.redux.enhancers = [
+					...config.redux.enhancers,
+					...(plugin.config.redux.enhancers || []),
+				]
+				config.redux.middlewares = [
+					...config.redux.middlewares,
+					...(plugin.config.redux.middlewares || []),
+				]
+				config.redux.combineReducers =
+					config.redux.combineReducers || plugin.config.redux.combineReducers
+				config.redux.createStore =
+					config.redux.createStore || plugin.config.redux.createStore
 			}
 		}
 	}

--- a/src/utils/mergeConfig.ts
+++ b/src/utils/mergeConfig.ts
@@ -13,7 +13,7 @@ const isObject = (obj: object): boolean =>
  *
  * merge init configs together
  */
-export default (initConfig: R.Config): R.Config => {
+export default (initConfig: R.InitConfig & { name: string }): R.Config => {
 	const config: R.Config = {
 		name: initConfig.name,
 		models: {},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
       "noImplicitReturns": true,
       "noImplicitThis": false,
       "noImplicitAny": true,
-      "strictNullChecks": false,
+      "strictNullChecks": true,
       "suppressImplicitAnyIndexErrors": true,
       "noUnusedLocals": true
   },


### PR DESCRIPTION
Fix #406

@ShMcK can you finish this PR? It requires more knowledge about the internals.
Please run `npx tsc -p .` to see the remaining errors.

They are mostly because the `name` field it optional, so things like `this.reducers[model.name]` could cause an issue (`this.reducers[undefined]`). But can they really be undefined? Maybe the `name` field should be required instead of optional? Or are you setting the name automatically somewhere else?

> If you are pretty sure they will never be undefined for some reason, you can just add an `!`, e.g. `this.reducers[model.name!]`.