### PR TITLE
Add `extraArguments` property to plugins to expose extra arguments for model member factories

### DIFF
--- a/src/pluginFactory.ts
+++ b/src/pluginFactory.ts
@@ -14,7 +14,7 @@ export default (config: R.Config) => ({
 	 * bind validate to the store for easy access
 	 */
 	validate,
-
+	extraArguments: {},
 	/**
 	 * create plugin
 	 *
@@ -43,14 +43,33 @@ export default (config: R.Config) => ({
 
 		const result: R.Plugin | any = {}
 
+		const exposed = {}
 		if (plugin.exposed) {
 			for (const key of Object.keys(plugin.exposed)) {
-				this[key] =
+				exposed[key] =
 					typeof plugin.exposed[key] === 'function'
 						? plugin.exposed[key].bind(this) // bind functions to plugin class
 						: Object.create(plugin.exposed[key]) // add exposed to plugin class
 			}
 		}
+
+		const extraArguments = this.extraArguments
+		if (plugin.extraArguments) {
+			for (const key of Object.keys(plugin.extraArguments)) {
+				extraArguments[key] =
+					typeof plugin.extraArguments[key] === 'function'
+						? plugin.extraArguments[key].bind(this) // bind functions to plugin class
+						: plugin.extraArguments[key]
+			}
+		}
+
+		Object.assign(this, {
+			...exposed,
+			config,
+			validate,
+			extraArguments,
+		})
+
 		for (const method of ['onModel', 'middleware', 'onStoreCreated']) {
 			if (plugin[method]) {
 				result[method] = plugin[method].bind(this)

--- a/src/plugins/effects.ts
+++ b/src/plugins/effects.ts
@@ -20,7 +20,7 @@ const effectsPlugin: R.Plugin = {
 
 		const effects =
 			typeof model.effects === 'function'
-				? model.effects(this.dispatch)
+				? model.effects(this.dispatch, this.extraArguments)
 				: model.effects
 
 		for (const effectName of Object.keys(effects)) {

--- a/src/rematch.ts
+++ b/src/rematch.ts
@@ -69,6 +69,8 @@ export default class Rematch {
 		const rematchStore = {
 			name: this.config.name,
 			...redux.store,
+			// extra metadata used by models
+			extraArguments: this.pluginFactory.extraArguments,
 			// dynamic loading of models with `replaceReducer`
 			model: (model: R.Model) => {
 				this.addModel(model)
@@ -83,9 +85,7 @@ export default class Rematch {
 			// if onStoreCreated returns an object value
 			// merge its returned value onto the store
 			if (returned) {
-				Object.keys(returned || {}).forEach((key) => {
-					rematchStore[key] = returned[key]
-				})
+				Object.assign(rematchStore, returned)
 			}
 		})
 

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -160,7 +160,7 @@ export interface ModelConfig<S = any, SS = S> {
   state: S,
   baseReducer?: (state: SS, action: Action) => SS,
   reducers?: ModelReducers<S>,
-  effects?: ModelEffects<any> | ((dispatch: RematchDispatch) => ModelEffects<any>),
+  effects?: ModelEffects<any> | ((dispatch: RematchDispatch, extraArgs: any) => ModelEffects<any>),
   selectors?: {
     [key: string]: (state: SS, ...args: any[]) => any,
   },

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -24,7 +24,7 @@ export type ExtractRematchDispatchersFromEffectsObject<effects extends ModelEffe
   [effectKey in keyof effects]: ExtractRematchDispatcherAsyncFromEffect<effects[effectKey]>
 }
 
-export type ExtractRematchDispatchersFromEffects<effects extends ModelConfig['effects']> = 
+export type ExtractRematchDispatchersFromEffects<effects extends ModelConfig['effects']> =
   (effects extends ((...args: any[]) => infer R)
     ? R extends ModelEffects<any>
       ? ExtractRematchDispatchersFromEffectsObject<R>
@@ -47,7 +47,7 @@ export type ExtractRematchDispatchersFromReducersObject<reducers extends ModelRe
 export type ExtractRematchDispatchersFromReducers<reducers extends ModelConfig['reducers']> =
   ExtractRematchDispatchersFromReducersObject<reducers & {}>
 
-export type ExtractRematchDispatchersFromModel<M extends ModelConfig> = 
+export type ExtractRematchDispatchersFromModel<M extends ModelConfig> =
   ExtractRematchDispatchersFromReducers<M['reducers']> &
   ExtractRematchDispatchersFromEffects<M['effects']>
 
@@ -110,6 +110,7 @@ export namespace rematch {
 export interface RematchStore<M extends Models = Models, A extends Action = Action>
   extends Redux.Store<RematchRootState<M>, A> {
   name: string,
+  extraArguments: object,
   replaceReducer(nextReducer: Redux.Reducer<RematchRootState<M>, A>): void,
   dispatch: RematchDispatch<M>,
   getState(): RematchRootState<M>,
@@ -178,9 +179,10 @@ export interface Plugin<M extends Models = Models, A extends Action = Action> {
   onStoreCreated?: (store: RematchStore<M, A>) => void,
   onModel?: ModelHook,
   middleware?: Middleware,
-
-  // exposed
   exposed?: {
+    [key: string]: any,
+  },
+  extraArguments?: {
     [key: string]: any,
   },
   validate?(validations: Validation[]): void,

--- a/test/effects.test.js
+++ b/test/effects.test.js
@@ -385,5 +385,41 @@ describe('effects:', () => {
 				example: 1,
 			})
 		})
+
+		it('should pass store extraArguments', async () => {
+			const example = {
+				state: 0,
+				reducers: {
+					add: (state, value) => state + value,
+				},
+				effects: (dispatch, { chicken }) => {
+					return {
+						async asyncAddArrow() {
+							await this.add(chicken())
+						},
+					}
+				},
+			}
+
+			const plugin = {
+				extraArguments: {
+					chicken() {
+						return 42
+					},
+				},
+			}
+
+			const store = init({
+				models: { example },
+				plugins: [plugin],
+			})
+
+			expect(store.extraArguments.chicken).toBeDefined()
+			await store.dispatch.example.asyncAddArrow()
+
+			expect(store.getState()).toEqual({
+				example: 42,
+			})
+		})
 	})
 })

--- a/test/plugins.test.js
+++ b/test/plugins.test.js
@@ -99,4 +99,18 @@ describe('plugins:', () => {
 
 		expect(store.returned).toEqual(42)
 	})
+
+	test('should register extraArguments on store', async () => {
+		const plugin = {
+			extraArguments: {
+				chicken: 42,
+			},
+		}
+
+		const store = init({
+			plugins: [plugin],
+		})
+
+		expect(store.extraArguments.chicken).toBe(42)
+	})
 })


### PR DESCRIPTION
This PR adds the `extraArguments` property to plugins.

```js
const getStatePlugin = () => ({
  extraArguments: {
    getState () {
      return this.storeGetState()
    }
  }
})

const model = {
  effects: (dispatch, { getState }) => ({
    ...
  })
}

const store = init({
  models: { model },
  plugins: [getStatePlugin()]
})
```

After seeing #465, I'm hesitant to see the API change towards something that I think is a footgun to even have. There's a lot of people overthinking their routing already. #440 brought up a great point about a different feature from `thunks`, the `extraArguments`.

