### PR TITLE
Select plugin can also wire dependencies.

### DIFF
--- a/plugins/select/README.md
+++ b/plugins/select/README.md
@@ -1,6 +1,7 @@
 # Rematch Select
 
-Selectors plugin for Rematch.
+Selectors plugin for Rematch. Wires your store models with dependencies and collects their selectors. Uses [reselect](https://github.com/reduxjs/reselect) by default.
+
 
 ### Install
 
@@ -8,26 +9,34 @@ Selectors plugin for Rematch.
 npm install @rematch/select
 ```
 
-> For @rematch/core@0.x use @rematch/select@0.3.0
+[This is the documentation for @rematch/select 2.0. For older versions see the legacy docs](https://github.com/rematch/rematch/blob/v1/plugins/select/README.md)
+
+
 
 ### Setup
 
 ```js
-import selectPlugin, { getSelect } from '@rematch/select'
+import selectPlugin from '@rematch/select'
 import { init } from '@rematch/core'
-
-export const select = getSelect();
 
 init({
   plugins: [selectPlugin()]
 })
 ```
 
-### selectors
 
-`selectors: { [string]: (state, ...params) => any }`
 
-Selectors are read-only snippets of state.
+## Building Selectors
+
+### Basics
+
+Selectors are read-only snippets of state. They can be combined across models for powerful data retrieval.
+
+**Since selectors can depend on each other, they need to be created by factory functions.** When the store is fully ready, each factory will be evaluated once.
+
+> { selectors: { (models) => selector  } }
+
+The most basic selector is a function that receives `rootState`:
 
 ```js
 {
@@ -37,74 +46,222 @@ Selectors are read-only snippets of state.
     amount: 3,
   }],
   selectors: {
-    total(state) {
-      return state.reduce((a, b) => a + (b.price * b.amount), 0)
+    total() {
+      return (rootState, props) =>
+        rootState.cart.reduce((a, b) => a + (b.price * b.amount), 0)
     }
   }
 }
 ```
 
-> note: By default, the selector state does not refer to the complete state, only the state within the model.
-To change this behavior, use the sliceState configuration option described below.
 
-Selectors can be called anywhere within your app.
 
-```js
-import { select } from '@rematch/select'
+If we hook total up to something like `react-redux`'s `connect`, it will be recomputed any time our `rootState` changes. To avoid this, `@rematch/select` includes `reselect`.
 
-const store = init({ ... })
-
-select.cart.total(store.getState())
-```
-
-Selectors can also be used with memoization libraries like [reselect](https://github.com/reactjs/reselect).
+Models gain access to the `reselect` api through dependency injection:
 
 ```js
-import { createSelector } from 'reselect'
-
 {
-  selectors: {
-    total: createSelector(
-      state => state,
-      state => state.reduce((a, b) => a + (b.price * b.amount), 0)
-    )
-  }
+  name: 'cart',
+  selectors: (slice, createSelector, hasProps) => ({
+    ...
+  })
 }
 ```
 
-### Configuration Options
+
+
+Our selector, `total`, depends only on the cart model's state and doesn't need to update when the rest of the store updates. `slice` creates a basic selector
+memoized by the model's slice of state.
+
+```js
+total () {
+  return slice(cart =>
+    cart.reduce((a, b) => a + (b.price * b.amount), 0)
+  )
+}
+```
+
+
+
+If you want more control over what the dependencies of your selector are,
+you can directly call the passed in `createSelector`.
+This will memoize the last function by the results of all the previous functions.
+
+> `slice` can also be used as a selector directly, simply returning the model's slice of state.
+
+```js
+total () {
+  return createSelector(
+    slice,
+    (state, props) => props.shipping,
+    (cart, shipping) => cart.reduce((a, b) => a + (b.price * b.amount), shipping)
+  )
+}
+```
+
+
+
+### Combining selectors
+
+`@rematch/select` injects `models` into each selector factory to allow it to depend on other models state.
+
+
+> If your factory is a `function`, you can use `this` as a shortcut to the current model's selectors
+
+
+```js
+poorSortByHot (models) {
+  return createSelector(
+    this.cart,
+    models.popularity.pastDay,
+    (cart, hot) => cart.sort((a, b) => hot[a.product] > hot[b.product])
+  )
+}
+```
+
+### Selector arguments
+
+As you may have noticed, a selector's dependencies can receive `props`:
+```js
+(state, props) => props.shipping
+```
+
+[Be careful when passing `props` to a selector - passing different props could reset the cache! ](https://github.com/reduxjs/reselect/blob/master/README.md#sharing-selectors-with-props-across-multiple-component-instances)
+
+In some situations, configurable selectors may be better off with isolated caches. To opt-in to this behavior and create a new cache for every configuration, `@rematch/select` injects `hasProps`.
+
+`hasProps` wraps a factory so that it receives `models` and `props`. [For complex calculations or dashboards a recipe may be better](#re-reselect)
+
+
+> `hasProps` is a "higher-order selector factory" - it creates factories that can be used in other factories
+
+
+```js
+expensiveFilter: hasProps(function (models, lowerLimit) {
+  return slice(items => items.filter(item => item.price > lowerLimit))
+}),
+  
+wouldGetFreeShipping () {
+  return this.expensiveFilter(20.00)
+},
+```
+
+
+
+## Using Selectors in your app
+
+Most apps will consume selectors through `connect`. For this use case, `@rematch/select` provides the `select` function to create a selector you can pass directly to connect, or call yourself. `select` ensures your component re-renders only when its data actually changes. 
+
+
+> Under the hood, `select` create a [structuredSelector](https://github.com/reduxjs/reselect#createstructuredselectorinputselectors-selectorcreator--createselector). 
+
+
+```js
+import { connect } from 'react-redux'
+import { select } from '@rematch/select'
+
+connect(select(models => {
+  total: models.cart.total,
+  eligibleItems: models.cart.wouldGetFreeShipping 
+}))(...)
+```
+
+
+
+Selectors can also be called directly anywhere within your app.
+
+```js
+import { selectors } from '@rematch/select'
+
+const store = init({ ... })
+
+selectors.cart.expensiveFilter(50.00)(store.getState())
+```
+
+
+
+## External Selectors
+
+`@rematch/select` supports using your own `selectorCreator` directly in the models.
+
+> Configuring this store-wide in `options` makes testing easier.
+
+```js
+isHypeBeast (models) {
+  return customCreateSelector(
+    slice,
+    state => this.sortByHot(state)[0],
+    (state, hottest) => hottest.price > 100.00
+  )
+}
+```
+
+
+
+## Configuration Options
 
 The `selectorPlugin()` method will accept a configuration object with the following property.
+
+#### selectorCreator:
+
+`selectorCreator: (...deps, resultFunc) => any`
+
+An option that allows the user to specify a different function to be used when creating selectors.
+
+The default is `createSelector` from `reselect`. See [recipes](#Recipes) for other uses.
 
 #### sliceState:
 
 `sliceState: (rootState, model) => any`
 
-An option that allows the user to specify how the state will be sliced before being passed to the selectors.
+An option that allows the user to specify how the state will be sliced in the `slice` function.
 The function takes the `rootState` as the first parameter and the `model` corresponding to the selector as the
 second parameter.  It should return the desired state slice required by the selector.
 
 The default is to return the slice of the state that corresponds to the owning model's name,
 but this assumes the store is a Javascript object. Most of the time the default should be used.
-However, there are some cases where one may want to specify the `sliceState` function.
+However, there are some cases where one may want to specify the `sliceState` function. See [the immutable.js recipe for an example.](#immutablejs)
 
-##### Example 1 - Use the root state in selectors as opposed to a slice:
 
-This can easily be accomplished by returning the `rootState` in the `getState` config:
+
+## Recipes
+
+### Re-reselect
+When working on a dashboard or doing calculations with a lot of external values, you may find your selectors always re-run. This happens when your selector has props (such as a `hasProps` factory) and then share your selectors between multiple components.
+
+Selectors have a cache size of 1. Passing a different set of props will invalidate the cache. [re-reselect exists to solve this by caching your selectors by props as well](https://github.com/toomuchdesign/re-reselect)
 
 ```js
