### PR TITLE
fix: Reduced @rematch/core bundle-size

### DIFF
--- a/packages/core/src/reduxStore.ts
+++ b/packages/core/src/reduxStore.ts
@@ -158,12 +158,10 @@ function mergeReducers<TRootState>(
 function composeEnhancersWithDevtools(
 	devtoolOptions: DevtoolOptions = {}
 ): (...args: any[]) => Redux.StoreEnhancer {
-	const { disabled, ...options } = devtoolOptions
-
-	return !disabled &&
+	return !devtoolOptions.disabled &&
 		typeof window === 'object' &&
 		window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
-		? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__(options)
+		? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__(devtoolOptions)
 		: Redux.compose
 }
 


### PR DESCRIPTION
Decreased more the size of core library, doing this we remove a polyfill used in IE11 :)