### PR TITLE
Fix persist config typing.

### DIFF
--- a/plugins/persist/src/typings.d.ts
+++ b/plugins/persist/src/typings.d.ts
@@ -39,7 +39,7 @@ interface PluginPersistConfig {
 }
 
 declare const persistPlugin: (
-	persistConfig: PluginPersistConfig,
+	persistConfig?: PluginPersistConfig,
 	persistorOptions?: PersistorOptions,
 	callback?: () => void
 ) => Plugin<Models, Action<any, any>>


### PR DESCRIPTION
The config is not required, as it has a `{}` default.