### PR TITLE
Overloads createModel function when no ModelConfig

### DIFF
--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -96,6 +96,9 @@ export function init<M extends Models>(
 
 export function getDispatch<M extends Models>(): RematchDispatch<M>
 
+export function createModel<S = any>(
+  model: ModelConfig<S>,
+): ModelConfig<S>
 export function createModel<S = any, M extends ModelConfig<S> = ModelConfig>(
   model: M,
 ): M


### PR DESCRIPTION
add overloads to the function of createModel when Generic type M is not presented.