### PR TITLE
Removed duplicate createModel function in type decleration

### DIFF
--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -109,7 +109,6 @@ export function init<M extends Models>(
 
 export function getDispatch<M extends Models>(): RematchDispatch<M>
 
-export function createModel<S = any>(model: ModelConfig<S>): ModelConfig<S>
 export function createModel<S = any, M extends ModelConfig<S> = ModelConfig>(
 	model: M
 ): M


### PR DESCRIPTION
Hi! I've been having type issues with the createModel with it returning different types due to it be duplicated in the `index.d.ts` I removed the duplication and that fixes the error.