### PR TITLE
Add getState to function effects

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -124,6 +124,7 @@ Reducers may also listen to actions from other models by listing the 'model name
 #### effects
 
 `effects: { [string]: (payload, rootState) }`
+or `effects: (dispatch, getState) => ({ [string]: (payload, rootState) })`
 
 An object of functions that can handle the world outside of the model.
 
@@ -148,6 +149,23 @@ Effects provide a simple way of handling async actions when used with `async/awa
       const data = await response.json()
       // pass the result to a local reducer
       dispatch.example.update(data)
+    }
+  }
+}
+```
+
+Effects can be defined as a function that recieve `dispatch` and `getState` as arguments.
+
+```js
+{
+  effects:(dispatch, getState) => {
+    async loadData(payload) {
+      // wait for data to load
+      const response = await fetch('http://example.com/data')
+      const data = await response.json()
+      // pass the result to a local reducer
+      dispatch.example.update(data)
+      const updatedRootState = getState()
     }
   }
 }

--- a/src/plugins/dispatch.ts
+++ b/src/plugins/dispatch.ts
@@ -26,6 +26,10 @@ const dispatchPlugin: R.Plugin = {
 			return this.storeDispatch(action)
 		},
 
+
+		getState(){
+			return this.storeGetState()
+		},
 		/**
 		 * createDispatcher
 		 *

--- a/src/plugins/effects.ts
+++ b/src/plugins/effects.ts
@@ -20,7 +20,7 @@ const effectsPlugin: R.Plugin = {
 
 		const effects =
 			typeof model.effects === 'function'
-				? model.effects(this.dispatch)
+				? model.effects(this.dispatch, this.getState)
 				: model.effects
 
 		for (const effectName of Object.keys(effects)) {

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -159,7 +159,7 @@ export interface ModelConfig<S = any, SS = S> {
   state: S,
   baseReducer?: (state: SS, action: Action) => SS,
   reducers?: ModelReducers<S>,
-  effects?: ModelEffects<any> | ((dispatch: RematchDispatch, getState():any) => ModelEffects<any>),
+  effects?: ModelEffects<any> | ((dispatch: RematchDispatch, getState:()=>RematchRootState<any>) => ModelEffects<any>),
   selectors?: {
     [key: string]: (state: SS, ...args: any[]) => any,
   },

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -159,7 +159,7 @@ export interface ModelConfig<S = any, SS = S> {
   state: S,
   baseReducer?: (state: SS, action: Action) => SS,
   reducers?: ModelReducers<S>,
-  effects?: ModelEffects<any> | ((dispatch: RematchDispatch) => ModelEffects<any>),
+  effects?: ModelEffects<any> | ((dispatch: RematchDispatch, getState():any) => ModelEffects<any>),
   selectors?: {
     [key: string]: (state: SS, ...args: any[]) => any,
   },

--- a/test/effects.test.js
+++ b/test/effects.test.js
@@ -385,5 +385,33 @@ describe('effects:', () => {
 				example: 1,
 			})
 		})
+
+		it('should pass getState in as a function', async () => {
+			const example = {
+				state: 0,
+				reducers: {
+					addOne: state => state + 1,
+				},
+				effects: (dispatch, getState) => ({
+					async asyncAddOneArrow() {
+						console.log(getState)
+						expect(getState()).toEqual({
+							example: 0,
+						})
+						await dispatch.example.addOne()
+						
+						expect(getState()).toEqual({
+							example: 1,
+						})
+					},
+				}),
+			}
+
+			const store = init({
+				models: { example },
+			})
+
+			await store.dispatch.example.asyncAddOneArrow()
+		})
 	})
 })


### PR DESCRIPTION
following discussion about https://github.com/rematch/rematch/issues/464,
this PR adds `getState` to effects-function parameters as that avoid deprecated state and looks more like `redux-thunk`'s syntax
```javascript
effects: (dispatch, getState) => ({
		async asyncAddOneArrow() {
			console.log(getState) // { example: 1 }
			await dispatch.example.addOne()
			console.log(getState) // { example: 2 }
		},
	}),
```