### PR TITLE
docs: fix immer plugin href

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -49,7 +49,7 @@ Migrating from Redux to Rematch may only involve minor changes to your state man
 
 ## Composable Plugins
 
-Rematch and its internals are all built upon a plugin pipeline. As a result, developers can make complex custom plugins that modify the setup or add data models, often without requiring any changes to Rematch itself. See the [plugins](plugins) developed by the Rematch team or the [API for creating plugins](api-reference/plugins).
+Rematch and its internals are all built upon a plugin pipeline. As a result, developers can make complex custom plugins that modify the setup or add data models, often without requiring any changes to Rematch itself. See the [plugins](plugins/) developed by the Rematch team or the [API for creating plugins](api-reference/plugins).
 
 
 ## All plugins


### PR DESCRIPTION
## problem

If you in [docs](https://rematchjs.org/docs/), and then click plugin hyperlink in **Composable Plugins**. After that, your current location is `https://rematchjs.org/docs/plugins`. Finally, click the plugin list such as **Immer Plugin** hyperlink, you will get `Page Not Found`.
