### PR TITLE
Persist Plugin: Optional callback when creating persistor.

### DIFF
--- a/plugins/persist/src/index.ts
+++ b/plugins/persist/src/index.ts
@@ -8,7 +8,7 @@ let persistor
 export const getPersistor = () => persistor
 
 // rematch plugin
-const persistPlugin = (config = {}, callback): Plugin => {
+const persistPlugin = (config = {}, pesistStoreConfig, callback): Plugin => {
 	// merge config with common config options
 	const mergedConfig = {
 		key: 'root',
@@ -24,7 +24,7 @@ const persistPlugin = (config = {}, callback): Plugin => {
 		},
 		onStoreCreated(store) {
 			// run persist store once store is available
-			persistor = persistStore(store, null, callback)
+			persistor = persistStore(store, pesistStoreConfig, callback)
 		},
 	}
 }

--- a/plugins/persist/src/index.ts
+++ b/plugins/persist/src/index.ts
@@ -8,7 +8,7 @@ let persistor
 export const getPersistor = () => persistor
 
 // rematch plugin
-const reactNavigationPlugin = (config = {}): Plugin => {
+const persistPlugin = (config = {}, callback): Plugin => {
 	// merge config with common config options
 	const mergedConfig = {
 		key: 'root',
@@ -24,9 +24,9 @@ const reactNavigationPlugin = (config = {}): Plugin => {
 		},
 		onStoreCreated(store) {
 			// run persist store once store is available
-			persistor = persistStore(store)
+			persistor = persistStore(store, null, callback)
 		},
 	}
 }
 
-export default reactNavigationPlugin
+export default persistPlugin


### PR DESCRIPTION
I work with '_react-native-navigation_' and I need to know when the persistor has done its job without using the PersistorGate.
The callback added here does the trick.