### PR TITLE
Actions plugin to replace effects and selectors

### DIFF
--- a/plugins/actions/index.js
+++ b/plugins/actions/index.js
@@ -65,8 +65,8 @@ export default {
         )
 
         // Bind exposed dispatch[modelName][actionName] to call actions[actionName]
-        this.dispatch[model.name][actionName] = payload =>
-          actions[actionName].call(this.dispatch[model.name], payload)
+        this.dispatch[model.name][actionName] = (...params) =>
+          actions[actionName].apply(this.dispatch[model.name], params)
       } else if (typeof actions[actionName] === 'object') {
         // Bind exposed actions[modelName/actionName] to dispatch(actions[actionName])
         this.actions[`${model.name}/${actionName}`] = () =>

--- a/plugins/actions/index.js
+++ b/plugins/actions/index.js
@@ -1,0 +1,95 @@
+export default {
+  exposed: {
+    // access exposed actions obj using this.actions
+    actions: {},
+    storeDispatch() {
+      console.warn('Warning: store not yet loaded')
+    },
+    storeGetState() {
+      console.warn('Warning: store not yet loaded')
+    },
+    // Because we do not have access to store until the store is initialized,
+    // Create a reference point for dispatch and getState that onModel can call.
+    dispatch(action) {
+      return this.storeDispatch(action)
+    },
+    getState() {
+      return this.storeGetState()
+    },
+  },
+  onStoreCreated(store) {
+    this.storeDispatch = store.dispatch
+    this.storeGetState = store.getState
+  },
+  onModel(model) {
+    if (!model.actions) {
+      return
+    }
+    if (
+      typeof model.actions !== 'function' &&
+      typeof model.actions !== 'object'
+    ) {
+      throw new Error('actions must be a function or an object')
+    }
+
+    // model.actions can be a function that takes dispatch and getState as callback params
+    // or simply just an object (if you don't need to use dispatch and getState)
+    const actions =
+      typeof model.actions === 'function'
+        ? model.actions({
+            dispatch: this.dispatch,
+            getState: this.getState,
+          })
+        : model.actions
+
+    for (const actionName of Object.keys(actions)) {
+      this.validate([
+        [
+          !!actionName.match(/\//),
+          `Invalid action name (${model.name}/${actionName})`,
+        ],
+        [
+          typeof actions[actionName] !== 'function' &&
+            typeof actions[actionName] !== 'object',
+          `Invalid action (${
+            model.name
+          }/${actionName}). Must be a function or an object`,
+        ],
+      ])
+
+      if (typeof actions[actionName] === 'function') {
+        // Bind exposed actions[modelName/actionName] to call actions[actionName]
+        // actions[modelName/actionName] will be called from middleware
+        this.actions[`${model.name}/${actionName}`] = actions[actionName].bind(
+          this.dispatch[model.name]
+        )
+
+        // Bind exposed dispatch[modelName][actionName] to call actions[actionName]
+        this.dispatch[model.name][actionName] = payload =>
+          actions[actionName].call(this.dispatch[model.name], payload)
+      } else if (typeof actions[actionName] === 'object') {
+        // Bind exposed actions[modelName/actionName] to dispatch(actions[actionName])
+        this.actions[`${model.name}/${actionName}`] = () =>
+          this.dispatch(actions[actionName])
+
+        // Bind exposed dispatch[modelName][actionName] to dispatch(actions[actionName])
+        this.dispatch[model.name][actionName] = () =>
+          this.dispatch(actions[actionName])
+      }
+    }
+  },
+  middleware(store) {
+    return next => action => {
+      if (action.type in this.actions) {
+        next(action)
+        return this.actions[action.type](
+          action.payload,
+          store.getState(),
+          action.meta
+        )
+      } else {
+        return next(action)
+      }
+    }
+  },
+}


### PR DESCRIPTION
I have been using rematch for the past 2 weeks.
This is the best redux library ever,
but I ran into a couple of annoying problems: 
1. calling effects plugin through dispatch.modelName.effectName not resolving synchronously, but rather dispatches an action that hopefully gets resolved by middleware. Also calling dispatch.modelName.effectName does not return what my function in effects returns and always wrap it in a Promise.
2. using selectors plugin is broken in 1.x.
3. Using selector plugin cannot reference your own or other selectors easily.

I created actions plugin that not only combines both effects and selectors plugin but also solves my problems stated above.

Actions is like combining mapStateToProps, mapDispatchToProps, and redux-thunk all at once.

To use actions plugin

### 1. add it as a plugin
```js
// src/store.js
import * as models from 'src/models'
import actionsPlugin from '@rematch/actions'
export const store = init({
  models,
  plugins: [actionsPlugin],
})
export const { dispatch, getState } = store
```

### 2. define actions inside your model
```js
// src/models/index.js

export const cart = {
 state: {},
 actions: ({dispatch, getState})=> {
    
 }
}

```

### 3. actions can call your own reducers, other reducers, and other actions zero, one, or many times synchronously or asynchronously.

```js
// src/models/index.js

export const cart = {
  state: 0,
  reducer: {
    increment: state => state + 1,
  },
  actions: ({ dispatch, getState }) => ({
    incrementMutiple(count) {
      for (let i = 0; i < count; i++) {
        dispatch.cart.increment()
      }
      // incrementMultiple will return synchronously with this string, no more promise.
      return `incremented ${count} times!!` 
    },
    async incrementAsync() {
      // wait 1 second before calling cart.increment
      await new Promise(r => setTimeout(r, 1000))
      dispatch.cart.increment()
      // incrementAsync will return promise which resolves to 'Succeed' 1 second later
      return 'Succeed!!' 
    },
    callOtherModelReducerOrActions() {
      dispatch.otherModel.reducerName()
      dispatch.otherModel.actionName()
    },
    // Object instead of a function? Actions plugin will dispatch this obj for you.
    simpleSingleDispatch: { type: 'cart/increment' }, 
    getCartState() {
       // Note that getState returns entire redux state.
      return getState().cart 
    },
    getCartStateMultiple(multiplier) {
      // You can call other actions that instantly returns some state
      return dispatch.cart.getCartState() * multiplier 
    },
  }),
}

```

### Here is a more complete example.

```js
// src/models/index.js
import { get, omit } from 'lodash'

export const cart = {
  state: {
    products: {},
  },
  reducers: {
    addProduct: (state, { id, price, name }) => ({
      ...state,
      products: {
        ...state.products,
        [id]: {
          id,
          count: get(state.products[id], 'count', 0) + 1,
          price,
          name,
        },
      },
    }),
    subtractProduct: (state, { id }) => ({
      ...state,
      products:
        state.products[id].count === 1
          ? omit(state.products, id)
          : {
              ...state.products,
              [id]: {
                ...state.products[id],
                count: state.products[id].count - 1,
              },
            },
    }),
  },
  actions: ({ dispatch, getState }) => ({
    getProducts() {
      return getState().cart.products
    },
    getSubTotal() {
      const products = dispatch.cart.getProducts()
      return Object.keys(products).reduce((prev, id) => {
        return prev + products[id].price * products[id].count
      }, 0)
    },
    getTax() {
      return dispatch.cart.getSubTotal() * 0.12
    },
    getTotal() {
      return dispatch.cart.getSubTotal() + dispatch.cart.getTax()
    },
  }),
}

```