### PR TITLE
Allow to disable redux devtools

### DIFF
--- a/docs/recipes/devtools.md
+++ b/docs/recipes/devtools.md
@@ -18,6 +18,18 @@ init({
 })
 ```
 
+To disable redux devtools, set `disabled` property to `true`:
+
+```js
+init({
+  redux: {
+    devtoolOptions: {
+      disabled: true,
+    },
+  },
+})
+```
+
 ### Remote-Redux-Devtools
 
 To use Redux Devtools in React Native, simply use [Remote Redux Devtools](https://github.com/zalmoxisus/remote-redux-devtools).

--- a/src/redux.ts
+++ b/src/redux.ts
@@ -2,11 +2,13 @@ import * as Redux from 'redux'
 import * as R from './typings'
 import isListener from './utils/isListener'
 
-const composeEnhancersWithDevtools = (devtoolOptions = {}): any =>
+const composeEnhancersWithDevtools = (devtoolOptions: R.DevtoolOptions = {}): any => {
+	const { disabled, ...options } = devtoolOptions
 	/* istanbul ignore next */
-	typeof window === 'object' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
-		? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__(devtoolOptions)
+	return !disabled && typeof window === 'object' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
+		? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__(options)
 		: Redux.compose
+}
 
 export default function({
 	redux,

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -193,6 +193,11 @@ export interface RootReducers {
   [type: string]: Redux.Reducer<any, Action>,
 }
 
+export interface DevtoolOptions {
+  disabled?: boolean,
+  [key: string]: any,
+}
+
 export interface InitConfigRedux<S = any> {
   initialState?: S,
   reducers?: ModelReducers,
@@ -201,7 +206,7 @@ export interface InitConfigRedux<S = any> {
   rootReducers?: RootReducers,
   combineReducers?: (reducers: Redux.ReducersMapObject) => Redux.Reducer<any, Action>,
   createStore?: Redux.StoreCreator,
-  devtoolOptions?: Object,
+  devtoolOptions?: DevtoolOptions,
 }
 
 export interface InitConfig<M extends Models = Models> {
@@ -230,7 +235,7 @@ export interface ConfigRedux {
   rootReducers?: RootReducers,
   combineReducers?: (reducers: Redux.ReducersMapObject) => Redux.Reducer<any, Action>,
   createStore?: Redux.StoreCreator,
-  devtoolOptions?: Object,
+  devtoolOptions?: DevtoolOptions,
 }
 
 export interface RematchClass {


### PR DESCRIPTION
Hey guys,

this PR is to allow redux devtools to be disabled. As per discussion here (https://github.com/rematch/rematch/issues/351), it's enabled by default, but can be disabled if needed. Please let me know what you think. Thanks!