### PR TITLE
make the github link absolute in typescript recipe

### DIFF
--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -2,7 +2,7 @@
 
 ### Examples
 
-- [Counter](github.com/rematch/rematch/tree/master/examples/ts/count/)
+- [Counter](https://github.com/rematch/rematch/tree/master/examples/ts/count/)
 
 ### Changes
 

--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -2,7 +2,7 @@
 
 ### Examples
 
-- [Counter](../../examples/ts/count)
+- [Counter](github.com/rematch/rematch/tree/master/examples/ts/count/)
 
 ### Changes
 


### PR DESCRIPTION
Should fix #589 - relative paths under `/docs` will be _relative to gitbooks.io_