### PR TITLE
Fix incorrect typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7528,9 +7528,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
-			"integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==",
+			"version": "3.7.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+			"integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
 			"dev": true
 		},
 		"typings-tester": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 		"rollup-plugin-uglify": "^6.0.3",
 		"ts-jest": "^24.0.2",
 		"tslint": "^5.19.0",
-		"typescript": "^3.6.2",
+		"typescript": "^3.7.5",
 		"typings-tester": "^0.3.2",
 		"uglify-es": "^3.3.9"
 	},

--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -24,8 +24,6 @@ export type ExtractRematchDispatcherAsyncFromEffect<
 	? RematchDispatcherAsync<void, void, R>
 	: E extends (payload: infer P) => Promise<infer R>
 	? RematchDispatcherAsync<P, void, R>
-	: E extends (payload: infer P, meta: infer M) => Promise<infer R>
-	? RematchDispatcherAsync<P, M, R>
 	: RematchDispatcherAsync<any, any, any>
 
 export type ExtractRematchDispatchersFromEffectsObject<
@@ -160,8 +158,8 @@ type ModelEffects<S> = {
 	) => void
 }
 
-export type Models = {
-	[key: string]: ModelConfig
+export type Models<K extends string = string> = {
+	[key: K]: ModelConfig
 }
 
 export type ModelHook = (model: Model) => void
@@ -180,7 +178,7 @@ export interface ModelConfig<S = any, SS = S> {
 	reducers?: ModelReducers<S>
 	effects?:
 		| ModelEffects<any>
-		| ((dispatch: RematchDispatch) => ModelEffects<any>)
+		| (<M extends Models | void = void>(dispatch: RematchDispatch<M>) => ModelEffects<any>)
 }
 
 export interface PluginFactory extends Plugin {

--- a/src/typings/index.d.ts
+++ b/src/typings/index.d.ts
@@ -158,8 +158,8 @@ type ModelEffects<S> = {
 	) => void
 }
 
-export type Models<K extends string = string> = {
-	[key: K]: ModelConfig
+export type Models = {
+	[key: string]: ModelConfig
 }
 
 export type ModelHook = (model: Model) => void


### PR DESCRIPTION
1. Fix #723 
2. Fix effect dispatcher type. When declaring and effect like `(payload, state) => {}` the `state` type was infered as `meta` type.
