### PR TITLE
Missing directory: scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "Shawn McKay <shawn.j.mckay@gmail.com> (https://github.com/shmck)"
   ],
   "files": [
+    "scripts",
     "dist",
     "src/typings.d.ts"
   ],


### PR DESCRIPTION
Without the scripts directory, postinstall can't run.

Running yarn, I get the following error:

```
error /home/millette/glassjaw-v5/node_modules/@rematch/core: Command failed.
Exit code: 1
Command:  node ./scripts/post_install.js
Arguments: 
Directory: /home/millette/glassjaw-v5/node_modules/@rematch/core
Output:
module.js:549
    throw err;
    ^

Error: Cannot find module '/home/millette/glassjaw-v5/node_modules/@rematch/core/scripts/post_install.js'
    at Function.Module._resolveFilename (module.js:547:15)
    at Function.Module._load (module.js:474:25)
    at Function.Module.runMain (module.js:693:10)
    at startup (bootstrap_node.js:191:16)
    at bootstrap_node.js:612:3
```
