### PR TITLE
Select examples

### DIFF
--- a/examples/ts/count/package.json
+++ b/examples/ts/count/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rematch-typescript-example",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-beta.5",
   "private": true,
   "dependencies": {
     "@rematch/core": "../../..",

--- a/examples/ts/count/src/models/sharks.ts
+++ b/examples/ts/count/src/models/sharks.ts
@@ -17,9 +17,9 @@ export const sharks = createModel({
 			dispatch.sharks.increment(payload || 1)
 		},
 	}),
-	selectors: {
-		total(state: SharksState) {
-			return state
+	selectors: slice => ({
+		total() {
+			return slice
 		},
-	},
+	}),
 })

--- a/examples/ts/count/src/store.ts
+++ b/examples/ts/count/src/store.ts
@@ -1,4 +1,4 @@
-import selectPlugin, { getSelect } from '@rematch/select'
+import selectPlugin from '@rematch/select'
 import { init } from '@rematch/core'
 
 import * as models from './models'
@@ -6,9 +6,9 @@ import * as models from './models'
 export { models }
 export type models = typeof models
 
-export const select = getSelect<models>()
-
 export const store = init({
 	plugins: [selectPlugin()],
 	models,
 })
+
+export const { select } = store

--- a/plugins/select/examples/cart/.gitignore
+++ b/plugins/select/examples/cart/.gitignore
@@ -1,0 +1,22 @@
+# See https://help.github.com/ignore-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+package-lock.json

--- a/plugins/select/examples/cart/README.md
+++ b/plugins/select/examples/cart/README.md
@@ -1,0 +1,78 @@
+# Example using rematch with react and react-redux
+
+#### To run
+From the rematch directory...
+```
+npm install
+npm run build
+cd examples/react-redux-count/
+npm install
+npm start
+```
+Then go to http://localhost:3000
+
+#### The example
+```jsx
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { connect, Provider } from 'react-redux'
+import { init } from '@rematch/core'
+
+const count = {
+ state: 0,
+  reducers: {
+    increment: s => s + 1
+  },
+  effects: {
+    async asyncIncrement() {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1000)
+      })
+      this.increment()
+    }
+  },
+}
+
+// No need to specify a 'view' in init.
+const store = init({
+  models: { count }
+})
+
+// Make a presentational component.
+// It knows nothing about redux or rematch.
+const App = ({ count, asyncIncrement, increment }) => (
+  <div>
+    <h2>count is <b style={{ backgroundColor: '#ccc' }}>{count}</b></h2>
+    
+    <h2>
+      <button onClick={increment}>Increment count</button>
+    {' '}
+    <em style={{ backgroundColor: 'yellow' }}>(normal dispatch)</em>
+    </h2>
+
+    <h2>
+    <button onClick={asyncIncrement}>Increment count (delayed 1 second)</button>
+    {' '}
+    <em style={{ backgroundColor: 'yellow' }}>(an async effect!!!)</em>
+    </h2>
+  </div>
+)
+
+const mapState = state => ({
+  count: state.count,
+})
+
+const mapDispatch = dispatch => ({
+  increment: dispatch.count.increment,
+  asyncIncrement: dispatch.count.asyncIncrement,
+})
+
+
+// Use react-redux's <Provider /> and pass it the store.
+ReactDOM.render(
+  <Provider store={store}>
+    <App />
+  </Provider>,
+  document.getElementById('root')
+)
+```

--- a/plugins/select/examples/cart/README.md
+++ b/plugins/select/examples/cart/README.md
@@ -1,78 +1,12 @@
-# Example using rematch with react and react-redux
+# Example using rematch and rematch/select with react and react-redux
 
 #### To run
 From the rematch directory...
 ```
 npm install
 npm run build
-cd examples/react-redux-count/
+cd plugins/select/examples/cart
 npm install
 npm start
 ```
 Then go to http://localhost:3000
