### PR TITLE
fix relative import of core typings in loading plugin

### DIFF
--- a/plugins/loading/index.d.ts
+++ b/plugins/loading/index.d.ts
@@ -5,5 +5,5 @@ export interface LoadingConfig {
     blacklist?: string[];
     asNumber?: boolean;
 }
-declare const _default: (config?: LoadingConfig) => Plugin<import("../node_modules/@rematch/core/src/typings").Models, Action<any, any>>;
+declare const _default: (config?: LoadingConfig) => Plugin<import("../core/src/typings").Models, Action<any, any>>;
 export default _default;


### PR DESCRIPTION
relative imports are currently breaking due to an incorrect path