### PR TITLE
[loading] don't always resolve result

### DIFF
--- a/plugins/loading/src/index.ts
+++ b/plugins/loading/src/index.ts
@@ -118,15 +118,15 @@ export default (config: LoadingConfig = {}): Plugin => {
 
         // create function with pre & post loading calls
         const effectWrapper = async (...props) => {
-          let effectResult
-
           try {
             this.dispatch.loading.show({ name, action })
-            effectResult = await origEffect(...props)
             // waits for dispatch function to finish before calling "hide"
-          } finally {
+            const effectResult = await origEffect(...props)
             this.dispatch.loading.hide({ name, action })
             return effectResult
+          } catch(error) {
+            this.dispatch.loading.hide({ name, action })
+            throw error
           }
         }
 

--- a/plugins/loading/test/loading-asBoolean.test.js
+++ b/plugins/loading/test/loading-asBoolean.test.js
@@ -307,4 +307,22 @@ describe('loading asBoolean', () => {
 
     expect(effectResult).toEqual('foo')
   })
+
+  test('should allow the propagation of the effect reject', async () => {
+    const count2 = {
+      state: 0,
+      effects: {
+        doSomething() {
+          throw 'foo'
+        }
+      }
+    }
+    const store = init({
+      models: { count: count2 },
+      plugins: [loadingPlugin()]
+    })
+
+    const promise = store.dispatch.count.doSomething()
+    await expect(promise).rejects.toBe('foo')
+  })
 })

--- a/plugins/loading/test/loading-asNumber.test.js
+++ b/plugins/loading/test/loading-asNumber.test.js
@@ -326,4 +326,22 @@ describe('loading asNumbers', () => {
 
     expect(effectResult).toEqual('foo')
   })
+
+  test('should allow the propagation of the effect reject', async () => {
+    const count2 = {
+      state: 0,
+      effects: {
+        doSomething() {
+          throw 'foo'
+        }
+      }
+    }
+    const store = init({
+      models: { count: count2 },
+      plugins: [loadingPlugin({ asNumber: true })]
+    })
+
+    const promise = store.dispatch.count.doSomething()
+    await expect(promise).rejects.toBe('foo')
+  })
 })


### PR DESCRIPTION
right now the `loading` plugin always resolve result even if we reject in the effect, it resolves with `undefined`