### PR TITLE
Fix gatsby example

### DIFF
--- a/examples/gatsby-example/gatsby-config.js
+++ b/examples/gatsby-example/gatsby-config.js
@@ -6,13 +6,6 @@ module.exports = {
   },
   plugins: [
     `gatsby-plugin-react-helmet`,
-    {
-      resolve: `gatsby-source-filesystem`,
-      options: {
-        name: `images`,
-        path: `${__dirname}/src/images`,
-      },
-    },
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
     {
@@ -24,7 +17,6 @@ module.exports = {
         background_color: `#663399`,
         theme_color: `#663399`,
         display: `minimal-ui`,
-        icon: `src/images/gatsby-icon.png`, // This path is relative to the root of the site.
       },
     },
     // this (optional) plugin enables Progressive Web App + Offline functionality

--- a/examples/gatsby-example/package.json
+++ b/examples/gatsby-example/package.json
@@ -6,6 +6,7 @@
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "dependencies": {
     "@rematch/core": "^2.0.0-next.4",
+    "@types/react-redux": "^7.1.9",
     "gatsby": "^2.24.50",
     "gatsby-image": "^2.4.16",
     "gatsby-plugin-manifest": "^2.4.24",

--- a/examples/gatsby-example/src/pages/index.tsx
+++ b/examples/gatsby-example/src/pages/index.tsx
@@ -6,7 +6,7 @@ import { useDispatch, useSelector } from "react-redux"
 
 import Layout from "../components/layout"
 import SEO from "../components/seo"
-import { store, Dispatch, RootState } from "../store";
+import { Dispatch, RootState } from "../store"
 
 const UsingTypescript: React.FC<PageProps> = () => {
   const settings = useSelector((state: RootState) => state.settings)

--- a/examples/gatsby-example/src/pages/index.tsx
+++ b/examples/gatsby-example/src/pages/index.tsx
@@ -1,8 +1,7 @@
 // If you don't want to use TypeScript you can delete this file!
 import React from "react"
 import { PageProps } from "gatsby"
-import { Provider } from "react-redux";
-import { useDispatch, useSelector } from 'react-redux'
+import { useDispatch, useSelector } from "react-redux"
 
 
 import Layout from "../components/layout"
@@ -14,15 +13,13 @@ const UsingTypescript: React.FC<PageProps> = () => {
   const dispatch = useDispatch<Dispatch>()
 
   return (
-    <Provider store={store}>
-      <Layout isDark={settings.isDarkModeEnabled}>
-          <SEO title="Using TypeScript" />
-          <h1>Dark mode: {settings.isDarkModeEnabled.toString()}</h1>
-          <button onClick={() => dispatch.settings.toggleDarkThemeEffect()}>
-            Toggle dark theme
-          </button>
-      </Layout>
-    </Provider>
+    <Layout isDark={settings.isDarkModeEnabled}>
+        <SEO title="Using TypeScript" />
+        <h1>Dark mode: {settings.isDarkModeEnabled.toString()}</h1>
+        <button onClick={() => dispatch.settings.toggleDarkThemeEffect()}>
+          Toggle dark theme
+        </button>
+    </Layout>
   )
 }
 


### PR DESCRIPTION
Removes the duplicate Provider. It is already in `src/wrapper.tsx`, which wraps _all_ pages rendered by SSR and in-browser, so the one on `src/pages/index.tsx` may be omitted.

Also adds types for react-redux
And removes the references to src/images, which was preventing the build from starting

Closes last posed question in #807