### PR TITLE
fix typings in effects

### DIFF
--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -15,9 +15,9 @@ export type ExtractRematchStateFromModels<M extends Models> = {
 export type RematchRootState<M extends Models> = ExtractRematchStateFromModels<M>
 
 export type ExtractRematchDispatcherAsyncFromEffect<E> =
-  E extends () => Promise<void> ? RematchDispatcherAsync<void, void> :
-  E extends (payload: infer P) => Promise<void> ? RematchDispatcherAsync<P, void> :
-  E extends (payload: infer P, meta: infer M) => Promise<void> ? RematchDispatcherAsync<P, void> :
+  E extends () => Promise<any> ? RematchDispatcherAsync<void, void> :
+  E extends (payload: infer P) => Promise<any> ? RematchDispatcherAsync<P, void> :
+  E extends (payload: infer P, meta: infer M) => Promise<any> ? RematchDispatcherAsync<P, void> :
   RematchDispatcherAsync<any, any>
 
 export type ExtractRematchDispatchersFromEffectsObject<effects extends ModelEffects<any>> = {


### PR DESCRIPTION
return type in `effects` can be not only `void`

sometimes we need the return value from `effects`, so we will code like this:
```
// models/sample.ts
{
    effects: {
        async noPayloadWithReturnAsync() {
          return {
            res: 'noPayloadWithReturn'
          }
       },
   }
} 
```
```
// somewhere.ts
dispatch.sample.noPayloadWithReturnAsync()
.then(ret => {
    // do something with `ret.res`
})
```

in this PR, i allow the return type in `effects` not only `void`. 
The original will throw type error if you have return types except for `void`

there are bunch of issues about this: #398 #478 #520 #526 #515 
and i have tested all the cases on them

![image](https://user-images.githubusercontent.com/8722165/46256129-2dca9a80-c4d9-11e8-8854-3bdbfafeaa9c.png)

![image](https://user-images.githubusercontent.com/8722165/46256140-3f13a700-c4d9-11e8-9ee0-f47161f8373e.png)
