### PR TITLE
fix: make models on init() Partial<T>

### DIFF
--- a/packages/core/src/bag.ts
+++ b/packages/core/src/bag.ts
@@ -30,9 +30,9 @@ export default function createRematchBag<
  */
 function createNamedModels<
 	TModels extends Models<TModels> = Record<string, any>
->(models: TModels): NamedModel<TModels>[] {
+>(models: TModels | Partial<TModels>): NamedModel<TModels>[] {
 	return Object.keys(models).map((modelName: string) => {
-		const model = createNamedModel(modelName, models[modelName])
+		const model = createNamedModel(modelName, (models as TModels)[modelName])
 		validateModel(model)
 		return model
 	})

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -208,7 +208,7 @@ export interface InitConfig<
 	TExtraModels extends Models<TModels> = Record<string, any>
 > {
 	name?: string
-	models?: TModels
+	models?: TModels | Partial<TModels>
 	plugins?: Plugin<TModels, TExtraModels>[]
 	redux?: InitConfigRedux
 }
@@ -223,7 +223,7 @@ export interface Config<
 	TExtraModels extends Models<TModels> = Record<string, any>
 > extends InitConfig<TModels, TExtraModels> {
 	name: string
-	models: TModels
+	models: TModels | Partial<TModels>
 	plugins: Plugin<TModels, TExtraModels>[]
 	redux: ConfigRedux
 }


### PR DESCRIPTION
https://github.com/rematch/rematch/pull/891/files#diff-1f8711ffcf4ef0b26aea69d164072937102d5109ecfd8790b6e879c7421e00d3

Since I've checked how it's the strategy with typescript and `addModel`, has sense to define a RootModel which is Partial<T> of a complete RootModel.

```ts
import { Models } from '@rematch/core'
import { players } from './players'
import { settings } from './settings'
import { cart } from './cart'

export interface RootModel extends Models<RootModel> {
	players: typeof players
	cart: typeof cart
	settings: typeof settings
}

export const models: Partial<RootModel> = { players, cart }
```

In this way we can define the complete typings but a FUTURE usage, but the current models isn't complete yet.

