### PR TITLE
fix: fix type lost for reducer and effects

### DIFF
--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -61,7 +61,8 @@ export type RematchDispatcher<P = void, M = void> =
   ((action: Action<P, M>) => Redux.Dispatch<Action<P, M>>) &
   ((action: Action<P, void>) => Redux.Dispatch<Action<P, void>>) &
   (P extends void ? ((...args: any[]) => Action<any, any>) :
-    P extends any ? ((payload: any) => Action<any, any>) :
+    P extends boolean ? ((payload: boolean) => Action<any, any>) :
+    P extends any ? ((payload: P) => Action<any, any>) :
     M extends void ? ((payload: P) => Action<P, void>) :
     (payload: P, meta: M) => Action<P, M>)
 
@@ -69,7 +70,8 @@ export type RematchDispatcherAsync<P = void, M = void> =
   ((action: Action<P, M>) => Promise<Redux.Dispatch<Action<P, M>>>) &
   ((action: Action<P, void>) => Promise<Redux.Dispatch<Action<P, void>>>) &
   (P extends void ? ((...args: any[]) => Promise<Action<any, any>>) :
-    P extends any ? ((payload: any) => Promise<Action<any, any>>) :
+    P extends boolean ? ((payload: boolean) => Promise<Action<boolean, any>>) :
+    P extends any ? ((payload: P) => Promise<Action<P, any>>) :
     M extends void ? ((payload: P) => Promise<Action<P, void>>) :
     (payload: P, meta: M) => Promise<Action<P, M>>)
 


### PR DESCRIPTION
The current d.ts cannot export correct payload type of reducers or effects. 
So i export the type of payload reducers or effects.(But i don't know why have to make a  statement for `boolean`