### PR TITLE
fix: optional payload inference

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -345,30 +345,18 @@ export type ExtractRematchDispatchersFromReducers<
  * appropriate type for a dispatcher. Mapping goes like this:
  * - reducer not taking any parameters -> 'empty' dispatcher
  * - reducer only taking state -> 'empty' dispatcher
- * - reducer taking both state and payload -> dispatcher accepting payload as an argument
- * - reducer taking state, payload and meta -> dispatcher accepting payload and meta as arguments
+ * - reducer taking state and optional payload (and may also taking optional meta)
+ * 	 -> dispatcher accepting payload and meta as arguments
  */
 export type ExtractRematchDispatcherFromReducer<
 	TState,
 	TReducer
 > = TReducer extends () => any
 	? RematchDispatcher
-	: TReducer extends (state: TState) => TState // support optional payload(and meta) like `(state: TState, payload?: ..., meta?: ...) => TState`
-	? Parameters<TReducer> extends [TState]
+	: TReducer extends (state: TState, ...args: infer TRest) => TState
+	? TRest extends []
 		? RematchDispatcher
-		: Parameters<TReducer>[2] extends undefined
-		? RematchDispatcher<Parameters<TReducer>[1]>
-		: RematchDispatcher<Parameters<TReducer>[1], Parameters<TReducer>[2]>
-	: TReducer extends (state: TState, payload: infer TPayload) => TState // support optional meta like `(state: TState, payload: ..., meta?: ...) => TState`
-	? Parameters<TReducer> extends [TState, TPayload]
-		? RematchDispatcher<TPayload>
-		: RematchDispatcher<Parameters<TReducer>[1], Parameters<TReducer>[2]>
-	: TReducer extends (
-			state: TState,
-			payload: infer TPayload,
-			meta: infer TMeta
-	  ) => TState
-	? RematchDispatcher<TPayload, TMeta>
+		: RematchDispatcher<TRest[0], TRest[1]>
 	: never
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -358,7 +358,6 @@ export type ExtractRematchDispatcherFromReducer<
 		? RematchDispatcher
 		: RematchDispatcher<TRest[0], TRest[1]>
 	: never
-
 /**
  * When payload is of type void, it describes 'empty' dispatcher - meaning
  * it's a function not taking any arguments and returning an action.
@@ -434,34 +433,47 @@ export type ExtractRematchDispatchersFromEffectsObject<
  */
 export type ExtractRematchDispatcherFromEffect<
 	TEffect extends ModelEffect<TModels>,
-	TModels extends Models<TModels> = Record<string, any>
-> = TEffect extends () => infer TReturn
-	? EffectRematchDispatcher<TReturn>
-	: TEffect extends (payload: infer TPayload) => infer TReturn
-	? EffectRematchDispatcher<TReturn, TPayload>
-	: TEffect extends (payload: infer TPayload, state: any) => infer TReturn
-	? EffectRematchDispatcher<TReturn, TPayload>
-	: TEffect extends (
-			payload: infer TPayload,
-			state: any,
-			meta: infer TMeta
-	  ) => infer TReturn
-	? EffectRematchDispatcher<TReturn, TPayload, TMeta>
+	TModels extends Models<TModels>
+> = TEffect extends (...args: infer TRest) => infer TReturn
+	? TRest[1] extends undefined
+		? EffectRematchDispatcher<TReturn, TRest[0]>
+		: RematchRootState<TModels> extends TRest[1]
+		? EffectRematchDispatcher<TReturn, TRest[0], TRest[2]>
+		: never
 	: never
 
 /**
  * When payload is of type void, it describes 'empty' dispatcher - meaning
  * it's a function not taking any arguments and returning an action.
- * Otherwise, it describes dispatcher which accepts one argument (payload)
+ * Can be the case that payload is optional in the effect so, also handles payload as optional
+ * Otherwise, it describes dispatcher which accepts one argument (payload and a optional meta)
  * and returns an action.
  */
 export type EffectRematchDispatcher<
 	TReturn = any,
 	TPayload = void,
 	TMeta = void
-> = [TPayload] extends [void]
+> = [TPayload, TMeta] extends [void, void]
 	? (() => TReturn) & { isEffect: true }
