### PR TITLE
Update persist.md

### DIFF
--- a/docs/plugins/persist.md
+++ b/docs/plugins/persist.md
@@ -41,7 +41,7 @@ import { PersistGate } from 'redux-persist/lib/integration/react'
 const persistor = getPersistor()
 
 const Root = () => {
-	;<PersistGate persistor={persistor}>
+	<PersistGate persistor={persistor}>
 		<App />
 	</PersistGate>
 }


### PR DESCRIPTION
Removed not needed semicolon from rematch/persist plugin documentation.