### PR TITLE
Add LoadingState type.

### DIFF
--- a/plugins/loading/src/index.ts
+++ b/plugins/loading/src/index.ts
@@ -7,6 +7,18 @@ export interface LoadingConfig {
 	asNumber?: boolean
 }
 
+export interface LoadingState<M extends Models> {
+	loading: {
+		global: boolean,
+		models: { [modelName in keyof M]: boolean },
+		effects: {
+			[modelName in keyof M]: {
+				[effectName in keyof ExtractRematchDispatchersFromEffects<M[modelName]['effects']>]: boolean
+			}
+		},
+	}
+}
+
 const cntState = {
 	global: 0,
 	models: {},

--- a/plugins/loading/src/index.ts
+++ b/plugins/loading/src/index.ts
@@ -1,4 +1,4 @@
-import { Model, Plugin } from '@rematch/core'
+import { ExtractRematchDispatchersFromEffects, Model, Models, Plugin } from '@rematch/core'
 
 export interface LoadingConfig {
 	name?: string


### PR DESCRIPTION
Hi, 
Rematch newcomer here!

I'm using Typescript, and would like to use the loading plugin.
However, because the loading model is added with the plugin api, the AppState (`RematchRootState<typeof models>`) type doesn't know about the loading state.

I've added it in the plugin, to be able to import it and use it directly: 

`export type AppState = RematchRootState<typeof models> & LoadingState<typeof models>`

I use the type on my side, but share it with the community, as I think it can interest.

Thanks for this cool package,
Matt'.