### PR TITLE
Proposal: Select is a mirror of Effects

### DIFF
--- a/plugins/select/package.json
+++ b/plugins/select/package.json
@@ -32,7 +32,7 @@
   },
   "browser": "dist/rematch-select.umd.js",
   "devDependencies": {
-    "@rematch/core": "^1.0.0-alpha.8",
+    "@rematch/core": "^1.0.0-alpha.9",
     "rollup": "^0.60.1",
     "rollup-plugin-commonjs": "^9.1.3",
     "rollup-plugin-replace": "^2.0.0",
@@ -42,7 +42,7 @@
     "uglify-es": "^3.3.9"
   },
   "peerDependencies": {
-    "@rematch/core": ">=1.0.0-alpha.8"
+    "@rematch/core": ">=1.0.0-alpha.9"
   },
   "authors": [
     "Blair Bodnar <blairbodnar@gmail.com> (https://github.com/blairbodnar)",

--- a/plugins/select/package.json
+++ b/plugins/select/package.json
@@ -32,7 +32,7 @@
   },
   "browser": "dist/rematch-select.umd.js",
   "devDependencies": {
-    "@rematch/core": "^1.0.0-alpha.9",
+    "@rematch/core": "^1.0.0-beta.1",
     "rollup": "^0.60.1",
     "rollup-plugin-commonjs": "^9.1.3",
     "rollup-plugin-replace": "^2.0.0",
@@ -42,7 +42,7 @@
     "uglify-es": "^3.3.9"
   },
   "peerDependencies": {
-    "@rematch/core": ">=1.0.0-alpha.9"
+    "@rematch/core": ">=1.0.0-beta.1"
   },
   "authors": [
     "Blair Bodnar <blairbodnar@gmail.com> (https://github.com/blairbodnar)",

--- a/plugins/select/src/index.ts
+++ b/plugins/select/src/index.ts
@@ -7,54 +7,74 @@ export function getSelect<M extends Models = Models>() {
 }
 
 export interface SelectConfig {
+  name?: string,
 	sliceState?: any,
 }
 
-export const select = {};
-
-const createSelectPlugin = ({
-  sliceState = (rootState, model) => rootState[model.name]
-}: SelectConfig = {}): Plugin => ({
-  exposed: {
-    select,
-    createSelector(model: Model, selector: Function) {
-      return (state: any, ...args) => selector(sliceState(state, model), ...args);
-    }
-  },
-  onInit() {
-    this.validate([
-      [
-        typeof sliceState !== "function",
-        `createSelectPlugin's getState config must be a function. Instead got type ${typeof sliceState}.`
-      ]
-    ]);
-  },
-  onModel(model: Model) {
-    select[model.name] = {};
-    this.select[model.name] = {};
-
-    const selectors =
-      typeof model.selectors === "function"
-        ? model.selectors(this.select)
-        : model.selectors;
-
-    Object.keys(selectors || {}).forEach((selectorName: String) => {
-      this.validate([
-        [
-          typeof selectors[selectorName] !== "function",
-          `Selector (${model.name}/${selectorName}) must be a function`
-        ]
-      ]);
-
-      select[model.name][selectorName] = this.createSelector(
-        model,
-        selectors[selectorName].bind(this.select[model.name])
-      );
-
-      this.select[model.name][selectorName] = (...args) =>
-        select[model.name][selectorName](this.storeGetState(), ...args);
-    });
+const validateConfig = (config) => {
+  if (config.name && typeof config.name !== 'string') {
+    throw new Error('select plugin config name must be a string')
   }
-});
+  if (config.sliceState && typeof config.sliceState !== 'function') {
+    throw new Error('select plugin config sliceState must be a function')
+  }
+}
 
-export default createSelectPlugin;
+const createSelectPlugin = (config: SelectConfig = {}): Plugin => {
+  validateConfig(config)
+
+  const sliceState = config.sliceState || ((rootState, model) => rootState[model.name])
+
+  const selectModelName = config.name || 'select'
+
+  const selectModel: Model = {
+    state: {},
+    name: selectModelName,
+  }
+
+  return {
+    config: {
+      models: {
+        selectModel,
+      },
+    },
+    onModel(model: Model) {
+      if (model.name === selectModelName) { return }
+
+      select[model.name] = {}
+      selectModel.state[model.name] = {}
+
+      const selectors =
+        typeof model.selectors === "function"
+          ? model.selectors(selectModel.state)
+          : model.selectors
+
+      Object.keys(selectors || {}).forEach((selectorName: String) => {
+        this.validate([
+          [
+            typeof selectors[selectorName] !== "function",
+            `Selector (${model.name}/${selectorName}) must be a function`
+          ]
+        ])
+
+
+        select[model.name][selectorName] = (state: any, ...args) =>
+          selectors[selectorName].call(
+            state[selectModelName][model.name],
+            sliceState(state, model),
+            ...args
+          )
+
+
+        selectModel.state[model.name][selectorName] = (...args) =>
+          selectors[selectorName].call(
+            selectModel.state[model.name],
+            sliceState(this.storeGetState(), model),
+            ...args
+          )
+      })
+    }
+  }
+}
+
+export default createSelectPlugin

--- a/plugins/select/test/select.test.js
+++ b/plugins/select/test/select.test.js
@@ -183,7 +183,9 @@ describe('select:', () => {
         },
         selectors: {
           double: s => s * 2,
-          quadruple (s) { return this.double() + this.double() }
+          quadruple (s) {
+            return this.double() * 2
+          }
         }
       }
       const store = init({
@@ -205,7 +207,9 @@ describe('select:', () => {
         },
         selectors: (select) => ({
           double: s => s * 2,
-          quadruple (s) { return select.a.double() + select.a.double() }
+          quadruple (s) {
+            return select.a.double() * 2
+          }
         })
       }
       const store = init({
@@ -227,7 +231,9 @@ describe('select:', () => {
         },
         selectors: {
           double: s => s * 2,
-          curriedDouble (s) { return this.double(42) }
+          curriedDouble (s) {
+            return this.double(42)
+          }
         }
       }
       const store = init({

--- a/plugins/select/test/select.test.js
+++ b/plugins/select/test/select.test.js
@@ -1,5 +1,5 @@
 const { createSelector } = require('reselect')
-const createSelectPlugin = require('../src').default
+const { default: createSelectPlugin, SELECT_REF_KEY } = require('../src')
 const { select } = require('../src')
 const { init } = require('../../../src')
 
@@ -171,6 +171,32 @@ describe('select:', () => {
       const state = store.getState()
       const result = outsideSelector(state)
       expect(result).toBe(27)
+    })
+  })
+
+  describe('store ref: ', () => {
+    it('should expose the store name', async () => {
+      const store = init({
+        plugins: [createSelectPlugin()]
+      })
+
+      const state = store.getState()
+      expect(state).toEqual({
+        [SELECT_REF_KEY]: store.name
+      })
+    })
+
+    it('should expose the store name with a configured key', async () => {
+      const store = init({
+        plugins: [createSelectPlugin({
+          name: 'chicken'
+        })]
+      })
+
+      const state = store.getState()
+      expect(state).toEqual({
+        'chicken': store.name
+      })
     })
   })
 


### PR DESCRIPTION
**Proposal: optionally pass local select into selectors and allow directly calling other selectors on the same model.**

```js
{
  selectors: (select) => ({
    double: s => s * 2,
    quadruple: s => select.model.double() * 2
  })
}
```

[I recreated my external selectors inside rematch and it seems pretty clean](https://codesandbox.io/s/ql6m574l84)

**TODO:**
- [x] make multiple-store-safe
- [ ] typings
- [ ] examples
- [ ] validate - is this a good idea???

---

**Motivation**
Following #399, I made some comments in #400.

There are an alarming number of issues related to people using the global `dispatch` (not so much `select`, but it embraces the global aspect). Most of the outstanding issues I could find could be solved by using dependency injection through `connect`. It seems like that API is really what everything should look like.

This PR binds selectors to the current store and lets them call each other without passing down state - Exactly like dispatchers. So you have  state changes with no dependencies and identical dependent storage and selection flows. (pure selection is just consuming raw state, no?)

Unlike dispatchers, to establish bindings, the selectors are stored in the state and retrieved when the global `select` is used. I had a few ideas after reading #270, and it sounded like this might be the part that was objectionable...