-const select = selectorsPlugin({ sliceState: rootState => rootState });
+import { createCachedSelector } from 're-reselect'
+
+selectorPlugin({
+  selectorCreator: createCachedSelector
+})
 ```
 
-Now the `state` parameter that is passed to all of the selectors will be the root state.
+```js
+total () {
+  const mapProps = (state, props) => props.id
+  return createSelector(
+    slice,
+    mapProps,
+    (cart, id) => cart.reduce((a, b) => a + (b.price * b.amount), 0)
+  )(mapProps)
+}
+```
 
-##### Example 2 - Use an Immutable JS object as the store
+### Immutable.js
 
+**Use an Immutable JS object as the store**
 If you are using an [Immutable.js](https://facebook.github.io/immutable-js/) Map as your store, you will need to slice
 the state using [Map.get()](http://facebook.github.io/immutable-js/docs/#/Map/get):
 
 ```js
-const select = selectorsPlugin({ sliceState: (rootState, model) => rootState.get(model.name) })
+const select = selectorsPlugin({
+  sliceState: (rootState, model) =>
+    rootState.get(model.name)
+})
 ```
 
 Now you can use an [Immutable.js Map](http://facebook.github.io/immutable-js/docs/#/Map) as your store and access the

--- a/plugins/select/README.md
+++ b/plugins/select/README.md
@@ -106,7 +106,7 @@ total () {
 
 `@rematch/select` injects `select` into each selector factory to allow it to depend on other models state.
 
-> Its less redundant to give `select` the descriptive name `models` internally.
+> It's less redundant to give `select` the descriptive name `models` internally.
 
 > If your factory is a `function`, you can use `this` as a shortcut to the current model's selectors
 

--- a/plugins/select/README.md
+++ b/plugins/select/README.md
@@ -104,8 +104,9 @@ total () {
 
 ### Combining selectors
 
-`@rematch/select` injects `models` into each selector factory to allow it to depend on other models state.
+`@rematch/select` injects `select` into each selector factory to allow it to depend on other models state.
 
+> Its less redundant to give `select` the descriptive name `models` internally.
 
 > If your factory is a `function`, you can use `this` as a shortcut to the current model's selectors
 
@@ -151,15 +152,15 @@ wouldGetFreeShipping () {
 
 ## Using Selectors in your app
 
-Most apps will consume selectors through `connect`. For this use case, `@rematch/select` provides the `select` function to create a selector you can pass directly to connect, or call yourself. `select` ensures your component re-renders only when its data actually changes. 
+Most apps will consume selectors through `connect`. For this use case, the store's `select` can be called as a function to create a selector you can pass directly to connect, or call yourself. As a function, `select` ensures your component re-renders only when its data actually changes. 
 
 
-> Under the hood, `select` create a [structuredSelector](https://github.com/reduxjs/reselect#createstructuredselectorinputselectors-selectorcreator--createselector). 
+> Under the hood, `select` creates a [structuredSelector](https://github.com/reduxjs/reselect#createstructuredselectorinputselectors-selectorcreator--createselector). 
 
 
 ```js
 import { connect } from 'react-redux'
