### PR TITLE
Docs (api.md) effect with same name as reducer

### DIFF
--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -168,6 +168,24 @@ Effects provide a simple way of handling async actions when used with `async/awa
 }
 ```
 
+`effects` that share a name with a reducer are called **after** their reducer counterpart
+
+```js
+{
+  effects: {
+    // this will run after update reducer finished
+    update(payload, rootState) {
+      console.log('update reducer was called with payload: ', payload);
+    }
+  },
+  reducers: {
+    update(prev, data) {
+      return {...prev, ...data}
+    }
+  }
+}
+```
+
 #### baseReducer
 
 `baseReducer: (state, action) => state`

--- a/docs/api-reference/api.md
+++ b/docs/api-reference/api.md
@@ -173,7 +173,7 @@ Effects provide a simple way of handling async actions when used with `async/awa
 ```js
 {
   effects: {
-    // this will run after update reducer finished
+    // this will run after "update" reducer finished
     update(payload, rootState) {
       console.log('update reducer was called with payload: ', payload);
     }


### PR DESCRIPTION
## Changes
- Added section to `api.md` docs that explain the order in which effects and reducers with the same name are executed

Behavior from [src/plugins/effects.ts](https://github.com/rematch/rematch/blob/master/src/plugins/effects.ts#L56)