### PR TITLE
fix: @rematch/select structured selector typing (#866)

### DIFF
--- a/packages/select/src/types.ts
+++ b/packages/select/src/types.ts
@@ -152,17 +152,17 @@ export type ModelSelectorsConfig<
 export type RematchSelect<
 	TModels extends Models<TModels>,
 	TRootState = RematchRootState<TModels>
-> = (<TReturn>(
+> = (<TReturn extends { [key: string]: (state: TRootState) => any }>(
 	mapSelectToProps: (select: RematchSelect<TModels>) => TReturn
 ) => Reselect.OutputParametricSelector<
 	TRootState,
 	any,
-	TReturn,
+	{ [K in keyof TReturn]: ReturnType<TReturn[K]> },
 	Reselect.Selector<TRootState, Record<string, any>>
 > &
 	Reselect.OutputSelector<
 		TRootState,
-		TReturn,
+		{ [K in keyof TReturn]: ReturnType<TReturn[K]> },
 		Reselect.Selector<TRootState, Record<string, any>>
 	>) &
 	StoreSelectors<TModels>

--- a/packages/select/test/select.test.ts
+++ b/packages/select/test/select.test.ts
@@ -353,7 +353,7 @@ describe('select:', () => {
 				b: models.countB.double,
 			}))
 
-			const result = selector(state, undefined)
+			const result: { a: number; b: number } = selector(state, undefined)
 			expect(result).toEqual({ a: 4, b: 20 })
 		})
 	})


### PR DESCRIPTION
This should fix structured selector typing where executing a structured selector returned the correct selector values, but typescript indicated that the values are actually selectors. See #866 for more info.

I updated an existing test case that explicitly defines expected return types.