### PR TITLE
fix: @rematch/select typescript plugin compatibility

### DIFF
--- a/docs/plugins/loading.md
+++ b/docs/plugins/loading.md
@@ -90,7 +90,7 @@ export const store = init<RootModel, FullModel>({
 
 export type Store = typeof store
 export type Dispatch = RematchDispatch<RootModel>
-export type RootState = RematchRootState<RootModel & FullModel>
+export type RootState = RematchRootState<RootModel, FullModel>
 
 ```
 

--- a/docs/plugins/select.md
+++ b/docs/plugins/select.md
@@ -40,16 +40,41 @@ The select plugin accepts one optional argument - **config**, which is an object
 Start by adding the plugin to your store:
 
 **store.js**
+<!-- tabs:start -->
+#### ** JavaScript **
 
 ```javascript
-import selectPlugin from '@rematch/select'
 import { init } from '@rematch/core'
+import selectPlugin from '@rematch/select'
+import * as models from './models'
 
 init({
-    // add selectPlugin to your store
-	plugins: [selectPlugin()],
+  models,
+  // add selectPlugin to your store
+  plugins: [selectPlugin()],
 })
 ```
+
+#### ** Typescript **
+
+```typescript
+import selectPlugin from '@rematch/select'
+import { init, RematchDispatch, RematchRootState } from '@rematch/core'
+import { models, RootModel } from './models'
+
+export const store = init<RootModel>({
+    models,
+    // add selectPlugin to your store
+    plugins: [selectPlugin()],
+})
+
+export type Store = typeof store
+export type Dispatch = RematchDispatch<RootModel>
+export type RootState = RematchRootState<RootModel>
+
+```
+
+<!-- tabs:end -->
 
 ### 2. Add selectors
 

--- a/docs/plugins/updated.md
+++ b/docs/plugins/updated.md
@@ -91,7 +91,7 @@ export const store = init<RootModel, FullModel>({
 
 export type Store = typeof store
 export type Dispatch = RematchDispatch<RootModel>
-export type RootState = RematchRootState<RootModel & FullModel>
+export type RootState = RematchRootState<RootModel, FullModel>
 
 ```
 

--- a/examples/all-plugins-react-ts/src/AppWithoutHooks.tsx
+++ b/examples/all-plugins-react-ts/src/AppWithoutHooks.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { RootState, Dispatch } from './store'
+import { RootState, Dispatch, store } from './store'
 import { connect } from 'react-redux'
 import { PlayerModel } from './models/players';
 import "./index.css";
@@ -61,10 +61,17 @@ class App extends React.PureComponent<Props> {
   }
 }
 
+const selection = store.select(models => ({
+  // todo: this isn't getting autocompleted
+  total: models.cart.total,
+}))
+
 const mapState = (state: RootState) => ({
 	settingsState: state.settings,
   loadingState: state.loading,
-  playersState: state.players
+  playersState: state.players,
+  // todo: props shouldn't be required
+  ...selection(state, null)
 })
 
 const mapDispatch = (dispatch: Dispatch) => ({
@@ -74,6 +81,7 @@ const mapDispatch = (dispatch: Dispatch) => ({
 
 type StateProps = ReturnType<typeof mapState>
 type DispatchProps = ReturnType<typeof mapDispatch>
+// todo: we must type the props autocomplete of the selector new values
 type Props = StateProps & DispatchProps
 
 export default connect(mapState, mapDispatch)(App);

--- a/examples/all-plugins-react-ts/src/AppWithoutHooks.tsx
+++ b/examples/all-plugins-react-ts/src/AppWithoutHooks.tsx
@@ -62,7 +62,6 @@ class App extends React.PureComponent<Props> {
 }
 
 const selection = store.select(models => ({
-  // todo: this isn't getting autocompleted
   total: models.cart.total,
 }))
 
@@ -70,8 +69,7 @@ const mapState = (state: RootState) => ({
 	settingsState: state.settings,
   loadingState: state.loading,
   playersState: state.players,
-  // todo: props shouldn't be required
-  ...selection(state, null)
+  ...selection(state)
 })
 
 const mapDispatch = (dispatch: Dispatch) => ({
@@ -81,7 +79,6 @@ const mapDispatch = (dispatch: Dispatch) => ({
 
 type StateProps = ReturnType<typeof mapState>
 type DispatchProps = ReturnType<typeof mapDispatch>
-// todo: we must type the props autocomplete of the selector new values
 type Props = StateProps & DispatchProps
 
 export default connect(mapState, mapDispatch)(App);

--- a/examples/all-plugins-react-ts/src/models/cart.ts
+++ b/examples/all-plugins-react-ts/src/models/cart.ts
@@ -1,4 +1,4 @@
-import { createModelWithSelectors } from "@rematch/select"
+import { createModel } from "@rematch/core"
 import { RootModel } from "."
 
 interface CartState {
@@ -7,7 +7,7 @@ interface CartState {
   productId: number;
 }
 
-export const cart = createModelWithSelectors<RootModel>()({
+export const cart = createModel<RootModel>()({
   state: [{
     price: 42.00,
     amount: 3,

--- a/examples/all-plugins-react-ts/src/models/cart.ts
+++ b/examples/all-plugins-react-ts/src/models/cart.ts
@@ -1,0 +1,55 @@
+import { createModelWithSelectors } from "@rematch/select"
+import { RootModel } from "."
+
+interface CartState {
+  price: number;
+  amount: number;
+  productId: number;
+}
+
+export const cart = createModelWithSelectors<RootModel>()({
+  state: [{
+    price: 42.00,
+    amount: 3,
+    productId: 2,
+  }] as CartState[],
+  selectors: (slice, createSelector, hasProps) => ({
+    // creates a simple memoized selector based on the cart state
+    total () {
+      return slice(cart =>
+        cart.reduce((a, b) => a + (b.price * b.amount), 0)
+      )
+    },
+    // // uses createSelector method to create more complex memoized selector
+    // totalWithShipping () {
+    //   return createSelector(
+    //     slice, // shortcut for (rootState) => rootState.cart
+    //     (rootState, props) => props.shipping,
+    //     (cart, shipping) => cart.reduce((a, b) => a + (b.price * b.amount), shipping)
+    //   )
+    // },
+    // // refers to the other selector from this model
+    // doubleTotal () {
+    //   return createSelector(
+    //     this.totalWithShipping,
+    //     (totalWithShipping: number) => totalWithShipping * 2,
+    //   )
+    // },
+    // // accesses selector from a different model
+    // productsPopularity (models) {
+    //   return createSelector(
+    //     slice, // shortcut for (rootState) => rootState.cart
+    //     models.popularity.pastDay, // gets 'pastDay' selector from 'popularity' model
+    //     (cart, hot) => cart.sort((a, b) => hot[a.productId] > hot[b.productId])
+    //   )
+    // },
+    // // uses hasProps function, which returns new selector for each given lowerLimit prop
+    // expensiveFilter: hasProps(function (models, lowerLimit) {
+    //   return slice(items => items.filter(item => item.price > lowerLimit))
+    // }),
+    // // uses expensiveFilter selector to create a new selector where lowerLimit is set to 20.00
+    // wouldGetFreeShipping () {
+    //   return this.expensiveFilter(20.00)
+    // },
+  }),
+})

--- a/examples/all-plugins-react-ts/src/models/cart.ts
+++ b/examples/all-plugins-react-ts/src/models/cart.ts
@@ -1,55 +1,58 @@
-import { createModel } from "@rematch/core"
-import { RootModel } from "."
+import { createModel } from '@rematch/core'
+import { RootModel } from '.'
+import { RootState } from '../store'
 
 interface CartState {
-  price: number;
-  amount: number;
-  productId: number;
+	price: number
+	amount: number
+	productId: number
 }
 
 export const cart = createModel<RootModel>()({
-  state: [{
-    price: 42.00,
-    amount: 3,
-    productId: 2,
-  }] as CartState[],
-  selectors: (slice, createSelector, hasProps) => ({
-    // creates a simple memoized selector based on the cart state
-    total () {
-      return slice(cart =>
-        cart.reduce((a, b) => a + (b.price * b.amount), 0)
-      )
-    },
-    // // uses createSelector method to create more complex memoized selector
-    // totalWithShipping () {
-    //   return createSelector(
-    //     slice, // shortcut for (rootState) => rootState.cart
-    //     (rootState, props) => props.shipping,
-    //     (cart, shipping) => cart.reduce((a, b) => a + (b.price * b.amount), shipping)
-    //   )
-    // },
-    // // refers to the other selector from this model
-    // doubleTotal () {
-    //   return createSelector(
-    //     this.totalWithShipping,
-    //     (totalWithShipping: number) => totalWithShipping * 2,
-    //   )
-    // },
-    // // accesses selector from a different model
-    // productsPopularity (models) {
-    //   return createSelector(
-    //     slice, // shortcut for (rootState) => rootState.cart
-    //     models.popularity.pastDay, // gets 'pastDay' selector from 'popularity' model
-    //     (cart, hot) => cart.sort((a, b) => hot[a.productId] > hot[b.productId])
-    //   )
-    // },
-    // // uses hasProps function, which returns new selector for each given lowerLimit prop
-    // expensiveFilter: hasProps(function (models, lowerLimit) {
-    //   return slice(items => items.filter(item => item.price > lowerLimit))
-    // }),
-    // // uses expensiveFilter selector to create a new selector where lowerLimit is set to 20.00
-    // wouldGetFreeShipping () {
-    //   return this.expensiveFilter(20.00)
-    // },
-  }),
+	state: [
+		{
+			price: 42.0,
+			amount: 3,
+			productId: 2,
+		},
+	] as CartState[],
+	selectors: (slice, createSelector, hasProps) => ({
+		// creates a simple memoized selector based on the cart state
+		total() {
+			return slice((cart) => cart.reduce((a, b) => a + b.price * b.amount, 0))
+		},
+		// uses createSelector method to create more complex memoized selector
+		totalWithShipping() {
+			return createSelector(
+				// IMP: `slice` is a `Selector` and `(rootState, props) => props.shipping` is an `ParametricSelector`. In reselect, there are no overloads for it.
+				slice, // shortcut for (rootState) => rootState.cart
+				(rootState: any, props: any) => props.shipping as number,
+				(cart, shipping) =>
+					cart.reduce((a, b) => a + b.price * b.amount, shipping)
+			)
+		},
+		// refers to the other selector from this model
+		doubleTotal() {
+			return createSelector(
+				this.totalWithShipping(),
+				(totalWithShipping) => totalWithShipping * 2
+			)
+		},
+		// accesses selector from a different model
+		// productsPopularity(models, a) {
+		// 	return createSelector(
+		// 		slice, // shortcut for (rootState) => rootState.cart
+		// 		models.popularity.pastDay, // gets 'pastDay' selector from 'popularity' model
+		// 		(cart, hot) => cart.sort((a, b) => hot[a.productId] - hot[b.productId])
+		// 	)
+		// },
+		// uses hasProps function, which returns new selector for each given lowerLimit prop
+		expensiveFilter: hasProps(function (models, lowerLimit) {
+			return slice((items) => items.filter((item) => item.price > lowerLimit))
+		}),
+		// uses expensiveFilter selector to create a new selector where lowerLimit is set to 20.00
+		// wouldGetFreeShipping(models) {
+		// 	return this.expensiveFilter(models, 20.0)
+		// },
+	}),
 })

--- a/examples/all-plugins-react-ts/src/models/index.ts
+++ b/examples/all-plugins-react-ts/src/models/index.ts
@@ -1,10 +1,12 @@
 import { Models } from '@rematch/core'
 import { players } from './players'
 import { settings } from './settings'
+import { cart } from './cart'
 
 export interface RootModel extends Models<RootModel> {
 	players: typeof players
+	cart: typeof cart
 	settings: typeof settings
 }
 
-export const models: RootModel = { players, settings }
+export const models: RootModel = { players, settings, cart }

--- a/examples/all-plugins-react-ts/src/models/players.ts
+++ b/examples/all-plugins-react-ts/src/models/players.ts
@@ -30,14 +30,6 @@ export const players = createModel<RootModel>()({
 	state: {
 		players: []
 	} as PlayersState,
-	selectors: (slice, createSelector, hasProps) => ({
-		total() {
-			return slice(cart => cart.reduce((t: any, item: any) => t + item.value, 0))
-		},
-		items() {
-			return slice
-		},
-	}),
 	reducers: {
 		SET_PLAYERS: (state: PlayersState, players: PlayerModel[]) =>  {
 			return {

--- a/examples/all-plugins-react-ts/src/models/players.ts
+++ b/examples/all-plugins-react-ts/src/models/players.ts
@@ -30,6 +30,14 @@ export const players = createModel<RootModel>()({
 	state: {
 		players: []
 	} as PlayersState,
+	selectors: (slice, createSelector, hasProps) => ({
+		total() {
+			return slice(cart => cart.reduce((t: any, item: any) => t + item.value, 0))
+		},
+		items() {
+			return slice
+		},
+	}),
 	reducers: {
 		SET_PLAYERS: (state: PlayersState, players: PlayerModel[]) =>  {
 			return {

--- a/examples/all-plugins-react-ts/src/store.ts
+++ b/examples/all-plugins-react-ts/src/store.ts
@@ -5,6 +5,7 @@ import updated, { ExtraModelsFromUpdated } from '@rematch/updated';
 import persist from '@rematch/persist';
 import storage from 'redux-persist/lib/storage'
 import immerPlugin from '@rematch/immer'
+import selectPlugin from '@rematch/select'
 
 type FullModel =  ExtraModelsFromLoading<RootModel> & ExtraModelsFromUpdated<RootModel>
 export const store = init<RootModel, FullModel>({
@@ -19,7 +20,8 @@ export const store = init<RootModel, FullModel>({
 		}),
 		immerPlugin({
 			whitelist: ['settings']
-		})
+		}),
+		selectPlugin(),
 	]
 })
 

--- a/examples/all-plugins-react-ts/src/store.ts
+++ b/examples/all-plugins-react-ts/src/store.ts
@@ -1,4 +1,4 @@
-import { init, RematchDispatch, RematchRootState } from '@rematch/core'
+import { init, RematchDispatch, RematchRootState, RematchStore } from '@rematch/core'
 import { models, RootModel } from './models'
 import loading, { ExtraModelsFromLoading } from '@rematch/loading';
 import updated, { ExtraModelsFromUpdated } from '@rematch/updated';
@@ -27,4 +27,4 @@ export const store = init<RootModel, FullModel>({
 
 export type Store = typeof store
 export type Dispatch = RematchDispatch<RootModel>
-export type RootState = RematchRootState<RootModel & FullModel>
+export type RootState = RematchRootState<RootModel, FullModel>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,7 +10,7 @@ export const init = <
 	TExtraModels extends Models<TModels> = {}
 >(
 	initConfig?: InitConfig<TModels, TExtraModels>
-): RematchStore<TModels & TExtraModels> => {
+): RematchStore<TModels, TExtraModels> => {
 	const config = createConfig(initConfig || {})
 	return createRematchStore(config)
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,25 +23,23 @@ export const init = <
 	return createRematchStore(config)
 }
 
+export interface ModelResult<S, R, BR, E> {
+	name?: string
+	state: S
+	reducers?: R
+	baseReducer?: BR
+	effects?: E
+}
+
 export const createModel: <RM extends Models<RM>>() => <
 	R extends ModelReducers<S>,
 	BR extends ReduxReducer<BS>,
 	E extends ModelEffects | ModelEffectsCreator<RM>,
 	S,
 	BS = S
->(mo: {
-	name?: string
-	state: S
-	reducers?: R
-	baseReducer?: BR
-	effects?: E
-}) => {
-	name?: string
-	state: S
-	reducers: R
-	baseReducer: BR
-	effects: E
-} = () => (mo): any => {
+>(
+	mo: ModelResult<S, R, BR, E>
+) => ModelResult<S, R, BR, E> = () => (mo): any => {
 	const { reducers = {}, effects = {} } = mo
 
 	return {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,13 +1,5 @@
-import { Reducer as ReduxReducer } from 'redux'
 import createRematchStore from './rematchStore'
-import {
-	InitConfig,
-	Models,
-	RematchStore,
-	ModelReducers,
-	ModelEffects,
-	ModelEffectsCreator,
-} from './types'
+import { InitConfig, Models, RematchStore, ModelCreator } from './types'
 import createConfig from './config'
 
 /**
@@ -23,25 +15,7 @@ export const init = <
 	return createRematchStore(config)
 }
 
-export const createModel: <RM extends Models<RM>>() => <
-	R extends ModelReducers<S>,
-	BR extends ReduxReducer<BS>,
-	E extends ModelEffects | ModelEffectsCreator<RM>,
-	S,
-	BS = S
->(mo: {
-	name?: string
-	state: S
-	reducers?: R
-	baseReducer?: BR
-	effects?: E
-}) => {
-	name?: string
-	state: S
-	reducers: R
-	baseReducer: BR
-	effects: E
-} = () => (mo): any => {
+export const createModel: ModelCreator = () => (mo): any => {
 	const { reducers = {}, effects = {} } = mo
 
 	return {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,23 +23,25 @@ export const init = <
 	return createRematchStore(config)
 }
 
-export interface ModelResult<S, R, BR, E> {
-	name?: string
-	state: S
-	reducers?: R
-	baseReducer?: BR
-	effects?: E
-}
-
 export const createModel: <RM extends Models<RM>>() => <
 	R extends ModelReducers<S>,
 	BR extends ReduxReducer<BS>,
 	E extends ModelEffects | ModelEffectsCreator<RM>,
 	S,
 	BS = S
->(
-	mo: ModelResult<S, R, BR, E>
-) => ModelResult<S, R, BR, E> = () => (mo): any => {
+>(mo: {
+	name?: string
+	state: S
+	reducers?: R
+	baseReducer?: BR
+	effects?: E
+}) => {
+	name?: string
+	state: S
+	reducers: R
+	baseReducer: BR
+	effects: E
+} = () => (mo): any => {
 	const { reducers = {}, effects = {} } = mo
 
 	return {

--- a/packages/core/src/reduxStore.ts
+++ b/packages/core/src/reduxStore.ts
@@ -18,7 +18,7 @@ import {
 export default function createReduxStore<
 	TModels extends Models<TModels> = Record<string, any>,
 	TExtraModels extends Models<TModels> = {},
-	RootState = RematchRootState<TModels & TExtraModels>
+	RootState = RematchRootState<TModels, TExtraModels>
 >(bag: RematchBag<TModels, TExtraModels>): Redux.Store<RootState> {
 	for (const model of bag.models) {
 		createModelReducer(bag, model)

--- a/packages/core/src/rematchStore.ts
+++ b/packages/core/src/rematchStore.ts
@@ -23,7 +23,7 @@ import createRematchBag from './bag'
 export default function createRematchStore<
 	TModels extends Models<TModels> = Record<string, any>,
 	TExtraModels extends Models<TModels> = {}
->(config: Config<TModels, TExtraModels>): RematchStore<TModels & TExtraModels> {
+>(config: Config<TModels, TExtraModels>): RematchStore<TModels, TExtraModels> {
 	// setup rematch 'bag' for storing useful values and functions
 	const bag = createRematchBag(config)
 
@@ -47,7 +47,7 @@ export default function createRematchStore<
 			this.replaceReducer(createRootReducer(bag))
 			reduxStore.dispatch({ type: '@@redux/REPLACE' })
 		},
-	} as RematchStore<TModels & TExtraModels>
+	} as RematchStore<TModels, TExtraModels>
 
 	addExposed(rematchStore, config.plugins)
 
@@ -114,7 +114,7 @@ function addExposed<
 	TModels extends Models<TModels> = Record<string, any>,
 	TExtraModels extends Models<TModels> = {}
 >(
-	store: RematchStore<TModels & TExtraModels>,
+	store: RematchStore<TModels, TExtraModels>,
 	plugins: Plugin<TModels, TExtraModels>[]
 ): void {
 	for (const plugin of plugins) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -250,8 +250,9 @@ export interface ConfigRedux<TRootState = any>
 }
 
 export interface RematchStore<
-	TModels extends Models<TModels> = Record<string, any>
-> extends ReduxStore<RematchRootState<TModels>, Action> {
+	TModels extends Models<TModels> = Record<string, any>,
+	TExtraModels extends Models<TModels> = {}
+> extends ReduxStore<RematchRootState<TModels, TExtraModels>, Action> {
 	[index: string]: ExposedFunction | Record<string, any> | string
 	name: string
 	dispatch: RematchDispatch<TModels>
@@ -264,17 +265,22 @@ export interface RematchStore<
  * The type of state held by a store.
  */
 export type RematchRootState<
-	TModels extends Models<TModels> = Record<string, any>
-> = ExtractRematchStateFromModels<TModels>
+	TModels extends Models<TModels> = Record<string, any>,
+	TExtraModels extends Models<TModels> = {}
+> = ExtractRematchStateFromModels<TModels, TExtraModels>
 
 /**
  * A mapping from each model's name to a type of state it holds.
  */
 export type ExtractRematchStateFromModels<
-	TModels extends Models<TModels> = Record<string, any>
+	TModels extends Models<TModels> = Record<string, any>,
+	TExtraModels extends Models<TModels> = {}
 > = {
 	[modelKey in keyof TModels]: TModels[modelKey]['state']
-}
+} &
+	{
+		[modelKey in keyof TExtraModels]: TExtraModels[modelKey]['state']
+	}
 
 /** ************************** Dispatch *************************** */
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -422,6 +422,28 @@ export interface DevtoolOptions {
 	[key: string]: any
 }
 
+export interface ModelCreator {
+	<RM extends Models<RM>>(): <
+		R extends ModelReducers<S>,
+		BR extends ReduxReducer<BS>,
+		E extends ModelEffects | ModelEffectsCreator<RM>,
+		S,
+		BS = S
+	>(mo: {
+		name?: string
+		state: S
+		reducers?: R
+		baseReducer?: BR
+		effects?: E
+	}) => {
+		name?: string
+		state: S
+		reducers: R
+		baseReducer: BR
+		effects: E
+	}
+}
+
 declare module 'redux' {
 	export interface Dispatch<A extends Action = AnyAction> {
 		[modelName: string]: any

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -435,7 +435,7 @@ export interface ModelCreator {
 	<RM extends Models<RM>>(): <
 		R extends ModelReducers<S>,
 		BR extends ReduxReducer<BS>,
-		E extends ModelEffects | ModelEffectsCreator<RM>,
+		E extends ModelEffects<RM> | ModelEffectsCreator<RM>,
 		S,
 		BS = S
 	>(mo: {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -117,15 +117,18 @@ export interface PluginHooks<
 	TExtraModels extends Models<TModels> = {}
 > {
 	onStoreCreated?: StoreCreatedHook<TModels, TExtraModels>
-	onModel?: ModelHook<TModels & TExtraModels>
+	onModel?: ModelHook<TModels, TExtraModels>
 	onReducer?: ReducerHook<TModels, TExtraModels>
 	onRootReducer?: RootReducerHook<TModels, TExtraModels>
 	createMiddleware?: MiddlewareCreator<TModels>
 }
 
-export type ModelHook<TModels extends Models<TModels> = Record<string, any>> = (
+export type ModelHook<
+	TModels extends Models<TModels> = Record<string, any>,
+	TExtraModels extends Models<TModels> = {}
+> = (
 	model: NamedModel<TModels>,
-	rematch: RematchStore<TModels>
+	rematch: RematchStore<TModels, TExtraModels>
 ) => void
 
 export type ReducerHook<
@@ -149,9 +152,9 @@ export type StoreCreatedHook<
 	TModels extends Models<TModels> = Record<string, any>,
 	TExtraModels extends Models<TModels> = {}
 > = (
-	store: RematchStore<TModels & TExtraModels>,
+	store: RematchStore<TModels, TExtraModels>,
 	rematch: RematchBag<TModels, TExtraModels>
-) => RematchStore<TModels & TExtraModels> | void
+) => RematchStore<TModels, TExtraModels> | void
 
 export type MiddlewareCreator<
 	TModels extends Models<TModels> = Record<string, any>,

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -24,7 +24,8 @@
     "src"
   ],
   "dependencies": {
-    "reselect": "^4.0.0"
+    "reselect": "^4.0.0",
+    "redux": "^4.0.0"
   },
   "devDependencies": {
     "@rematch/core": "^2.0.0-next.6"

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -24,13 +24,14 @@
     "src"
   ],
   "dependencies": {
-    "reselect": "^4.0.0",
-    "redux": "^4.0.0"
+    "reselect": "^4.0.0"
   },
   "devDependencies": {
+    "redux": "^4.0.0",
     "@rematch/core": "^2.0.0-next.6"
   },
   "peerDependencies": {
+    "redux": "^4.0.0",
     "@rematch/core": ">=2.0.0-next.0"
   },
   "husky": {

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -1,13 +1,13 @@
 // @ts-nocheck
 import {
 	Models,
-	NamedModel,
 	Plugin,
 	ExtractRematchStateFromModels,
 	Model,
 	ModelReducers,
 	ModelEffects,
 	ModelEffectsCreator,
+	RematchRootState,
 } from '@rematch/core'
 import { Reducer } from 'redux'
 import { createSelector, createStructuredSelector } from 'reselect'
@@ -118,7 +118,7 @@ export const createModelWithSelectors: <RM extends Models<RM>>() => <
 
 const createSelectPlugin = <
 	TModels extends Models<TModels>,
-	TExtraModels extends Models<TModels> = {}
+	TExtraModels extends Models<TModels> = Record<string, any>
 >(
 	config: SelectConfig = {}
 ): Plugin<TModels, TExtraModels> => {
@@ -144,7 +144,7 @@ const createSelectPlugin = <
 	}
 
 	const hasProps = (inner: any) =>
-		function (models: TModels) {
+		function (models: any) {
 			return selectorCreator(
 				(props: any) => props,
 				(props: any) => inner.call(this, models, props)
@@ -161,7 +161,11 @@ const createSelectPlugin = <
 			sliceState,
 			selectorCreator,
 		},
-		onModel(model: NamedModel<TModels>): void {
+		onModel(
+			model: Model<TModels> & {
+				selectors?: ModelSelectorsConfig<RematchRootState<TModels>>
+			}
+		): void {
 			select[model.name] = {}
 
 			const selectorFactories =

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -82,40 +82,6 @@ const validateSelector = (selectorFactories, selectorName, model): void => {
 	}
 }
 
-/**
- * Todo: could we extend types of standard createModel?
- */
-export const createModelWithSelectors: <RM extends Models<RM>>() => <
-	R extends ModelReducers<S>,
-	BR extends Reducer<BS>,
-	E extends ModelEffects | ModelEffectsCreator<RM>,
-	SE extends ModelSelectorsConfig<S>,
-	S,
-	BS = S
->(mo: {
-	name?: string
-	state: S
-	selectors?: SE
-	reducers?: R
-	baseReducer?: BR
-	effects?: E
-}) => {
-	name?: string
-	state: S
-	selectors?: SE
-	reducers: R
-	baseReducer: BR
-	effects: E
-} = () => (mo): any => {
-	const { reducers = {}, effects = {} } = mo
-
-	return {
-		...mo,
-		reducers,
-		effects,
-	}
-}
-
 const createSelectPlugin = <
 	TModels extends Models<TModels>,
 	TExtraModels extends Models<TModels> = Record<string, any>

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -1,17 +1,12 @@
-// @ts-nocheck
 import {
-	Models,
-	Plugin,
 	ExtractRematchStateFromModels,
 	Model,
-	ModelReducers,
-	ModelEffects,
-	ModelEffectsCreator,
-	RematchRootState,
+	Models,
+	Plugin,
+	RematchStore,
 } from '@rematch/core'
-import { Reducer } from 'redux'
 import { createSelector, createStructuredSelector } from 'reselect'
-import { ModelSelectorsConfig, SelectConfig } from './types'
+import { SelectConfig } from './types'
 
 const makeSelect = () => {
 	/**
@@ -25,12 +20,12 @@ const makeSelect = () => {
 		mapSelectToStructure: any,
 		structuredSelectorCreator = createStructuredSelector
 	) {
-		let func = (state, props) => {
+		let func = (state: any, props: any): any => {
 			func = structuredSelectorCreator(mapSelectToStructure(select))
 			return func(state, props)
 		}
 
-		return (state, props) => func(state, props)
+		return (state: any, props: any) => func(state, props)
 	}
 
 	return select
@@ -40,24 +35,26 @@ const makeFactoryGroup = () => {
 	let ready = false
 	const factories = new Set()
 	return {
-		add(added) {
+		add(added: any) {
 			if (!ready) {
-				added.forEach((factory) => factories.add(factory))
+				added.forEach((factory: any) => factories.add(factory))
 			} else {
-				added.forEach((factory) => factory())
+				added.forEach((factory: any) => factory())
 			}
 		},
-		finish(factory) {
+		finish(factory: any) {
 			factories.delete(factory)
 		},
 		startBuilding() {
 			ready = true
-			factories.forEach((factory) => factory())
+			factories.forEach((factory: any) => factory())
 		},
 	}
 }
 
-const validateConfig = (config: SelectConfig): void => {
+const validateConfig = <TModels extends Models<TModels>>(
+	config: SelectConfig<TModels>
+): void => {
 	if (process.env.NODE_ENV !== 'production') {
 		if (config.sliceState && typeof config.sliceState !== 'function') {
 			throw new Error('select plugin config sliceState must be a function')
@@ -72,7 +69,11 @@ const validateConfig = (config: SelectConfig): void => {
 	}
 }
 
-const validateSelector = (selectorFactories, selectorName, model): void => {
+const validateSelector = (
+	selectorFactories: any,
+	selectorName: any,
+	model: any
+): void => {
 	if (process.env.NODE_ENV !== 'production') {
 		if (typeof selectorFactories?.[selectorName] !== 'function') {
 			throw new Error(
@@ -86,19 +87,17 @@ const createSelectPlugin = <
 	TModels extends Models<TModels>,
 	TExtraModels extends Models<TModels> = Record<string, any>
 >(
-	config: SelectConfig = {}
+	config: SelectConfig<TModels> = {}
 ): Plugin<TModels, TExtraModels> => {
 	validateConfig(config)
 
-	const sliceState: ExtractRematchStateFromModels<TModels> =
-		config.sliceState ||
-		((state: ExtractRematchStateFromModels<TModels>, model: Model<TModels>) =>
-			state[model.name])
+	const sliceState: SelectConfig<TModels>['sliceState'] =
+		config.sliceState || ((state, model) => state[model.name || ''])
 	const selectorCreator = config.selectorCreator || createSelector
 
-	const slice = (
-		model: Model<TModels, ExtractRematchStateFromModels<TModels>>
-	) => (stateOrNext: ExtractRematchStateFromModels<TModels>) => {
+	const slice = (model: Model<TModels>) => (
+		stateOrNext: ExtractRematchStateFromModels<TModels>
+	) => {
 		if (typeof stateOrNext === 'function') {
 			return selectorCreator(
 				(state: ExtractRematchStateFromModels<TModels>) =>
@@ -110,7 +109,7 @@ const createSelectPlugin = <
 	}
 
 	const hasProps = (inner: any) =>
-		function (models: any) {
+		function (this: any, models: any) {
 			return selectorCreator(
 				(props: any) => props,
 				(props: any) => inner.call(this, models, props)
@@ -124,19 +123,18 @@ const createSelectPlugin = <
 	return {
 		exposed: {
 			select,
+			// @ts-ignore
 			sliceState,
 			selectorCreator,
 		},
-		onModel(
-			model: Model<TModels> & {
-				selectors?: ModelSelectorsConfig<RematchRootState<TModels>>
-			}
-		): void {
+		onModel(model: Model<TModels>) {
+			// @ts-ignore
 			select[model.name] = {}
 
 			const selectorFactories =
 				typeof model.selectors === 'function'
-					? model.selectors(slice(model), selectorCreator, hasProps)
+					? // @ts-ignore
+					  model.selectors(slice(model), selectorCreator, hasProps)
 					: model.selectors
 
 			factoryGroup.add(
@@ -145,14 +143,19 @@ const createSelectPlugin = <
 
 					const factory = () => {
 						factoryGroup.finish(factory)
+						// @ts-ignore
 						delete select[model.name][selectorName]
-						// eslint-disable-next-line no-return-assign
-						return (select[model.name][selectorName] = selectorFactories[
+						// @ts-ignore
+						select[model.name][selectorName] = selectorFactories[
 							selectorName
-						].call(select[model.name], select))
+							// @ts-ignore
+						].call(select[model.name], select)
+						// @ts-ignore
+						return select[model.name][selectorName]
 					}
 
 					// Define a getter for early constructing
+					// @ts-ignore
 					Object.defineProperty(select[model.name], selectorName, {
 						configurable: true,
 						get() {
@@ -164,8 +167,10 @@ const createSelectPlugin = <
 				})
 			)
 		},
-		onStoreCreated(store: any) {
+		// @ts-ignore
+		onStoreCreated(store: RematchStore) {
 			factoryGroup.startBuilding()
+			// @ts-ignore
 			store.select = select
 		},
 	}

--- a/packages/select/src/index.ts
+++ b/packages/select/src/index.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { NamedModel, Plugin } from '@rematch/core'
+import { Models, NamedModel, Plugin, RematchStore } from '@rematch/core'
 import { createSelector, createStructuredSelector } from 'reselect'
 import { SelectConfig } from './types'
 
@@ -72,7 +72,12 @@ const validateSelector = (selectorFactories, selectorName, model): void => {
 	}
 }
 
-const createSelectPlugin = (config: SelectConfig = {}): Plugin => {
+const createSelectPlugin = <
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels> = {}
+>(
+	config: SelectConfig = {}
+): Plugin<TModels, TExtraModels> => {
 	validateConfig(config)
 
 	const sliceState = config.sliceState || ((state, model) => state[model.name])
@@ -103,7 +108,7 @@ const createSelectPlugin = (config: SelectConfig = {}): Plugin => {
 			sliceState,
 			selectorCreator,
 		},
-		onModel(model: NamedModel): void {
+		onModel(model: NamedModel<TModels>): void {
 			select[model.name] = {}
 
 			const selectorFactories =
@@ -136,7 +141,7 @@ const createSelectPlugin = (config: SelectConfig = {}): Plugin => {
 				})
 			)
 		},
-		onStoreCreated(store): void {
+		onStoreCreated(store) {
 			factoryGroup.startBuilding()
 			store.select = select
 		},

--- a/packages/select/src/types.ts
+++ b/packages/select/src/types.ts
@@ -2,13 +2,10 @@
 // Definitions by: Sam Richard <https://github.com/d3dc>
 import {
 	Action,
-	ExposedFunction,
 	ModelEffects,
 	ModelEffectsCreator,
 	ModelReducers,
 	Models,
-	NamedModel,
-	RematchDispatch,
 	RematchRootState,
 } from '@rematch/core'
 import * as Reselect from 'reselect'
@@ -84,25 +81,15 @@ declare module '@rematch/core' {
 	// Add overloads for store to add select
 	interface RematchStore<TModels extends Models<TModels> = Record<string, any>>
 		extends ReduxStore<RematchRootState<TModels>, Action> {
-		[index: string]: ExposedFunction | Record<string, any> | string
-		name: string
-		dispatch: RematchDispatch<TModels>
 		select: RematchSelect<TModels, RematchRootState<TModels>>
-		addModel: (model: NamedModel<TModels>) => void
 	}
 
 	// add overloads for Model here.
 	interface Model<
 		TModels extends Models<TModels> = Record<string, any>,
-		TState = any,
-		TBaseState = TState
+		TState = any
 	> {
-		name?: string
-		state: TState
 		selectors?: ModelSelectorsConfig<TState>
-		reducers?: ModelReducers<TState>
-		baseReducer?: ReduxReducer<TBaseState>
-		effects?: ModelEffects<TModels> | ModelEffectsCreator<TModels>
 	}
 
 	// add overloads for ModelCreator here.

--- a/packages/select/src/types.ts
+++ b/packages/select/src/types.ts
@@ -44,8 +44,7 @@ export type SelectorParametricFactory<S, P = any> = (
 ) => Selector<S>
 
 export type Slicer<S, M = any, R = any> = Selector<S, void, M> &
-	((resultFn: (slice: M) => R) => Selector<S, void, R>)
-
+	((resultFn: (slice: S) => R) => Selector<S, void, R>)
 export type SelectorCreator = typeof Reselect.createSelector
 
 export type Parameterizer<S, P = any> = (

--- a/packages/select/src/types.ts
+++ b/packages/select/src/types.ts
@@ -7,6 +7,7 @@ import {
 	ModelReducers,
 	Models,
 	RematchRootState,
+	Model,
 } from '@rematch/core'
 import * as Reselect from 'reselect'
 import { Store as ReduxStore, Reducer as ReduxReducer } from 'redux'
@@ -18,64 +19,185 @@ export interface SelectConfig {
 	selectorCreator?: any
 }
 
-export type Selector<S, P = any, R = any> = Reselect.Selector<S, R> &
-	Reselect.ParametricSelector<S, P, R>
+export type Selector<TState, TReturns, TProps = void> = TProps extends void
+	? (state: TState) => TReturns
+	: (state: TState, props: TProps) => TReturns
 
-export interface ModelSelectors<S> {
-	[key: string]: Selector<S>
+export type ModelSelectors<
+	TModels extends Models<TModels> = Record<string, any>,
+	TModel extends Model<TModels> = Model<TModels>,
+	TRootState = Record<string, any>
+> = {
+	[key in keyof ExtractSelectorsFromModel<
+		TModels,
+		TModel
+	>]: ExtractSelectorsSignatureFromSelectorsModel<
+		TRootState,
+		ExtractSelectorsFromModel<TModels, TModel>,
+		key
+	>
 }
 
-export interface StoreSelectors<S> {
-	[key: string]: ModelSelectors<S>
+export type ReturnTypeOfSelectProps<TSelectProps> = {
+	[key in keyof TSelectProps]: TSelectProps[key] extends (
+		...args: any[]
+	) => infer TReturn
+		? TReturn
+		: never
 }
 
-export type SelectorFactory<S, P = any, R = any> = (
-	this: ModelSelectors<S>,
-	models: StoreSelectors<S>
-) => Selector<S, P, R>
+export type ExtractSelectorsFromModel<
+	TModels extends Models<TModels> = Record<string, any>,
+	TModel extends Model<TModels> = Model<TModels>
+> =
+	// thunk case: (models) => ({...})
+	TModel['selectors'] extends (...args: any[]) => infer TReturnObj
+		? TReturnObj
+		: // normal object case
+		TModel['selectors'] extends object
+		? TModel['selectors']
+		: never
 
-export type SelectorParametricFactory<S, P = any> = (
-	this: ModelSelectors<S>,
-	models: StoreSelectors<S>,
-	props: P
-) => Selector<S>
+export type ExtractSelectorsSignatureFromSelectorsModel<
+	TRootState,
+	TSelectorsConfigObject,
+	TKey extends keyof TSelectorsConfigObject
+> = TSelectorsConfigObject[TKey] extends (...args: any[]) => infer TSelector
+	? // hasProps case
+	  TSelector extends (props: infer TProps) => Selector<any, infer TReturns>
+		? (props: TProps) => Selector<TRootState, TReturns>
+		: // selector without props case
+		TSelector extends Selector<any, infer TReturns>
+		? Selector<TRootState, TReturns>
+		: // selector with props case
+		TSelector extends Selector<any, infer TReturns, infer TProps>
+		? Selector<TRootState, TReturns, TProps>
+		: never
+	: never
 
-export type Slicer<S, M = any, R = any> = Selector<S, void, M> &
-	((resultFn: (slice: S) => R) => Selector<S, void, R>)
+export type StoreSelectors<
+	TModels extends Models<TModels> = Record<string, any>,
+	TRootState = Record<string, any>
+> = {
+	[TModelKey in keyof TModels]: ModelSelectors<
+		TModels,
+		TModels[TModelKey],
+		TRootState
+	>
+}
+
+export type SelectorFactory<
+	TModels extends Models<TModels> = Record<string, any>,
+	TSliceState = Record<string, any>,
+	TRootState = Record<string, any>
+> = <TReturns>(
+	// FIXME: https://github.com/Microsoft/TypeScript/issues/27862
+	this: ModelSelectorFactories<TModels, TSliceState, TRootState>,
+	models: ModelsSelectors<TModels, TRootState>
+) => Selector<TRootState, TReturns>
+
+export type ModelsSelectors<
+	TModels extends Models<TModels> = Record<string, any>,
+	TRootState = Record<string, any>
+> = {
+	[key: string]: ModelSelectorFactories<TModels, TRootState>
+}
+
+export type SelectorParametricFactory<
+	TModels extends Models<TModels> = Record<string, any>,
+	TSliceState = Record<string, any>,
+	TRootState = Record<string, any>,
+	TProps = any,
+	TReturns = any
+> = (
+	// FIXME: https://github.com/Microsoft/TypeScript/issues/27862
+	this: ModelSelectorFactories<TModels, TSliceState, TRootState>,
+	models: ModelsSelectors<TModels, TRootState>,
+	props: TProps
+) => Selector<TRootState, TReturns, TProps>
+
+// the same as `SelectorParametricFactory` but with different return signature
+export type ParameterizerSelectorFactory<
+	TModels extends Models<TModels> = Record<string, any>,
+	TSliceState = Record<string, any>,
+	TRootState = Record<string, any>,
+	TProps = any,
+	TReturns = any
+> = (
+	// FIXME: https://github.com/Microsoft/TypeScript/issues/27862
+	this: ModelSelectorFactories<TModels, TSliceState, TRootState>,
+	models: ModelsSelectors<TModels, TRootState>,
+	props: TProps
+) => (props: TProps) => Selector<TRootState, TReturns>
+
+export type Slicer<TSliceState, TRootState> = (<TReturns>(
+	resultFn: (slice: TSliceState) => TReturns
+) => Selector<TRootState, TReturns>) &
+	Selector<TRootState, TSliceState>
 export type SelectorCreator = typeof Reselect.createSelector
 
-export type Parameterizer<S, P = any> = (
-	factory: SelectorParametricFactory<S, P>
-) => SelectorFactory<P, void, Selector<S>>
+export type Parameterizer<
+	TModels extends Models<TModels> = Record<string, any>,
+	TSliceState = Record<string, any>,
+	TRootState = Record<string, any>
+> = <TProps, TReturns>(
+	factory: SelectorParametricFactory<
+		TModels,
+		TSliceState,
+		TRootState,
+		TProps,
+		TReturns
+	>
+) => ParameterizerSelectorFactory<
+	TModels,
+	TSliceState,
+	TRootState,
+	TProps,
+	TReturns
+>
 
-export interface ModelSelectorFactories<S> {
-	[key: string]: SelectorFactory<S> | SelectorParametricFactory<S>
+export interface ModelSelectorFactories<
+	TModels extends Models<TModels> = Record<string, any>,
+	TSliceState = Record<string, any>,
+	TRootState = Record<string, any>
+> {
+	[key: string]:
+		| SelectorFactory<TModels, TSliceState, TRootState>
+		| SelectorParametricFactory<TModels, TSliceState, TRootState>
 }
 
-export type ModelSelectorsFactory<S> = (
-	slice: Slicer<S>,
+export type ModelSelectorsFactory<
+	TModels extends Models<TModels> = Record<string, any>,
+	S = any,
+	TRootState = Record<string, any>
+> = (
+	slice: Slicer<S, TRootState>,
 	createSelector: SelectorCreator,
-	hasProps: Parameterizer<S>
-) => ModelSelectorFactories<S>
+	hasProps: Parameterizer<TModels, S, TRootState>
+) => ModelSelectorFactories<TModels, S, TRootState>
 
-export type ModelSelectorsConfig<S> =
-	| ModelSelectorsFactory<S>
-	| ModelSelectorFactories<S>
+export type ModelSelectorsConfig<
+	TModels extends Models<TModels> = Record<string, any>,
+	S = any,
+	TRootState = Record<string, any>
+> =
+	| ModelSelectorsFactory<TModels, S, TRootState>
+	| ModelSelectorFactories<TModels, S, TRootState>
 
 export type RematchSelect<
 	TModels extends Models<TModels>,
-	RootState = Record<string, any>
+	TRootState = Record<string, any>
 > = ((
 	mapSelectToProps: (
-		select: RematchSelect<TModels, RootState>
+		select: RematchSelect<TModels, TRootState>
 	) => Record<string, any>
 ) => Reselect.OutputParametricSelector<
-	RootState,
+	TRootState,
 	any,
 	Record<string, any>,
-	Reselect.Selector<RootState, Record<string, any>>
+	Reselect.Selector<TRootState, Record<string, any>>
 >) &
-	StoreSelectors<RootState>
+	StoreSelectors<TModels, TRootState>
 
 declare module '@rematch/core' {
 	// Add overloads for store to add select
@@ -89,7 +211,7 @@ declare module '@rematch/core' {
 		TModels extends Models<TModels> = Record<string, any>,
 		TState = any
 	> {
-		selectors?: ModelSelectorsConfig<TState>
+		selectors?: ModelSelectorsConfig<TModels, TState, RematchRootState<TModels>>
 	}
 
 	// add overloads for ModelCreator here.
@@ -98,7 +220,7 @@ declare module '@rematch/core' {
 			R extends ModelReducers<S>,
 			BR extends ReduxReducer<BS>,
 			E extends ModelEffects | ModelEffectsCreator<RM>,
-			SE extends ModelSelectorsConfig<S>,
+			SE extends ModelSelectorsConfig<RM, S, RematchRootState<RM>>,
 			S,
 			BS = S
 		>(mo: {
@@ -111,7 +233,7 @@ declare module '@rematch/core' {
 		}) => {
 			name?: string
 			state: S
-			selectors?: SE
+			selectors: SE
 			reducers: R
 			baseReducer: BR
 			effects: E

--- a/packages/select/src/types.ts
+++ b/packages/select/src/types.ts
@@ -176,8 +176,10 @@ export type RematchSelect<
 
 declare module '@rematch/core' {
 	// Add overloads for store to add select
-	interface RematchStore<TModels extends Models<TModels> = Record<string, any>>
-		extends ReduxStore<RematchRootState<TModels>, Action> {
+	interface RematchStore<
+		TModels extends Models<TModels> = Record<string, any>,
+		TExtraModels extends Models<TModels> = {}
+	> extends ReduxStore<RematchRootState<TModels, TExtraModels>, Action> {
 		select: RematchSelect<TModels, RematchRootState<TModels>>
 	}
 

--- a/packages/select/src/types.ts
+++ b/packages/select/src/types.ts
@@ -81,14 +81,28 @@ export type RematchSelect<
 	StoreSelectors<RootState>
 
 declare module '@rematch/core' {
-	export interface RematchStore<
-		TModels extends Models<TModels> = Record<string, any>
-	> extends ReduxStore<RematchRootState<TModels>, Action> {
+	// Add overloads for store to add select
+	interface RematchStore<TModels extends Models<TModels> = Record<string, any>>
+		extends ReduxStore<RematchRootState<TModels>, Action> {
 		[index: string]: ExposedFunction | Record<string, any> | string
 		name: string
 		dispatch: RematchDispatch<TModels>
 		select: RematchSelect<TModels, RematchRootState<TModels>>
 		addModel: (model: NamedModel<TModels>) => void
+	}
+
+	// add overloads for Model here.
+	interface Model<
+		TModels extends Models<TModels> = Record<string, any>,
+		TState = any,
+		TBaseState = TState
+	> {
+		name?: string
+		state: TState
+		selectors?: ModelSelectorsConfig<TState>
+		reducers?: ModelReducers<TState>
+		baseReducer?: ReduxReducer<TBaseState>
+		effects?: ModelEffects<TModels> | ModelEffectsCreator<TModels>
 	}
 
 	// add overloads for ModelCreator here.

--- a/packages/select/src/types.ts
+++ b/packages/select/src/types.ts
@@ -3,13 +3,16 @@
 import {
 	Action,
 	ExposedFunction,
+	ModelEffects,
+	ModelEffectsCreator,
+	ModelReducers,
 	Models,
 	NamedModel,
 	RematchDispatch,
 	RematchRootState,
 } from '@rematch/core'
 import * as Reselect from 'reselect'
-import { Store as ReduxStore } from 'redux'
+import { Store as ReduxStore, Reducer as ReduxReducer } from 'redux'
 
 export { createSelector, createStructuredSelector } from 'reselect'
 
@@ -86,5 +89,31 @@ declare module '@rematch/core' {
 		dispatch: RematchDispatch<TModels>
 		select: RematchSelect<TModels, RematchRootState<TModels>>
 		addModel: (model: NamedModel<TModels>) => void
+	}
+
+	// add overloads for ModelCreator here.
+	interface ModelCreator {
+		<RM extends Models<RM>>(): <
+			R extends ModelReducers<S>,
+			BR extends ReduxReducer<BS>,
+			E extends ModelEffects | ModelEffectsCreator<RM>,
+			SE extends ModelSelectorsConfig<S>,
+			S,
+			BS = S
+		>(mo: {
+			name?: string
+			state: S
+			selectors?: SE
+			reducers?: R
+			baseReducer?: BR
+			effects?: E
+		}) => {
+			name?: string
+			state: S
+			selectors?: SE
+			reducers: R
+			baseReducer: BR
+			effects: E
+		}
 	}
 }

--- a/packages/select/src/types.ts
+++ b/packages/select/src/types.ts
@@ -194,7 +194,7 @@ declare module '@rematch/core' {
 		<RM extends Models<RM>>(): <
 			R extends ModelReducers<S>,
 			BR extends ReduxReducer<BS>,
-			E extends ModelEffects | ModelEffectsCreator<RM>,
+			E extends ModelEffects<RM> | ModelEffectsCreator<RM>,
 			SE extends ModelSelectorsConfig<S, RematchRootState<RM>>,
 			S,
 			BS = S

--- a/packages/select/src/types.ts
+++ b/packages/select/src/types.ts
@@ -3,16 +3,13 @@
 import {
 	Action,
 	ExposedFunction,
-	ModelEffects,
-	ModelEffectsCreator,
-	ModelReducers,
 	Models,
 	NamedModel,
 	RematchDispatch,
 	RematchRootState,
 } from '@rematch/core'
 import * as Reselect from 'reselect'
-import { Reducer as ReduxReducer, Store as ReduxStore } from 'redux'
+import { Store as ReduxStore } from 'redux'
 
 export { createSelector, createStructuredSelector } from 'reselect'
 
@@ -65,45 +62,29 @@ export type ModelSelectorsConfig<S> =
 	| ModelSelectorsFactory<S>
 	| ModelSelectorFactories<S>
 
-export type RematchSelect<TModels extends Models<TModels>, RootState = any> = ((
-	mapSelectToProps: (select: RematchSelect<TModels, RootState>) => object
+export type RematchSelect<
+	TModels extends Models<TModels>,
+	RootState = Record<string, any>
+> = ((
+	mapSelectToProps: (
+		select: RematchSelect<TModels, RootState>
+	) => Record<string, any>
 ) => Reselect.OutputParametricSelector<
 	RootState,
 	any,
-	object,
-	Reselect.Selector<RootState, object>
+	Record<string, any>,
+	Reselect.Selector<RootState, Record<string, any>>
 >) &
 	StoreSelectors<RootState>
 
 declare module '@rematch/core' {
-	export interface Model<
-		TModels extends Models<TModels> = Record<string, any>,
-		TState = any,
-		TBaseState = TState
-	> {
-		name?: string
-		state: TState
-		selectors?: ModelSelectorsConfig<TState>
-		reducers?: ModelReducers<TState>
-		baseReducer?: ReduxReducer<TBaseState>
-		effects?: ModelEffects<TModels> | ModelEffectsCreator<TModels>
-	}
-
-	export interface ModelResult<S, R, BR, E> {
-		name?: string
-		state: S
-		reducers?: R
-		selectors?: ModelSelectorsConfig<S>
-		baseReducer?: BR
-		effects?: E
-	}
-
 	export interface RematchStore<
 		TModels extends Models<TModels> = Record<string, any>
 	> extends ReduxStore<RematchRootState<TModels>, Action> {
 		[index: string]: ExposedFunction | Record<string, any> | string
 		name: string
 		dispatch: RematchDispatch<TModels>
+		select: RematchSelect<TModels, RematchRootState<TModels>>
 		addModel: (model: NamedModel<TModels>) => void
 	}
 }

--- a/packages/select/src/types.ts
+++ b/packages/select/src/types.ts
@@ -1,7 +1,18 @@
 // Type definitions for @rematch/select 3.0.0
 // Definitions by: Sam Richard <https://github.com/d3dc>
-import { Models, RematchRootState } from '@rematch/core'
+import {
+	Action,
+	ExposedFunction,
+	ModelEffects,
+	ModelEffectsCreator,
+	ModelReducers,
+	Models,
+	NamedModel,
+	RematchDispatch,
+	RematchRootState,
+} from '@rematch/core'
 import * as Reselect from 'reselect'
+import { Reducer as ReduxReducer, Store as ReduxStore } from 'redux'
 
 export { createSelector, createStructuredSelector } from 'reselect'
 
@@ -55,8 +66,8 @@ export type ModelSelectorsConfig<S> =
 	| ModelSelectorsFactory<S>
 	| ModelSelectorFactories<S>
 
-export type RematchSelect<M extends object = Models, RootState = any> = ((
-	mapSelectToProps: (select: RematchSelect<M, RootState>) => object
+export type RematchSelect<TModels extends Models<TModels>, RootState = any> = ((
+	mapSelectToProps: (select: RematchSelect<TModels, RootState>) => object
 ) => Reselect.OutputParametricSelector<
 	RootState,
 	any,
@@ -66,15 +77,34 @@ export type RematchSelect<M extends object = Models, RootState = any> = ((
 	StoreSelectors<RootState>
 
 declare module '@rematch/core' {
-	interface Model<
+	export interface Model<
 		TModels extends Models<TModels> = Record<string, any>,
 		TState = any,
 		TBaseState = TState
 	> {
+		name?: string
+		state: TState
 		selectors?: ModelSelectorsConfig<TState>
+		reducers?: ModelReducers<TState>
+		baseReducer?: ReduxReducer<TBaseState>
+		effects?: ModelEffects<TModels> | ModelEffectsCreator<TModels>
 	}
 
-	interface RematchStore<TModels> {
-		select: RematchSelect<TModels, RematchRootState<TModels>>
+	export interface ModelResult<S, R, BR, E> {
+		name?: string
+		state: S
+		reducers?: R
+		selectors?: ModelSelectorsConfig<S>
+		baseReducer?: BR
+		effects?: E
+	}
+
+	export interface RematchStore<
+		TModels extends Models<TModels> = Record<string, any>
+	> extends ReduxStore<RematchRootState<TModels>, Action> {
+		[index: string]: ExposedFunction | Record<string, any> | string
+		name: string
+		dispatch: RematchDispatch<TModels>
+		addModel: (model: NamedModel<TModels>) => void
 	}
 }


### PR DESCRIPTION
### TODO:
- [x] is it a good practice create a createModelWithSelectors<RootModel>()({})? or could we extends native createModel for plugins?

- selectors on model has three props, we must guarantee it doesn't have errors:
	- [X]  selectors: (slice) => ...
	- [ ]  selectors: (slice, createSelector) => ...
	- [ ]  selectors: (slice, createSelector, hasProps) => ...


- [x] store.select is not autocompleted
```jsx
const selection = store.select(models => ({
  // todo: this isn't getting autocompleted
  total: models.cart.total,
}))
```

- [x] second param shouldn't be required, or yes?.. take a look at reselect examples
```jsx
const mapState = (state: RootState) => ({
	settingsState: state.settings,
  loadingState: state.loading,
  playersState: state.players,
  // todo: props shouldn't be required
  ...selection(state, null)
})
```

- [x] Props for class and hooks, should be filled...
```jsx
// todo: we must type the props autocomplete of the selector new values
type Props = StateProps & DispatchProps
```
- [x] Props for class and hooks, should be filled...
```jsx
// todo: we must type the props autocomplete of the selector new values
type Props = StateProps & DispatchProps
```
