### PR TITLE
fix global variable name for reselect

### DIFF
--- a/plugins/select/rollup.config.js
+++ b/plugins/select/rollup.config.js
@@ -31,7 +31,7 @@ const config = {
 			exports: 'named',
 			sourcemap: true,
 			globals: {
-				reselect: 'reselect',
+				reselect: 'Reselect',
 			},
 		}, // Universal Modules
 		{ file: pkg.main, format: 'cjs', exports: 'named', sourcemap: true }, // CommonJS Modules


### PR DESCRIPTION
The umd build for reselect library exposes the lib with capital letter, i.e. `Reselect`, which means current UMD build is broken.