### PR TITLE
Update the npm install guide for @rematch/immer

### DIFF
--- a/plugins/immer/README.md
+++ b/plugins/immer/README.md
@@ -5,7 +5,7 @@ Immer plugin for Rematch. Provides immutable ability on immer library.
 ### Install
 
 ```
-npm install @rematch/immer
+npm install @rematch/immer@next
 ```
 
 > For @rematch/core@0.x use @rematch/immer@0.1.0


### PR DESCRIPTION
The default version installed by `npm install @rematch/immer` was `0.1.0`, and it would get an error like [issues349](https://github.com/rematch/rematch/issues/349) with `rematch@next` installed.