-
-#### The example
-```jsx
-import React from 'react'
-import ReactDOM from 'react-dom'
-import { connect, Provider } from 'react-redux'
-import { init } from '@rematch/core'
-
-const count = {
- state: 0,
-  reducers: {
-    increment: s => s + 1
-  },
-  effects: {
-    async asyncIncrement() {
-      await new Promise((resolve) => {
-        setTimeout(resolve, 1000)
-      })
-      this.increment()
-    }
-  },
-}
-
-// No need to specify a 'view' in init.
-const store = init({
-  models: { count }
-})
-
-// Make a presentational component.
-// It knows nothing about redux or rematch.
-const App = ({ count, asyncIncrement, increment }) => (
-  <div>
-    <h2>count is <b style={{ backgroundColor: '#ccc' }}>{count}</b></h2>
-    
-    <h2>
-      <button onClick={increment}>Increment count</button>
-    {' '}
-    <em style={{ backgroundColor: 'yellow' }}>(normal dispatch)</em>
-    </h2>
-
-    <h2>
-    <button onClick={asyncIncrement}>Increment count (delayed 1 second)</button>
-    {' '}
-    <em style={{ backgroundColor: 'yellow' }}>(an async effect!!!)</em>
-    </h2>
-  </div>
-)
-
-const mapState = state => ({
-  count: state.count,
-})
-
-const mapDispatch = dispatch => ({
-  increment: dispatch.count.increment,
-  asyncIncrement: dispatch.count.asyncIncrement,
-})
-
-
-// Use react-redux's <Provider /> and pass it the store.
-ReactDOM.render(
-  <Provider store={store}>
-    <App />
-  </Provider>,
-  document.getElementById('root')
-)
-```

--- a/plugins/select/examples/cart/package.json
+++ b/plugins/select/examples/cart/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "rematch-example-select-cart",
+  "version": "1.0.0-beta.5",
+  "scripts": {
+    "build": "react-scripts build",
+    "eject": "react-scripts eject",
+    "start": "react-scripts start",
+    "test": "react-scripts test --env=jsdom"
+  },
+  "dependencies": {
+    "@rematch/core": "../../../../..",
+    "@rematch/select": "../../..",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
+    "react-redux": "^5.0.7",
+    "react-scripts": "^1.1.0"
+  },
+  "private": true
+}

