### PR TITLE
Docs Fix URL for "examples" page

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,5 +1,5 @@
 # Examples
 
-Check out the examples available in GitHub repository: https://github.com/rematch/rematch/examples
+Check out the examples available in GitHub repository: https://github.com/rematch/rematch/tree/next/examples
 
 Everyone is more than welcome to create more examples and share them with the community!


### PR DESCRIPTION
Currently it refers to: https://github.com/rematch/rematch/examples which returns a 404.

Not sure if this should point to the next or master branch, but it seems most library refer to the newer one of the two.