### PR TITLE
fixed docs/plugins/persist.md with syntax error

### DIFF
--- a/docs/lang/zh-cn/cha-jian/rematch-persist.md
+++ b/docs/lang/zh-cn/cha-jian/rematch-persist.md
@@ -42,11 +42,11 @@ import { PersistGate } from 'redux-persist/es/integration/react'
 
 const persistor = getPersistor()
 
-const Root = () => {
-	;<PersistGate persistor={persistor}>
+const Root = () => (
+	<PersistGate persistor={persistor}>
 		<App />
 	</PersistGate>
-}
+)
 ```
 
 ### 配置选项

--- a/docs/plugins/persist.md
+++ b/docs/plugins/persist.md
@@ -40,11 +40,11 @@ import { PersistGate } from 'redux-persist/lib/integration/react'
 
 const persistor = getPersistor()
 
-const Root = () => {
-	;<PersistGate persistor={persistor}>
+const Root = () => (
+	<PersistGate persistor={persistor}>
 		<App />
 	</PersistGate>
-}
+)
 ```
 
 ### Config Options


### PR DESCRIPTION
should be:
```
const Root = () => (
	<PersistGate persistor={persistor}>
		<App />
	</PersistGate>
)
```
not:
```
const Root = () => {
	;<PersistGate persistor={persistor}>
		<App />
	</PersistGate>
}
```