--- a/plugins/select/examples/cart/package.json
+++ b/plugins/select/examples/cart/package.json
@@ -8,8 +8,8 @@
     "test": "react-scripts test --env=jsdom"
   },
   "dependencies": {
-    "@rematch/core": "../../../../..",
-    "@rematch/select": "../../..",
+    "@rematch/core": "../../../..",
+    "@rematch/select": "../..",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-redux": "^5.0.7",

--- a/plugins/select/examples/cart/public/index.html
+++ b/plugins/select/examples/cart/public/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>React App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/plugins/select/examples/cart/src/App.js
+++ b/plugins/select/examples/cart/src/App.js
@@ -4,12 +4,14 @@ import { select } from './store'
 
 // Make a presentational component.
 // It knows nothing about redux or rematch.
-const App = ({ count, total, items, add, remove }) => (
+const App = ({ total, items, add, remove }) => (
 	<div>
 		<h2>
 			Cart has{' '}
-			<b style={{ backgroundColor: '#dde', padding: 5 }}>{count} items</b> with
-			a total value of{' '}
+			<b style={{ backgroundColor: '#dde', padding: 5 }}>
+				{items.length} items
+			</b>{' '}
+			with a total value of{' '}
 			<b style={{ backgroundColor: '#aae', padding: 5 }}>{total}</b>
 		</h2>
 
@@ -36,15 +38,10 @@ const App = ({ count, total, items, add, remove }) => (
 	</div>
 )
 
-const selector = select(models => ({
+const mapState = select(models => ({
 	total: models.cart.total,
-	count: models.cart.count,
+	items: models.cart.items,
 }))
-
-const mapState = state => ({
-	...selector(state),
-	items: state.cart,
-})
 
 const mapDispatch = dispatch => ({
 	add: dispatch.cart.add,

--- a/plugins/select/examples/cart/src/App.js
+++ b/plugins/select/examples/cart/src/App.js
@@ -26,13 +26,13 @@ const App = ({ total, items, add, remove }) => (
 
 		<h5>
 			{items.map(item => (
-				<span
+				<button
 					key={item.id}
 					onClick={() => remove(item)}
 					style={{ backgroundColor: 'yellow', marginRight: 10 }}
 				>
 					{item.value}
-				</span>
+				</button>
 			))}
 		</h5>
 	</div>

--- a/plugins/select/examples/cart/src/App.js
+++ b/plugins/select/examples/cart/src/App.js
@@ -1,0 +1,58 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { select } from './store'
+
+// Make a presentational component.
+// It knows nothing about redux or rematch.
+const App = ({ count, total, items, add, remove }) => (
+	<div>
+		<h2>
+			Cart has{' '}
+			<b style={{ backgroundColor: '#dde', padding: 5 }}>{count} items</b> with
+			a total value of{' '}
+			<b style={{ backgroundColor: '#aae', padding: 5 }}>{total}</b>
+		</h2>
+
+		<h2>
+			<input type="number" ref={ref => (this.input = ref)} defaultValue={1} />
+			<button
+				onClick={() => add({ id: Date.now(), value: Number(this.input.value) })}
+			>
+				Add Item
+			</button>{' '}
+		</h2>
+
+		<h5>
+			{items.map(item => (
+				<span
+					key={item.id}
+					onClick={() => remove(item)}
+					style={{ backgroundColor: 'yellow', marginRight: 10 }}
+				>
+					{item.value}
+				</span>
+			))}
+		</h5>
+	</div>
+)
+
+const selector = select(models => ({
+	total: models.cart.total,
+	count: models.cart.count,
+}))
+
+const mapState = state => ({
+	...selector(state),
+	items: state.cart,
+})
+
+const mapDispatch = dispatch => ({
+	add: dispatch.cart.add,
+	remove: dispatch.cart.remove,
+})
+
+// Use react-redux's connect
+export default connect(
+	mapState,
+	mapDispatch
+)(App)

--- a/plugins/select/examples/cart/src/index.js
+++ b/plugins/select/examples/cart/src/index.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { Provider } from 'react-redux'
+import App from './App'
+import store from './store'
+
+// Use react-redux's <Provider /> and pass it the store.
+ReactDOM.render(
+	<Provider store={store}>
+		<App />
+	</Provider>,
+	document.getElementById('root')
+)

--- a/plugins/select/examples/cart/src/models.js
+++ b/plugins/select/examples/cart/src/models.js
@@ -1,0 +1,15 @@
+export const cart = {
+	state: [],
+	reducers: {
+		add: (cart, added) => [...cart, added],
+		remove: (cart, removed) => cart.filter(item => item.id !== removed.id),
+	},
+	selectors: slice => ({
+		total() {
+			return slice(cart => cart.reduce((t, item) => t + item.value, 0))
+		},
+		count() {
+			return slice(cart => cart.length)
+		},
+	}),
+}

--- a/plugins/select/examples/cart/src/models.js
+++ b/plugins/select/examples/cart/src/models.js
@@ -8,8 +8,8 @@ export const cart = {
 		total() {
 			return slice(cart => cart.reduce((t, item) => t + item.value, 0))
 		},
-		count() {
-			return slice(cart => cart.length)
+		items() {
+			return slice
 		},
 	}),
 }

--- a/plugins/select/examples/cart/src/store.js
+++ b/plugins/select/examples/cart/src/store.js
@@ -1,0 +1,12 @@
+import { init } from '@rematch/core'
+import selectPlugin from '@rematch/select'
+import * as models from './models'
+
+export const store = init({
+	models,
+  plugins: [selectPlugin()]
+})
+
+export const { select } = store
+
+export default store


### PR DESCRIPTION
This updates the examples to use `@rematch/select` 2.0.0.

closes #298

I added a selector to the react/count example since it shows `connect`. I can take that commit out if it should remain simple. (or make a new example)