-import { select } from '@rematch/select'
+import { select } = './store'
 
 connect(select(models => {
   total: models.cart.total,
@@ -172,11 +173,9 @@ connect(select(models => {
 Selectors can also be called directly anywhere within your app.
 
 ```js
-import { selectors } from '@rematch/select'
-
 const store = init({ ... })
 
-selectors.cart.expensiveFilter(50.00)(store.getState())
+store.select.cart.expensiveFilter(50.00)(store.getState())
 ```
 
 
@@ -258,7 +257,7 @@ If you are using an [Immutable.js](https://facebook.github.io/immutable-js/) Map
 the state using [Map.get()](http://facebook.github.io/immutable-js/docs/#/Map/get):
 
 ```js
-const select = selectorsPlugin({
+selectorsPlugin({
   sliceState: (rootState, model) =>
     rootState.get(model.name)
 })

--- a/plugins/select/index.d.ts
+++ b/plugins/select/index.d.ts
@@ -1,9 +1,52 @@
-import { Action, ExtractRematchSelectorsFromModels, Models, Plugin } from '@rematch/core'
+// Type definitions for @rematch/select 2.0.0
+// Definitions by: Sam Richard <https://github.com/d3dc>
 
-export declare const select: {}
-export declare function getSelect<M extends Models = Models>(): ExtractRematchSelectorsFromModels<M, any>
+import { Action, Models, Plugin } from '@rematch/core'
+
+import * as Reselect from 'reselect'
+
 export interface SelectConfig {
-    sliceState?: any
+    sliceState?: any;
+    selectorCreator?: any;
 }
-declare const selectPlugin: ({ sliceState, }?: SelectConfig) => Plugin<Models, Action<any, any>>
+
+declare const selectPlugin: (config?: SelectConfig) => Plugin<Models, Action<any, any>>
 export default selectPlugin
+
+type RematchSelector<S, P = any, R = any> =
+    Reselect.Selector<S, R>
+    | Reselect.ParametricSelector<S, P, R>
+
+type ModelSelectors<S> = {
+    [key: string]: RematchSelector<S>
+}
+
+type StoreSelectors<S> = {
+    [key: string]: ModelSelectors<S>
+}
+
+type ModelSelectorFactories<S> = {
+    [key: string]: (
+        this: ModelSelectors<S>,
+        models: StoreSelectors<S>
+    ) => ModelSelectors<S>
+}
+
+type RematchSelect<M extends Models | void = void, RootState = any> =
+ (
+    (mapSelectToProps: (select: RematchSelect<M,RootState>) => object) =>
+        Reselect.OutputParametricSelector<RootState, any, object, Reselect.Selector<RootState, object>>
+ ) & StoreSelectors<RootState>
+
+declare module '@rematch/core' {
+    
+    export interface ModelConfig<S = any, SS = S> {
+        selectors?: ModelSelectorFactories<S> | ((models: StoreSelectors<S>) => ModelSelectorFactories<S>);
+    }
+    
+    export interface RematchStore<M extends Models = Models, A extends Action = Action> {
+        select: RematchSelect<M>;
+    }
+    
+}
+

--- a/plugins/select/package-lock.json
+++ b/plugins/select/package-lock.json
@@ -5,9 +5,8 @@
   "requires": true,
   "dependencies": {
     "@rematch/core": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@rematch/core/-/core-1.0.0-beta.2.tgz",
-      "integrity": "sha512-qBtM8Da2gfeqXLwYxzDtOPV4grWtaHDWI9CMN5A7/M+TtgPE0jJEi5z+xQO3wqb9628xzYDLOMgEpwBYC2r5wQ==",
+      "version": "github:rematch/rematch#d752096a1b677f01930ea3f58e61fb17cdb1f6e7",
+      "from": "github:rematch/rematch",
       "dev": true,
       "requires": {
         "redux": "4.0.0"

--- a/plugins/select/package-lock.json
+++ b/plugins/select/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "@rematch/select",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@rematch/core": {
-      "version": "github:rematch/rematch#d752096a1b677f01930ea3f58e61fb17cdb1f6e7",
-      "from": "github:rematch/rematch",
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/@rematch/core/-/core-1.0.0-beta.4.tgz",
+      "integrity": "sha512-V5cVhRvG2ab/sdKRUgn8xaIxMhwjtJPomSVcmjxJbSQrAm7/lzELY7WPJSIuXrQG1tiSPOlkoRqyQ3kOQdX8NQ==",
       "dev": true,
       "requires": {
         "redux": "4.0.0"

--- a/plugins/select/package-lock.json
+++ b/plugins/select/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@rematch/core": {
-      "version": "1.0.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@rematch/core/-/core-1.0.0-alpha.8.tgz",
-      "integrity": "sha512-QA9BO3DjHlchMb/Mw/ZcYI9D3fuK2mS+VTDdd+uv2z9o8He8N36N2ivh6jE8OfYDCa73vVuZiCt32ugG0qxsCw==",
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@rematch/core/-/core-1.0.0-beta.2.tgz",
+      "integrity": "sha512-qBtM8Da2gfeqXLwYxzDtOPV4grWtaHDWI9CMN5A7/M+TtgPE0jJEi5z+xQO3wqb9628xzYDLOMgEpwBYC2r5wQ==",
       "dev": true,
       "requires": {
         "redux": "4.0.0"
@@ -458,6 +458,11 @@
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
+    },
+    "reselect": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
+      "integrity": "sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc="
     },
     "resolve": {
       "version": "1.7.1",

--- a/plugins/select/package.json
+++ b/plugins/select/package.json
@@ -32,7 +32,7 @@
   },
   "browser": "dist/rematch-select.umd.js",
   "devDependencies": {
-    "@rematch/core": "^1.0.0-beta.1",
+    "@rematch/core": "1.0.0-beta.3",
     "rollup": "^0.60.1",
     "rollup-plugin-commonjs": "^9.1.3",
     "rollup-plugin-replace": "^2.0.0",
@@ -42,7 +42,7 @@
     "uglify-es": "^3.3.9"
   },
   "peerDependencies": {
-    "@rematch/core": ">=1.0.0-beta.1"
+    "@rematch/core": "1.0.0-beta.3"
   },
   "dependencies": {
     "reselect": "^3.0.1"

--- a/plugins/select/package.json
+++ b/plugins/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rematch/select",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Selectors plugin for Rematch",
   "keywords": [
     "plugin",
@@ -48,6 +48,7 @@
     "reselect": "^3.0.1"
   },
   "authors": [
+    "Sam Richard <sam.richard@gmail.com> (https://github.com/d3dc)",
     "Blair Bodnar <blairbodnar@gmail.com> (https://github.com/blairbodnar)",
     "Tom Aranda <tga@arandacybersolutions.com> (https://github.com/taranda)"
   ]

--- a/plugins/select/package.json
+++ b/plugins/select/package.json
@@ -32,7 +32,7 @@
   },
   "browser": "dist/rematch-select.umd.js",
   "devDependencies": {
-    "@rematch/core": "^1.0.0-alpha.8",
+    "@rematch/core": "^1.0.0-beta.1",
     "rollup": "^0.60.1",
     "rollup-plugin-commonjs": "^9.1.3",
     "rollup-plugin-replace": "^2.0.0",
@@ -42,7 +42,10 @@
     "uglify-es": "^3.3.9"
   },
   "peerDependencies": {
-    "@rematch/core": ">=1.0.0-alpha.8"
+    "@rematch/core": ">=1.0.0-beta.1"
+  },
+  "dependencies": {
+    "reselect": "^3.0.1"
   },
   "authors": [
     "Blair Bodnar <blairbodnar@gmail.com> (https://github.com/blairbodnar)",

--- a/plugins/select/package.json
+++ b/plugins/select/package.json
@@ -32,7 +32,7 @@
   },
   "browser": "dist/rematch-select.umd.js",
   "devDependencies": {
-    "@rematch/core": "1.0.0-beta.3",
+    "@rematch/core": "^1.0.0-beta.5",
     "rollup": "^0.60.1",
     "rollup-plugin-commonjs": "^9.1.3",
     "rollup-plugin-replace": "^2.0.0",
@@ -42,7 +42,7 @@
     "uglify-es": "^3.3.9"
   },
   "peerDependencies": {
-    "@rematch/core": "1.0.0-beta.3"
+    "@rematch/core": "1.0.0-beta.5"
   },
   "dependencies": {
     "reselect": "^3.0.1"

--- a/plugins/select/src/index.ts
+++ b/plugins/select/src/index.ts
@@ -1,44 +1,125 @@
-import { ExtractRematchSelectorsFromModels, Model, Models, Plugin } from '@rematch/core'
+import { Store, Model, Plugin } from '@rematch/core'
+import { createSelector, createStructuredSelector } from 'reselect'
+export { createSelector, createStructuredSelector } from 'reselect'
 
-export const select = {}
+export const selectors = {}
 
-export function getSelect<M extends Models = Models>() {
-	return select as ExtractRematchSelectorsFromModels<M>
+/**
+ * Maps models to structured selector
+ * @param  mapModelsToSelectors function that gets passed `selectors` and returns an object
+ * @param  structuredSelectorCreator=createStructuredSelector if you need to provide your own implementation
+ *
+ * @return the result of calling `structuredSelectorCreator` with the new selectors
+ */
+export function select(
+	mapModelsToSelectors: any,
+	structuredSelectorCreator = createStructuredSelector
+) {
+	let func = (state, props) => {
+		func = structuredSelectorCreator(mapModelsToSelectors(selectors))
+		return func(state, props)
+	}
+
+	return (state, props) => func(state, props)
 }
 
 export interface SelectConfig {
-	sliceState?: any,
+	sliceState?: any;
+	selectorCreator?: any;
 }
 
-const selectPlugin = ({
-	sliceState = (rootState, model) => rootState[model.name],
-}: SelectConfig = {}): Plugin => ({
-	exposed: { select },
-	onInit() {
-		this.validate([
-			[
-					typeof sliceState !== 'function',
-					`The selectPlugin's getState config must be a function. Instead got type ${typeof sliceState}.`,
-				],
-			])
-	},
-	onModel(model: Model) {
-		select[model.name] = {}
+const validateConfig = config => {
+	if (config.sliceState && typeof config.sliceState !== 'function') {
+		throw new Error('select plugin config sliceState must be a function')
+	}
+	if (config.selectorCreator && typeof config.selectorCreator !== 'function') {
+		throw new Error('select plugin config selectorCreator must be a function')
+	}
+}
 
-		Object.keys(model.selectors || {}).forEach((selectorName: string) => {
-			this.validate([
-				[
-					typeof model.selectors[selectorName] !== 'function',
-					`Selector (${model.name}/${selectorName}) must be a function`,
-				],
-			])
-			select[model.name][selectorName] = (state: any, ...args) =>
-				model.selectors[selectorName](
-					sliceState(state, model),
-					...args,
-				)
-		})
-	},
-})
+const createSelectPlugin = (config: SelectConfig = {}): Plugin => {
+	validateConfig(config)
 
-export default selectPlugin
+	const sliceState = config.sliceState || ((state, model) => state[model.name])
+	const selectorCreator = config.selectorCreator || createSelector
+
+	const slice = model => stateOrNext => {
+		if (typeof stateOrNext === 'function') {
+			return selectorCreator(state => sliceState(state, model), stateOrNext)
+		}
+		return sliceState(stateOrNext, model)
+	}
+
+	const hasProps = inner =>
+		function(models) {
+			return selectorCreator(
+				props => props,
+				props => inner.call(this, models, props)
+			)
+		}
+
+	let ready = false
+	const factories = new Set()
+	const addFactories = added => {
+		if (!ready) {
+			added.forEach(factory => factories.add(factory))
+		} else {
+			added.forEach(factory => factory())
+		}
+	}
+	const startBuilding = () => {
+		ready = true
+		factories.forEach(factory => factory())
+	}
+
+	return {
+		exposed: {
+			select,
+			selectors,
+			sliceState,
+			selectorCreator,
+		},
+		onModel(model: Model) {
+			selectors[model.name] = {}
+
+			const selectorFactories =
+				typeof model.selectors === 'function'
+					? model.selectors(slice(model), selectorCreator, hasProps)
+					: model.selectors
+
+			addFactories(
+				Object.keys(selectorFactories || {}).map((selectorName: string) => {
+					this.validate([
+						[
+							typeof selectorFactories[selectorName] !== 'function',
+							`Selector (${model.name}/${selectorName}) must be a function`,
+						],
+					])
+
+					const factory = () => {
+						factories.delete(factory)
+						delete selectors[model.name][selectorName]
+						return (selectors[model.name][selectorName] = selectorFactories[
+							selectorName
+						].call(selectors[model.name], selectors))
+					}
+
+					// Define a getter for early constructing
+					Object.defineProperty(selectors[model.name], selectorName, {
+						configurable: true,
+						get() {
+							return factory()
+						},
+					})
+
+					return factory
+				})
+			)
+		},
+		onStoreCreated(store: Store) {
+			startBuilding()
+		},
+	}
+}
+
+export default createSelectPlugin

--- a/plugins/select/src/index.ts
+++ b/plugins/select/src/index.ts
@@ -5,17 +5,17 @@ export { createSelector, createStructuredSelector } from 'reselect'
 const makeSelect = () => {
 	/**
 	 * Maps models to structured selector
-	 * @param  mapModelsToSelectors function that gets passed `selectors` and returns an object
+	 * @param  mapSelectToStructure function that gets passed `selectors` and returns an object
 	 * @param  structuredSelectorCreator=createStructuredSelector if you need to provide your own implementation
 	 *
 	 * @return the result of calling `structuredSelectorCreator` with the new selectors
 	 */
 	function select(
-		mapModelsToSelectors: any,
+		mapSelectToStructure: any,
 		structuredSelectorCreator = createStructuredSelector
 	) {
 		let func = (state, props) => {
-			func = structuredSelectorCreator(mapModelsToSelectors(select))
+			func = structuredSelectorCreator(mapSelectToStructure(select))
 			return func(state, props)
 		}
 

--- a/plugins/select/test/select.test.js
+++ b/plugins/select/test/select.test.js
@@ -1,5 +1,4 @@
 const selectPlugin = require('../src').default
-const { selectors, select } = require('../src')
 const { init } = require('../../../src')
 
 describe('select:', () => {
@@ -44,11 +43,11 @@ describe('select:', () => {
 					double: () => s => s.a * 2,
 				},
 			}
-			init({
+			const store = init({
 				models: { a },
 				plugins: [selectPlugin()],
 			})
-			expect(typeof selectors.a.double).toBe('function')
+			expect(typeof store.select.a.double).toBe('function')
 		})
 
 		it('should allow access to a function', () => {
@@ -66,7 +65,7 @@ describe('select:', () => {
 				plugins: [selectPlugin()],
 			})
 			const state = store.getState()
-			const doubled = selectors.a.double(state)
+			const doubled = store.select.a.double(state)
 			expect(doubled).toBe(4)
 		})
 
@@ -85,7 +84,9 @@ describe('select:', () => {
 				plugins: [selectPlugin()],
 			})
 			const state = store.getState()
-			const prepended = selectors.a.prependWithLetter(state, { letter: 'P' })
+			const prepended = store.select.a.prependWithLetter(state, {
+				letter: 'P',
+			})
 			expect(prepended).toBe('P2')
 		})
 	})
@@ -104,7 +105,7 @@ describe('select:', () => {
 				plugins: [selectPlugin()],
 			})
 			const state = store.getState()
-			const doubled = selectors.count.double(state)
+			const doubled = store.select.count.double(state)
 			expect(doubled).toBe(4)
 		})
 
