### PR TITLE
(fix): select auto complete import docs

### DIFF
--- a/docs/recipes/typescript.md
+++ b/docs/recipes/typescript.md
@@ -108,18 +108,16 @@ export default connect(mapState, mapDispatch)(Count)
 
 > There remain some TS compatability issues with the select plugin. Help is always welcome
 
-To enable autocomplete of select, use `getSelect` with the select plugin. See example below:
+You can see a real example of this code in `examples/cart`
 
 ```ts
-import selectPlugin, { getSelect } from '@rematch/select';
 import { init } from '@rematch/core';
+import selectPlugin from '@rematch/select';
 import * as models from './models';
 
-export const select = getSelect<models>();
-
 export const store = init({
-  plugins: [selectPlugin()],
   models,
+  plugins: [selectPlugin()],
 });
 ```
 


### PR DESCRIPTION
Just updating docs for being in the same line that actual versions.
148e810#diff-adfd610834090020180c37221296a7e0

This fixes this: https://github.com/rematch/rematch/issues/622, that was related to other issue closed about getSelect was undefined. 