### PR TITLE
ci: added nightly builds for testing typescript next

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           # pulls all commits (needed for lerna to correctly version)
           fetch-depth: "0"
 
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
         with:
             always-auth: true
             node-version: 14

--- a/.github/workflows/next-typescript-ci.yml
+++ b/.github/workflows/next-typescript-ci.yml
@@ -17,7 +17,7 @@ jobs:
           # pulls all commits (needed for lerna to correctly version)
           fetch-depth: "0"
 
-      - uses: actions/setup-node@v2-beta
+      - uses: actions/setup-node@v2
         with:
             always-auth: true
             node-version: 14

--- a/.github/workflows/next-typescript-ci.yml
+++ b/.github/workflows/next-typescript-ci.yml
@@ -1,0 +1,51 @@
+name: Rematch Nightly Suite + Typescript@next
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  next-typescript-ci:
+    runs-on: ubuntu-latest
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
+    env:
+      CI: true
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # pulls all commits (needed for lerna to correctly version)
+          fetch-depth: "0"
+
+      - uses: actions/setup-node@v2-beta
+        with:
+            always-auth: true
+            node-version: 14
+            scope: '@rematch'
+      - name: Creates local .npmrc
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install
+        run: yarn install --frozen-lockfile --pure-lockfile
+
+      - name: Add Typescript@next
+        run: yarn add --dev typescript@next -W
+
+      - name: Build & Testing
+        run: |
+          yarn build
+          yarn test
+          yarn lint
+          yarn prettier:check


### PR DESCRIPTION
Will close #895

Also we get rid of setup-node@v2-beta, already it's stable with @v2