-	: ((payload: TPayload, meta: TMeta) => TReturn) & { isEffect: true }
+	: [TMeta] extends [void]
+	? undefined extends TPayload
+		? ((payload?: TPayload) => TReturn) & {
+				isEffect: true
+		  }
+		: ((payload: TPayload) => TReturn) & {
+				isEffect: true
+		  }
+	: [undefined, undefined] extends [TPayload, TMeta]
+	? ((payload?: TPayload, meta?: TMeta) => TReturn) & {
+			isEffect: true
+	  }
+	: undefined extends TMeta
+	? ((payload: TPayload, meta?: TMeta) => TReturn) & {
+			isEffect: true
+	  }
+	: ((payload: TPayload, meta: TMeta) => TReturn) & {
+			isEffect: true
+	  }
 
 export interface DevtoolOptions {
 	/**

--- a/packages/core/test/ts_typings/circular-references.test.ts
+++ b/packages/core/test/ts_typings/circular-references.test.ts
@@ -1,4 +1,4 @@
-import { createModel, Models } from '../src'
+import { createModel, Models } from '../../src'
 
 describe('circular references', () => {
 	it("shouldn't throw error accessing rootState in effects with a return value", () => {

--- a/packages/core/test/ts_typings/dispatcher-typings.test.ts
+++ b/packages/core/test/ts_typings/dispatcher-typings.test.ts
@@ -1,0 +1,142 @@
+import { createModel, init, Models, RematchDispatch } from '../../src'
+
+describe('Dispatcher typings', () => {
+	describe("shouldn't throw error accessing reducers with", () => {
+		it('required payload', () => {
+			const model = createModel<RootModel>()({
+				state: 0,
+				reducers: {
+					inc(state, payload: number) {
+						return state + payload
+					},
+				},
+			})
+			interface RootModel extends Models<RootModel> {
+				myModel: typeof model
+			}
+
+			const store = init({ models: { myModel: model } })
+
+			const dispatch = store.dispatch as RematchDispatch<RootModel>
+			dispatch.myModel.inc(1)
+			// @ts-expect-error
+			dispatch.myModel.inc()
+		})
+		it('optional payload', () => {
+			const model = createModel<RootModel>()({
+				state: 0,
+				reducers: {
+					inc(state, payload?: number) {
+						return state + (payload ?? 0)
+					},
+				},
+			})
+			interface RootModel extends Models<RootModel> {
+				myModel: typeof model
+			}
+
+			const store = init({ models: { myModel: model } })
+
+			const dispatch = store.dispatch as RematchDispatch<RootModel>
+			dispatch.myModel.inc(1)
+			dispatch.myModel.inc()
+		})
+	})
+	describe("shouldn't throw error accessing effects with", () => {
+		it('required payload', () => {
+			const count = createModel<RootModel>()({
+				state: 0, // initial state
+				effects: () => ({
+					incrementEffect(payload: number) {
+						return payload
+					},
+				}),
+			})
+			interface RootModel extends Models<RootModel> {
+				count: typeof count
+			}
+
+			const store = init<RootModel>({ models: { count } })
+			const dispatch = store.dispatch as RematchDispatch<RootModel>
+
+			// @ts-expect-error
+			dispatch.count.incrementEffect()
+			// @ts-expect-error
+			dispatch.count.incrementEffect('test')
+			dispatch.count.incrementEffect(2)
+		})
+		it('optional payload', () => {
+			const count = createModel<RootModel>()({
+				state: 0, // initial state
+				effects: () => ({
+					incrementEffect(payload?: number) {
+						return payload
+					},
+				}),
+			})
+			interface RootModel extends Models<RootModel> {
+				count: typeof count
+			}
+
+			const store = init<RootModel>({ models: { count } })
+			const { dispatch } = store
+
+			dispatch.count.incrementEffect(2)
+			dispatch.count.incrementEffect()
+			// @ts-expect-error
+			dispatch.count.incrementEffect('test')
+		})
+	})
+
+	describe("shouldn't throw error accessing effects with", () => {
+		it('required payload and accessing rootState', () => {
+			const count = createModel<RootModel>()({
+				state: 0, // initial state
+				effects: () => ({
+					incrementEffect(payload: number, rootState) {
+						if (rootState.count) {
+							// do nothing
+						}
+						return payload
+					},
+				}),
+			})
+			interface RootModel extends Models<RootModel> {
+				count: typeof count
+			}
+
+			const store = init<RootModel>({ models: { count } })
+			const dispatch = store.dispatch as RematchDispatch<RootModel>
+
+			// @ts-expect-error
+			dispatch.count.incrementEffect()
+			// @ts-expect-error
+			dispatch.count.incrementEffect('test')
+			dispatch.count.incrementEffect(2)
+		})
+		it('optional payload  and accessing rootState', () => {
+			const count = createModel<RootModel>()({
+				state: 0, // initial state
+				effects: () => ({
+					incrementEffect(payload?: number, rootState?): number | undefined {
+						if (rootState.count) {
+							// do nothing
+						}
+						return payload
+					},
+				}),
+			})
+			interface RootModel extends Models<RootModel> {
+				count: typeof count
+			}
+
+			const store = init<RootModel>({ models: { count } })
+			const dispatch = store.dispatch as RematchDispatch<RootModel>
+
+			dispatch.count.incrementEffect(2)
+			dispatch.count.incrementEffect()
+			// @ts-expect-error
+			dispatch.count.incrementEffect('test', { prueba: 'hola ' })
+		})
+	})
+})


### PR DESCRIPTION
1. Simplify the `ExtractRematchDispatcherFromReducer` type alias.  
2. Make the Inference of the optional payload (and meta) correctly.