### PR TITLE
Fix typings issue for effects that use rootState

### DIFF
--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -17,7 +17,7 @@ export type RematchRootState<M extends Models> = ExtractRematchStateFromModels<M
 export type ExtractRematchDispatcherAsyncFromEffect<E> =
   E extends () => Promise<void> ? RematchDispatcherAsync<void, void> :
   E extends (payload: infer P) => Promise<void> ? RematchDispatcherAsync<P, void> :
-  E extends (payload: infer P, meta: infer M) => Promise<void> ? RematchDispatcherAsync<P, M> :
+  E extends (payload: infer P, meta: infer M) => Promise<void> ? RematchDispatcherAsync<P, void> :
   RematchDispatcherAsync<any, any>
 
 export type ExtractRematchDispatchersFromEffectsObject<effects extends ModelEffects<any>> = {


### PR DESCRIPTION
Hi guys,

There is an issue with type inference when effects access `rootState`. This is the same issue that's described here: https://github.com/rematch/rematch/issues/515

So type inferrence for this snippet will work:

```ts
const model = createModel({
  /* omitted */
  effects: dispatch => ({
    async loadAsync(userId: string) {
      /* omitted */
    },
  }),
})
```

But it will break for this one since we use `rootState`

```ts
const model = createModel({
  /* omitted */
  effects: dispatch => ({
    async loadAsync(userId: string, rootState) {
      /* omitted */
    },
  }),
})
```

The problem is in this declaration on the second to last line:

```ts
export type ExtractRematchDispatcherAsyncFromEffect<E> =
  E extends () => Promise<void> ? RematchDispatcherAsync<void, void> :
  E extends (payload: infer P) => Promise<void> ? RematchDispatcherAsync<P, void> :
  E extends (payload: infer P, meta: infer M) => Promise<void> ? RematchDispatcherAsync<P, M> :
  RematchDispatcherAsync<any, any>
```

When we define effect function in the model, second argument that is called `meta` here will always be the `rootState`. However, the effect function that we want to call from inside our components must accept only one argument, which is a `payload`. The problem is that we pass inferred `M` type to `RematchDispatcherAsync`, so the effect function that we want to call from inside our components will expect the second argument of type `M` to be passed, which is incorrect.

This PR resolves this issue.