@@ -120,7 +121,7 @@ describe('select:', () => {
 				plugins: [selectPlugin()],
 			})
 			const state = store.getState()
-			const doubled = selectors.count.double(state)
+			const doubled = store.select.count.double(state)
 			expect(doubled).toBe(4)
 		})
 
@@ -136,7 +137,7 @@ describe('select:', () => {
 				plugins: [selectPlugin()],
 			})
 			const state = store.getState()
-			const doubled = selectors.count.double(state)
+			const doubled = store.select.count.double(state)
 			expect(doubled).toBe(4)
 		})
 
@@ -161,7 +162,7 @@ describe('select:', () => {
 				plugins: [selectPlugin()],
 			})
 			const state = store.getState()
-			const result = selectors.combined.value(state)
+			const result = store.select.combined.value(state)
 			expect(result).toBe(24)
 		})
 
@@ -180,7 +181,7 @@ describe('select:', () => {
 					plugins: [selectPlugin()],
 				})
 				const state = store.getState()
-				const prepended = selectors.a.prependWithLetter('P')(state)
+				const prepended = store.select.a.prependWithLetter('P')(state)
 				expect(prepended).toBe('P2')
 			})
 		})
@@ -219,7 +220,7 @@ describe('select:', () => {
 			})
 
 			const state = store.getState()
