### PR TITLE
Use an intersection for overloading

### DIFF
--- a/plugins/select/src/typings.d.ts
+++ b/plugins/select/src/typings.d.ts
@@ -15,7 +15,7 @@ export default createSelectPlugin
 
 type Selector<S, P = any, R = any> =
 	Reselect.Selector<S, R>
-	| Reselect.ParametricSelector<S, P, R>
+	& Reselect.ParametricSelector<S, P, R>
 
 interface ModelSelectors<S> {
 	[key: string]: Selector<S>


### PR DESCRIPTION
This makes `Selector<S,P,R>` callable in Typescript.

The intersection of two functions is a function that can be called with the args of either, the union is a function that fits both types.