### PR TITLE
fix: add missing variable for import statement

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -251,7 +251,7 @@ ReactDOM.render(
 ```typescript
 import * as React from 'react'
 import { connect } from 'react-redux'
-import { RootState, Dispatch } from './store'
+import { RootState, Dispatch, store } from './store'
 
 const mapState = (state: RootState) => ({
 	count: state.count,


### PR DESCRIPTION
When I refer to the TypeScript sample code, I found there is a missing variable in `import { RootState, Dispatch } from './store'` statement. so...it is suggested to add it :)