### PR TITLE
Updated plugins/select/README.md

### DIFF
--- a/plugins/select/README.md
+++ b/plugins/select/README.md
@@ -194,10 +194,10 @@ Most apps will consume selectors through `connect`. For this use case, the store
 import { connect } from 'react-redux'
 import { select } = './store'
 
-connect(select(models => {
+connect(select(models => ({
   total: models.cart.total,
   eligibleItems: models.cart.wouldGetFreeShipping
-}))(...)
+})))(...)
 ```
 
 


### PR DESCRIPTION
missing return statement - select expects first argument to be a function which returns an object where each property is a selector