### PR TITLE
Update Reactotron/Rematch Integration

### DIFF
--- a/docs/recipes/devtools.md
+++ b/docs/recipes/devtools.md
@@ -60,7 +60,8 @@ import Reactotron from './Reactotron.config.js'
 
 init({
 	redux: {
-		createStore: Reactotron.createStore,
+		enhancers: [Reactotron.createEnhancer()],
+		// If using typescript/flow, enhancers: [Reactotron.createEnhancer!()]
 	},
 })
 ```


### PR DESCRIPTION
Reactotron had a breaking change removing `createStore` in favor of `createEnhancer()` which now has to be defined on the `enhancers` array instead of the `createStore` function. For typescript with strict typing a null assertion is needed since the type can return undefined.