### PR TITLE
feat: support optional payload parameter on reducer

### DIFF
--- a/examples/hooks-react-ts/src/App.tsx
+++ b/examples/hooks-react-ts/src/App.tsx
@@ -13,8 +13,11 @@ const Count = () => {
 			<div style={{ width: 120 }}>
 				<h3>Dolphins</h3>
 				<h1>{dolphins}</h1>
-				<button onClick={dispatch.dolphins.increment}>+1</button>
-				<button onClick={dispatch.dolphins.incrementAsync}>Async +1</button>
+				<button onClick={() => dispatch.dolphins.increment()}>+1</button>
+				<button onClick={() => dispatch.dolphins.increment(3)}>+3</button>
+				<button onClick={() => dispatch.dolphins.incrementAsync()}>
+					Async +1
+				</button>
 			</div>
 			<div style={{ width: 200 }}>
 				<h3>Sharks</h3>

--- a/examples/hooks-react-ts/src/models/dolphins.ts
+++ b/examples/hooks-react-ts/src/models/dolphins.ts
@@ -5,7 +5,7 @@ import { RootModel } from '.';
 export const dolphins = createModel<RootModel>()({
 	state: 0,
 	reducers: {
-		increment: (state) => state + 1,
+		increment: (state, payload: number = 1) => state + payload,
 	},
 	effects: (dispatch) => ({
 		async incrementAsync() {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -337,7 +337,9 @@ export type ExtractRematchDispatcherFromReducer<
 > = TReducer extends () => any
 	? RematchDispatcher
 	: TReducer extends (state: TState) => TState
-	? RematchDispatcher
+	? Parameters<TReducer> extends [TState]
+		? RematchDispatcher
+		: RematchDispatcher<Parameters<TReducer>[1] | undefined>
 	: TReducer extends (state: TState, payload: infer TPayload) => TState
 	? RematchDispatcher<TPayload>
 	: never
@@ -350,6 +352,8 @@ export type ExtractRematchDispatcherFromReducer<
  */
 export type RematchDispatcher<TPayload = void> = [TPayload] extends [void]
 	? (() => Action<void>) & { isEffect: false }
+	: undefined extends TPayload
+	? ((payload?: TPayload) => Action<TPayload>) & { isEffect: false }
 	: ((payload: TPayload) => Action<TPayload>) & { isEffect: false }
 
 /** ************************ Effects Dispatcher ************************* */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -339,7 +339,7 @@ export type ExtractRematchDispatcherFromReducer<
 	: TReducer extends (state: TState) => TState
 	? Parameters<TReducer> extends [TState]
 		? RematchDispatcher
-		: RematchDispatcher<Parameters<TReducer>[1] | undefined>
+		: RematchDispatcher<Parameters<TReducer>[1]>
 	: TReducer extends (state: TState, payload: infer TPayload) => TState
 	? RematchDispatcher<TPayload>
 	: never


### PR DESCRIPTION
In my project, I came across the following scenario. 

I have a shared store that controls whether a global loading icon should show/hide. The global loading components supports an optional text.

Obviously, I call two reducers for each store field.  I'm thinking if we can do
```javascript
dispatch.globalLoading.show();  // only show loading icon

dispatch.globalLoading.show('Please wait...') // show loading icon with text
```
 
which is more simple and easy to use(in my opinion) 😃 