-			const result = selectors.countC.calc(state)
+			const result = store.select.countC.calc(state)
 			expect(result).toBe(27)
 		})
 	})
@@ -244,7 +245,7 @@ describe('select:', () => {
 			})
 
 			const state = store.getState()
-			const selector = select(models => ({
+			const selector = store.select(models => ({
 				a: models.countA.double,
 				b: models.countB.double,
 			}))
@@ -295,7 +296,7 @@ describe('select:', () => {
 			})
 
 			const state = store.getState()
-			const result = selectors.countB.double(state)
+			const result = store.select.countB.double(state)
 			expect(result).toBe(4)
 		})
 	})

--- a/plugins/select/test/select.test.js
+++ b/plugins/select/test/select.test.js
@@ -1,220 +1,302 @@
-const { createSelector } = require('reselect')
 const selectPlugin = require('../src').default
-const { select } = require('../src')
+const { selectors, select } = require('../src')
 const { init } = require('../../../src')
 
 describe('select:', () => {
-  it('should create a valid list of selectors', () => {
-    const a = {
-      state: 0,
-      reducers: {
-        increment: s => s + 1,
-      },
-      selectors: {
-        double: s => s * 2,
-      },
-    }
-    init({
-      models: { a },
-      plugins: [selectPlugin()]
-    })
-    expect(typeof select.a.double).toBe('function')
-  })
+	test('should not throw if no selectors', () => {
+		const a = {
+			state: 2,
+			reducers: {
+				increment: s => s + 1,
+			},
+		}
+		const start = () =>
+			init({
+				models: { a },
+				plugins: [selectPlugin()],
+			})
+		expect(start).not.toThrow()
+	})
 
-  it('should allow access to the selector', () => {
-    const a = {
-      state: 2,
-      reducers: {
-        increment: s => s + 1,
-      },
-      selectors: {
-        double: s => s * 2,
-      },
-    }
-    const store = init({
-      models: { a },
-      plugins: [selectPlugin()]
-    })
-    const state = store.getState()
-    const doubled = select.a.double(state)
-    expect(doubled).toBe(4)
-  })
+	test('should throw if any selector is not a function or descriptor', () => {
+		const store = init({
+			plugins: [selectPlugin()],
+		})
+		expect(() =>
+			store.model({
+				name: 'a',
+				state: 2,
+				selectors: {
+					invalid: 42,
+				},
+			})
+		).toThrow()
+	})
 
-  it('should allow passing in of params toselector', () => {
-    const a = {
-      state: 2,
-      reducers: {
-        increment: s => s + 1,
-      },
-      selectors: {
-        prependWithLetter: (s, letter) => letter + s
-      },
-    }
-    const store = init({
-      models: { a },
-      plugins: [selectPlugin()]
-    })
-    const state = store.getState()
-    const prepended = select.a.prependWithLetter(state, 'P')
-    expect(prepended).toBe('P2')
-  })
+	describe('externally created:', () => {
+		it('should register a function', () => {
+			const a = {
+				state: 0,
+				reducers: {
+					increment: s => s + 1,
+				},
+				selectors: {
+					double: () => s => s.a * 2,
+				},
+			}
+			init({
+				models: { a },
+				plugins: [selectPlugin()],
+			})
+			expect(typeof selectors.a.double).toBe('function')
+		})
 
-  test('should throw if selector is not a function', () => {
-    const store = init({
-      plugins: [selectPlugin()]
-    })
-    expect(() => store.model({
-      name: 'a',
-      state: 2,
-      selectors: {
-        invalid: 42,
-      },
-    })).toThrow()
-  })
+		it('should allow access to a function', () => {
+			const a = {
+				state: 2,
+				reducers: {
+					increment: s => s + 1,
+				},
+				selectors: {
+					double: () => s => s.a * 2,
+				},
+			}
+			const store = init({
+				models: { a },
+				plugins: [selectPlugin()],
+			})
+			const state = store.getState()
+			const doubled = selectors.a.double(state)
+			expect(doubled).toBe(4)
+		})
 
-  test('should not throw if no selectors', () => {
-    const a = {
-      state: 2,
-      reducers: {
-        increment: s => s + 1,
-      },
-    }
-    const start = () => init({
-      models: { a },
-      plugins: [selectPlugin()]
-    })
-    expect(start).not.toThrow()
-  })
+		it('should allow passing in of params to a function', () => {
+			const a = {
+				state: 2,
+				reducers: {
+					increment: s => s + 1,
+				},
+				selectors: {
+					prependWithLetter: () => (s, { letter }) => letter + s.a,
+				},
+			}
+			const store = init({
+				models: { a },
+				plugins: [selectPlugin()],
+			})
+			const state = store.getState()
+			const prepended = selectors.a.prependWithLetter(state, { letter: 'P' })
+			expect(prepended).toBe('P2')
+		})
+	})
 
-  describe('reselect: ', () => {
-    it('should allow for createSelector to be used instead of a normal selector', () => {
-      const count = {
-        state: 2,
-        selectors: {
-          double: createSelector(
-            state => state,
-            c => c * 2
-          )
-        },
-      }
-      const store = init({
-        models: { count },
-        plugins: [selectPlugin()]
-      })
-      const state = store.getState()
-      const doubled = select.count.double(state)
-      expect(doubled).toBe(4)
-    })
+	describe('internally created: ', () => {
+		it('should create a selector', () => {
+			const count = {
+				state: 2,
+				selectors: (slice, createSelector) => ({
+					double: () =>
+						createSelector(state => state, state => state.count * 2),
+				}),
+			}
+			const store = init({
+				models: { count },
+				plugins: [selectPlugin()],
+			})
+			const state = store.getState()
+			const doubled = selectors.count.double(state)
+			expect(doubled).toBe(4)
+		})
 
-    it('should allow createSelector to be used outside of a model', () => {
-      const countA = {
-        state: 2,
-        selectors: {
-          double: state => state * 2
-        }
-      }
-      const countB = {
-        state: 10,
-        selectors: {
-          double: state => state * 2
-        }
-      }
-      const store = init({
-        models: { countA, countB },
-        plugins: [selectPlugin()]
-      })
-      const outsideSelector = createSelector(
-        select.countA.double,
-        select.countB.double,
-        (countADoubled, countBDoubled) => countADoubled + countBDoubled
-      )
+		it('should create a selector for slice', () => {
+			const count = {
+				state: 2,
+				selectors: (slice, createSelector) => ({
+					double: () => createSelector(slice, c => c * 2),
+				}),
+			}
+			const store = init({
+				models: { count },
+				plugins: [selectPlugin()],
+			})
+			const state = store.getState()
+			const doubled = selectors.count.double(state)
+			expect(doubled).toBe(4)
+		})
 
-      const state = store.getState()
-      const result = outsideSelector(state)
-      expect(result).toBe(24)
-    })
+		it('should allow for slice shorthand', () => {
+			const count = {
+				state: 2,
+				selectors: slice => ({
+					double: () => slice(c => c * 2),
+				}),
+			}
+			const store = init({
+				models: { count },
+				plugins: [selectPlugin()],
+			})
+			const state = store.getState()
+			const doubled = selectors.count.double(state)
+			expect(doubled).toBe(4)
+		})
 
-    it('should allow for mixing normal selectors and reselect selectors', () => {
-      const countA = {
-        state: 2,
-        selectors: {
-          double: state => state * 2,
-          plusOne: createSelector(
-            state => state,
-            c => c + 1
-          )
-        }
-      }
-      const countB = {
-        state: 10,
-        selectors: {
-          double: createSelector(
-            state => state,
-            c => c * 2
-          )
-        }
-      }
+		it('create a selector with dependencies', () => {
+			const countA = {
+				state: 2,
+				selectors: {
+					double: () => state => state.countA * 2,
+				},
+			}
+			const combined = {
+				state: 10,
+				selectors: (slice, createSelector) => ({
+					double: () => slice(b => b * 2),
+					value({ countA }) {
+						return createSelector(this.double, countA.double, (b, a) => a + b)
+					},
+				}),
+			}
+			const store = init({
+				models: { countA, combined },
+				plugins: [selectPlugin()],
+			})
+			const state = store.getState()
+			const result = selectors.combined.value(state)
+			expect(result).toBe(24)
+		})
 
-      const store = init({
-        models: { countA, countB },
-        plugins: [selectPlugin()]
-      })
+		describe('creating selectors with hasProps factory: ', () => {
+			it('should create a selector with hasProps factory', () => {
+				const a = {
+					state: 2,
+					selectors: (slice, createSelector, hasProps) => ({
+						prependWithLetter: hasProps((models, letter) =>
+							slice(a => letter + a)
+						),
+					}),
+				}
+				const store = init({
+					models: { a },
+					plugins: [selectPlugin()],
+				})
+				const state = store.getState()
+				const prepended = selectors.a.prependWithLetter('P')(state)
+				expect(prepended).toBe('P2')
+			})
+		})
 
-      const outsideSelector = createSelector(
-        select.countA.double,
-        select.countA.plusOne,
-        select.countB.double,
-        (countADoubled, countAPlusOne, countBDoubled) =>
-          countADoubled + countAPlusOne + countBDoubled
-      )
+		it('should allow for mixing external and internal selectors', () => {
+			const countA = {
+				state: 2,
+				selectors: (slice, createSelector) => ({
+					double: () => state => state.countA * 2,
+					plusOne: () => slice(c => c + 1),
+				}),
+			}
+			const countB = {
+				state: 10,
+				selectors: (slice, createSelector) => ({
+					double: () => createSelector(slice, c => c * 2),
+				}),
+			}
+			const countC = {
+				state: 0,
+				selectors: (slice, createSelector) => ({
+					calc: ({ countA, countB }) =>
+						createSelector(
+							countA.double,
+							countA.plusOne,
+							countB.double,
+							(countADoubled, countAPlusOne, countBDoubled) =>
+								countADoubled + countAPlusOne + countBDoubled
+						),
+				}),
+			}
 
-      const state = store.getState()
-      const result = outsideSelector(state)
-      expect(result).toBe(27)
-    })
+			const store = init({
+				models: { countA, countB, countC },
+				plugins: [selectPlugin()],
+			})
 
+			const state = store.getState()
+			const result = selectors.countC.calc(state)
+			expect(result).toBe(27)
+		})
+	})
 
-  })
+	describe('select function: ', () => {
+		it('should create structural selector', () => {
+			const countA = {
+				state: 2,
+				selectors: {
+					double: () => state => state.countA * 2,
+				},
+			}
+			const countB = {
+				state: 10,
+				selectors: {
+					double: () => state => state.countB * 2,
+				},
+			}
+			const store = init({
+				models: { countA, countB },
+				plugins: [selectPlugin()],
+			})
 
-  describe('sliceState config: ', () => {
-    test('should throw if sliceState config is not a function', () => {
-      const selectPlugin = require('../src').default
-      const { init } = require('../../../src')
+			const state = store.getState()
+			const selector = select(models => ({
+				a: models.countA.double,
+				b: models.countB.double,
+			}))
+			const result = selector(state)
+			expect(result).toEqual({ a: 4, b: 20 })
+		})
+	})
 
-      const start = () => {
-        init({ plugins: [ selectPlugin({ sliceState: 'error' }) ] });
-      }
+	describe('selectorCreator config: ', () => {
+		test('should throw if selectorCreator config is not a function', () => {
+			const start = () => {
+				init({ plugins: [selectPlugin({ selectorCreator: 'error' })] })
+			}
 
-      expect(start).toThrow();
-    })
+			expect(start).toThrow()
+		})
+	})
 
-    it('should allow access to the global state with a property configured sliceState method', () => {
-      const selectPlugin = require('../src').default
-      const { select } = require('../src')
-      const { init } = require('../../../src')
+	describe('sliceState config: ', () => {
+		test('should throw if sliceState config is not a function', () => {
+			const selectPlugin = require('../src').default
+			const { init } = require('../../../src')
 
-      const countA = {
-        state: 2,
-        selectors: {
-          double: state => state.countB * 2,
-        }
-      }
-      const countB = {
-        state: 10,
-        selectors: {
-          double: state => state.countA * 2
-        }
-      }
+			const start = () => {
+				init({ plugins: [selectPlugin({ sliceState: 'error' })] })
+			}
 
-      const store = init({
-        models: { countA, countB },
-        plugins: [selectPlugin({ sliceState: (rootState) => rootState })]
-      })
+			expect(start).toThrow()
+		})
 
-      const state = store.getState()
-      const result = select.countB.double(state)
-      expect(result).toBe(4)
-    })
-  })
+		it('should allow access to the global state with a property configured sliceState method', () => {
+			const countA = {
+				state: 2,
+				selectors: slice => ({
+					double: () => slice(state => state.countB * 2),
+				}),
+			}
+			const countB = {
+				state: 10,
+				selectors: slice => ({
+					double: () => slice(state => state.countA * 2),
+				}),
+			}
+
+			const store = init({
+				models: { countA, countB },
+				plugins: [selectPlugin({ sliceState: rootState => rootState })],
+			})
+
+			const state = store.getState()
+			const result = selectors.countB.double(state)
+			expect(result).toBe(4)
+		})
+	})
 })
