### PR TITLE
Fix `Slicer` type and export select plugin types

### DIFF
--- a/plugins/select/src/typings.d.ts
+++ b/plugins/select/src/typings.d.ts
@@ -13,57 +13,54 @@ export interface SelectConfig {
 declare const createSelectPlugin: (config?: SelectConfig) => R.Plugin<R.Models, R.Action<any, any>>
 export default createSelectPlugin
 
-type Selector<S, P = any, R = any> =
+export type Selector<S, P = any, R = any> =
 	Reselect.Selector<S, R>
 	& Reselect.ParametricSelector<S, P, R>
 
-interface ModelSelectors<S> {
+export interface ModelSelectors<S> {
 	[key: string]: Selector<S>
 }
 
-interface StoreSelectors<S> {
+export interface StoreSelectors<S> {
 	[key: string]: ModelSelectors<S>
 }
 
-type SelectorFactory<S, P = any, R = any> =
+export type SelectorFactory<S, P = any, R = any> =
 	(this: ModelSelectors<S>, models: StoreSelectors<S>) => Selector<S, P, R>
 
-type SelectorParametricFactory<S, P = any> =
+export type SelectorParametricFactory<S, P = any> =
 	(this: ModelSelectors<S>, models: StoreSelectors<S>, props: P) => Selector<S>
 
-type Slicer<S, M = any, R = any> =
+export type Slicer<S, M = any, R = any> =
 	Selector<S, void, M>
-	| (
-			(resultFn: (slice: M) => R) =>
-				Selector <S, void, R>
-		)
+	& ((resultFn: (slice: M) => R) => Selector <S, void, R>)
 
-type SelectorCreator =
+export type SelectorCreator =
 	typeof Reselect.createSelector
 
-type Parameterizer<S, P = any> =
+export type Parameterizer<S, P = any> =
 	(factory: SelectorParametricFactory<S, P>) => SelectorFactory<P, void, Selector<S>>
 
-interface ModelSelectorFactories<S> {
+export interface ModelSelectorFactories<S> {
 	[key: string]: SelectorFactory<S> | SelectorParametricFactory<S>
 }
 
-type ModelSelectorsFactory<S> =
+export type ModelSelectorsFactory<S> =
 	(
 		slice: Slicer<S>,
 		createSelector: SelectorCreator,
 		hasProps: Parameterizer<S>
 	) => ModelSelectorFactories<S>
 
-type ModelSelectorsConfig<S> =
+export type ModelSelectorsConfig<S> =
 	ModelSelectorsFactory<S>
 	| ModelSelectorFactories<S>
 
-type RematchSelect<M extends R.Models | void = void, RootState = any> =
- (
-	 (mapSelectToProps: (select: RematchSelect<M, RootState>) => object) =>
+export type RematchSelect<M extends R.Models | void = void, RootState = any> =
+	(
+	 	(mapSelectToProps: (select: RematchSelect<M, RootState>) => object) =>
 	 		Reselect.OutputParametricSelector<RootState, any, object, Reselect.Selector<RootState, object>>
- ) & StoreSelectors<RootState>
+ 	) & StoreSelectors<RootState>
 
 declare module '@rematch/core' {
 	export interface ModelConfig<S = any, SS = S> {
@@ -71,6 +68,6 @@ declare module '@rematch/core' {
 	}
 
 	export interface RematchStore<M extends Models = Models, A extends Action = Action> {
-		select: RematchSelect<M>,
+		select: RematchSelect<M, R.RematchRootState<Models>>,
 	}
 }


### PR DESCRIPTION
This PR fix the `Slicer` type signature (from Union `|` to Intersection `&`) and the type of `RematchStore` select property (missing `RootState` type in generic).

It also exports all the types as `@rematch/core` for further integration and own types extensions by consumers.