### PR TITLE
onStoreCreated return value with init

### DIFF
--- a/docs/pluginsApi.md
+++ b/docs/pluginsApi.md
@@ -98,3 +98,19 @@ const plugin = {
 Run last, as it is after the store is created. This provides access to the `store`.
 
 See examples with "dispatch" & "persist".
+
+Returning an object from `onStoreCreated` will result in the keys being merged onto the `store` object. 
+
+```
+const plugin = {
+  onStoreCreated(store) {
+    return { count: 42 } 
+  }
+}
+
+const store = init({ plugins: [plugin] })
+store.count // 42
+```
+
+If you choose to do this with a plugin with TypeScript, be sure to update your stores typings.
+

--- a/src/plugins/dispatch.ts
+++ b/src/plugins/dispatch.ts
@@ -56,6 +56,7 @@ const dispatchPlugin: R.Plugin = {
 	onStoreCreated(store: any) {
 		this.storeDispatch = store.dispatch
 		this.storeGetState = store.getState
+		return { dispatch: this.dispatch }
 	},
 
 	// generate action creators for all model.reducers

--- a/src/rematch.ts
+++ b/src/rematch.ts
@@ -77,9 +77,16 @@ export default class Rematch {
 			},
 		}
 
-		this.forEachPlugin('onStoreCreated', (onStoreCreated) => onStoreCreated(rematchStore))
-
-		rematchStore.dispatch = this.pluginFactory.dispatch
+		this.forEachPlugin('onStoreCreated', (onStoreCreated) => {
+			const returned = onStoreCreated(rematchStore)
+			// if onStoreCreated returns an object value
+			// merge its returned value onto the store
+			if (returned) {
+				Object.keys(returned || {}).forEach((key) => {
+					rematchStore[key] = returned[key]
+				})
+			}
+		})
 
 		return rematchStore
 	}

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -1,87 +1,102 @@
 const { init } = require('../src')
 
 describe('plugins:', () => {
-  test('should add onModel subscription', () => {
-    let messageFromOnModel = null
-    init({
-      models: {
-        count: { state: 0 }
-      },
-      plugins: [{
-        onModel: () => {
-          messageFromOnModel = 'Hello, Rematch!'
-        }
-      }]
-    })
-    expect(messageFromOnModel).toEqual('Hello, Rematch!')
-  })
+	test('should add onModel subscription', () => {
+		let messageFromOnModel = null
+		init({
+			models: {
+				count: { state: 0 },
+			},
+			plugins: [
+				{
+					onModel: () => {
+						messageFromOnModel = 'Hello, Rematch!'
+					},
+				},
+			],
+		})
+		expect(messageFromOnModel).toEqual('Hello, Rematch!')
+	})
 
-  test('should add middleware', () => {
-    const payloadIsAlways100Middleware = () => next => action => {
-      return next({ ...action, payload: 100 })
-    }
-    const store = init({
-      models: {
-        a: {
-          state: 0,
-          reducers: { set: (state, payload) => payload }
-        }
-      },
-      plugins: [
-        { middleware: payloadIsAlways100Middleware },
-      ]
-    })
-    store.dispatch.a.set(1)
-    expect(store.getState()).toEqual({ a: 100 })
+	test('should add middleware', () => {
+		const payloadIsAlways100Middleware = () => next => action => {
+			return next({ ...action, payload: 100 })
+		}
+		const store = init({
+			models: {
+				a: {
+					state: 0,
+					reducers: { set: (state, payload) => payload },
+				},
+			},
+			plugins: [{ middleware: payloadIsAlways100Middleware }],
+		})
+		store.dispatch.a.set(1)
+		expect(store.getState()).toEqual({ a: 100 })
+	})
 
-  })
+	test('should add a model', () => {
+		const a = {
+			state: 0,
+		}
+		const plugin = {
+			config: {
+				models: { a },
+			},
+		}
+		const store = init({
+			plugins: [plugin],
+		})
+		expect(store.getState()).toEqual({ a: 0 })
+	})
 
-  test('should add a model', () => {
-    const a = {
-      state: 0,
-    }
-    const plugin = {
-      config: {
-        models: { a }
-      }
-    }
-    const store = init({
-      plugins: [plugin]
-    })
-    expect(store.getState()).toEqual({ a: 0 })
-  })
+	test('should add multiple models', () => {
+		const a = {
+			state: 0,
+		}
+		const b = {
+			state: 0,
+		}
+		const plugin = {
+			config: {
+				models: { a, b },
+			},
+		}
+		const store = init({
+			plugins: [plugin],
+		})
+		expect(store.getState()).toEqual({ a: 0, b: 0 })
+	})
 
-  test('should add multiple models', () => {
-    const a = {
-      state: 0,
-    }
-    const b = {
-      state: 0,
-    }
-    const plugin = {
-      config: {
-        models: { a, b }
-      }
-    }
-    const store = init({
-      plugins: [plugin]
-    })
-    expect(store.getState()).toEqual({ a: 0, b: 0 })
-  })
+	test('should merge plugin configs into configs', () => {
+		const plugin1 = {
+			config: {
+				redux: {
+					initialState: {
+						app: 1,
+					},
+				},
+			},
+		}
+		const store = init({
+			plugins: [plugin1],
+		})
+		expect(store.getState()).toEqual({ app: 1 })
+	})
 
-  test('should merge plugin configs into configs', () => {
-    const plugin1 = {
-      config: {
-        redux: {
-          initialState: {
-            app: 1
-          }
-        }
-      },
-    }
-    const store = init({
-      plugins: [plugin1],
-    })
-    expect(store.getState()).toEqual({ app: 1 })
-  })
+	test('plugins should be able to return a value', () => {
+		const pluginWithReturn = {
+			onStoreCreated: () => {
+				return {
+					returned: 42,
+				}
+			},
+		}
+
+		const store = init({
+			plugins: [pluginWithReturn],
+		})
+
+		expect(store.returned).toEqual(42)
+	})
 })


### PR DESCRIPTION
Returning an object from `onStoreCreated` will merge into the store.

This can be useful for plugins such as `select`, which are bound to a store.

Example:

```js
const pluginWithReturn = {
  onStoreCreated: () => {
    return {
      returned: 42,
     }
  },
}

const store = init({
  plugins: [pluginWithReturn],
})

expect(store.returned).toEqual(42)
```

### TODO
- [ ] prevent invalid return values from `onStoreCreated`
- [x] update docs