-

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -55,16 +55,6 @@ export type ExtractRematchDispatchersFromModels<M extends Models> = {
   [modelKey in keyof M]: ExtractRematchDispatchersFromModel<M[modelKey]>
 }
 
-export type ExtractRematchSelectorsFromModels<M extends Models, RootState = any> = {
-  [modelKey in keyof M]: {
-    [reducerKey in keyof M[modelKey]['selectors']]:
-    (state: RematchRootState<M>, ...args: any[]) =>
-      M[modelKey]['selectors'][reducerKey] extends ((...args: any[]) => any)
-        ? ReturnType<M[modelKey]['selectors'][reducerKey]>
-        : {}
-  }
-}
-
 export type RematchDispatcher<P = void, M = void> =
   ((action: Action<P, M>) => Redux.Dispatch<Action<P, M>>) &
   ((action: Action<P, void>) => Redux.Dispatch<Action<P, void>>) &
@@ -160,9 +150,6 @@ export interface ModelConfig<S = any, SS = S> {
   baseReducer?: (state: SS, action: Action) => SS,
   reducers?: ModelReducers<S>,
   effects?: ModelEffects<any> | ((dispatch: RematchDispatch) => ModelEffects<any>),
-  selectors?: {
-    [key: string]: (state: SS, ...args: any[]) => any,
-  },
   subscriptions?: {
     [matcher: string]: (action: Action) => void,
   },


### PR DESCRIPTION
I typed a lot about the importance of dependency injection and getting data out of the state in #413.

The advantage I see to the current recommendation of "import your own selectors" is that you can declare inputs to selectors much more directly. All the select plugin currently does is remove control over that from you.

This PR seeks to make it more natural to handle the entire API of `reselect` inside the models.

First off, it imports `reselect` directly, and lets you override this through configuration. If we're imitating the `reselect` api, why not just be the `reselect` api?

Models are auto-wired with dependencies, completely decoupling them for testing:
```js
{
  state: 1,
  selectors: (slice, createSelector, hasProps) => ({
    valueA () {
      return slice(a => a)
    },
    valueB () {
      return createSelector(slice, a => a)
    },
    valueC (models) {
      return createSelector(slice, models.other.b, (a, b) => a + b)
    },
    valueD: hasProps(function(models, props) {
      return createSelector(slice, a => a + props))
    })
  })
}
```

Since the plugin is built around the `reselect` api, why not make it the default to get a little more performance and change `select`:
```js
connect(select(models => ({
  x: models.one.a,
  y: models.two.b
})))
```

This makes a [structuredSelector](https://github.com/reduxjs/reselect#createstructuredselectorinputselectors-selectorcreator--createselector) or you can configure it too.


**Todo:**
- [x] tests
- [x] docs
- [x] examples

### Typing could be improved
