### PR TITLE
fix(loading): fix ts type when asNumber enabled

### DIFF
--- a/docs/plugins/loading.md
+++ b/docs/plugins/loading.md
@@ -88,6 +88,15 @@ export const store = init<RootModel, FullModel>({
 	  plugins: [loadingPlugin()],
 })
 
+// or
+// type FullModel =  ExtraModelsFromLoading<RootModel, { asNumber: true }>
+//
+// export const store = init<RootModel, FullModel>({
+//     models,
+//     // add loadingPlugin to your store
+//     plugins: [loadingPlugin({ asNumber: true })],
+// })
+
 export type Store = typeof store
 export type Dispatch = RematchDispatch<RootModel>
 export type RootState = RematchRootState<RootModel, FullModel>

--- a/packages/loading/src/index.ts
+++ b/packages/loading/src/index.ts
@@ -56,9 +56,14 @@ interface LoadingModel<
 	}
 }
 
-export interface ExtraModelsFromLoading<TModels extends Models<TModels>>
-	extends Models<TModels> {
-	loading: LoadingModel<TModels>
+export interface ExtraModelsFromLoading<
+	TModels extends Models<TModels>,
+	Config extends { asNumber: boolean } = { asNumber: false }
+> extends Models<TModels> {
+	loading: LoadingModel<
+		TModels,
+		Config extends { asNumber: true } ? true : false
+	>
 }
 
 const createLoadingAction = <
@@ -123,10 +128,20 @@ const validateConfig = (config: LoadingConfig): void => {
 
 export default <
 	TModels extends Models<TModels>,
-	TExtraModels extends Models<TModels> = {}
+	TExtraModels extends Models<TModels>,
+	T extends LoadingConfig
 >(
-	config: LoadingConfig = {}
-): Plugin<TModels, TExtraModels, ExtraModelsFromLoading<TModels>> => {
+	config: T = {} as T
+): Plugin<
+	TModels,
+	TExtraModels,
+	ExtraModelsFromLoading<
+		TModels,
+		T['asNumber'] extends boolean
+			? { asNumber: T['asNumber'] }
+			: { asNumber: false }
+	>
+> => {
 	validateConfig(config)
 
 	const loadingModelName = config.name || 'loading'

--- a/packages/loading/test/loading-asNumber.test.ts
+++ b/packages/loading/test/loading-asNumber.test.ts
@@ -1,12 +1,14 @@
 import { init } from '@rematch/core'
 import loadingPlugin, { ExtraModelsFromLoading } from '../src'
-import { delay, count, Models, ExtraModels } from './utils'
+import { delay, count, Models } from './utils'
+
+type ExtraModels = ExtraModelsFromLoading<Models, { asNumber: true }>
 
 describe('loading asNumbers', () => {
 	test('loading.global should be 0 for normal dispatched action', () => {
 		const store = init({
-			models: { count } as Models,
-			plugins: [loadingPlugin<Models, ExtraModels>({ asNumber: true })],
+			models: { count },
+			plugins: [loadingPlugin({ asNumber: true })],
 		})
 
 		store.dispatch.count.addOne()
@@ -14,7 +16,7 @@ describe('loading asNumbers', () => {
 	})
 
 	test('loading.global should be 1 for a dispatched effect', () => {
-		const store = init<Models, ExtraModels>({
+		const store = init({
 			models: { count },
 			plugins: [loadingPlugin({ asNumber: true })],
 		})
@@ -108,7 +110,7 @@ describe('loading asNumbers', () => {
 			reducers: {},
 		}
 		type Models = { count: typeof count2 }
-		type ExtraModels = ExtraModelsFromLoading<Models>
+		type ExtraModels = ExtraModelsFromLoading<Models, { asNumber: true }>
 
 		const store = init<Models, ExtraModels>({
 			models: { count: count2 },
@@ -153,6 +155,7 @@ describe('loading asNumbers', () => {
 			init<Models, ExtraModels>({
 				models: { count },
 				plugins: [
+					// @ts-expect-error
 					loadingPlugin({
 						asNumber: true,
 						// @ts-expect-error
@@ -169,6 +172,7 @@ describe('loading asNumbers', () => {
 			init<Models, ExtraModels>({
 				models: { count },
 				plugins: [
+					// @ts-expect-error
 					loadingPlugin({
 						// @ts-expect-error
 						asNumber: 'should throw',
@@ -214,6 +218,7 @@ describe('loading asNumbers', () => {
 			init<Models, ExtraModels>({
 				models: { count },
 				plugins: [
+					// @ts-expect-error
 					loadingPlugin({
 						asNumber: true,
 						// @ts-expect-error
@@ -230,6 +235,7 @@ describe('loading asNumbers', () => {
 			init<Models, ExtraModels>({
 				models: { count },
 				plugins: [
+					// @ts-expect-error
 					loadingPlugin({
 						asNumber: true,
 						// @ts-expect-error
@@ -268,7 +274,7 @@ describe('loading asNumbers', () => {
 			reducers: {},
 		}
 		type Models = { count: typeof count2 }
-		type ExtraModels = ExtraModelsFromLoading<Models>
+		type ExtraModels = ExtraModelsFromLoading<Models, { asNumber: true }>
 
 		const store = init<Models, ExtraModels>({
 			models: { count: count2 },
@@ -317,7 +323,7 @@ describe('loading asNumbers', () => {
 			reducers: {},
 		}
 		type Models = { count: typeof count2 }
-		type ExtraModels = ExtraModelsFromLoading<Models>
+		type ExtraModels = ExtraModelsFromLoading<Models, { asNumber: true }>
 
 		const store = init<Models, ExtraModels>({
 			models: { count: count2 },
@@ -343,7 +349,7 @@ describe('loading asNumbers', () => {
 		}
 
 		type Models = { count: typeof count2 }
-		type ExtraModels = ExtraModelsFromLoading<Models>
+		type ExtraModels = ExtraModelsFromLoading<Models, { asNumber: true }>
 
 		const store = init<Models, ExtraModels>({
 			models: { count: count2 },
@@ -367,7 +373,7 @@ describe('loading asNumbers', () => {
 			reducers: {},
 		}
 		type Models = { count: typeof count2 }
-		type ExtraModels = ExtraModelsFromLoading<Models>
+		type ExtraModels = ExtraModelsFromLoading<Models, { asNumber: true }>
 
 		const store = init<Models, ExtraModels>({
 			models: { count: count2 },


### PR DESCRIPTION
### What's the problem?

The `loading` state value has a `boolean` type even when `asNumber` is enabled.

![WX20201204-114827](https://user-images.githubusercontent.com/1198651/101121408-12182d00-362b-11eb-95fc-ce66fb13aec9.png)


### Why this happens?

![image](https://user-images.githubusercontent.com/1198651/101121787-ec3f5800-362b-11eb-8304-7a452215ee8b.png)


### What I did to fix that?

Add an optional parameter to `ExtraModelsFromLoading` to let the developer specify whether `asNumber` is enabled.

