### PR TITLE
fix: optional payload inference inside effects

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -433,13 +433,13 @@ export type ExtractRematchDispatchersFromEffectsObject<
  */
 export type ExtractRematchDispatcherFromEffect<
 	TEffect extends ModelEffect<TModels>,
-	TModels extends Models<TModels> = Record<string, any>
-> = TEffect extends (
-	payload: infer TPayload,
-	rootState: RematchRootState<TModels>,
-	meta: infer TMeta
-) => infer TReturn
-	? EffectRematchDispatcher<TReturn, TPayload, TMeta>
+	TModels extends Models<TModels>
+> = TEffect extends (...args: infer TRest) => infer TReturn
+	? TRest[1] extends undefined
+		? EffectRematchDispatcher<TReturn, TRest[0]>
+		: RematchRootState<TModels> extends TRest[1]
+		? EffectRematchDispatcher<TReturn, TRest[0], TRest[2]>
+		: never
 	: never
 
 /**
@@ -453,7 +453,7 @@ export type EffectRematchDispatcher<
 	TReturn = any,
 	TPayload = void,
 	TMeta = void
-> = [TReturn, TPayload, TMeta] extends [void, void, void]
+> = [TPayload, TMeta] extends [void, void]
 	? (() => TReturn) & { isEffect: true }
 	: [TMeta] extends [void]
 	? undefined extends TPayload

--- a/packages/core/test/ts_typings/circular-references.test.ts
+++ b/packages/core/test/ts_typings/circular-references.test.ts
@@ -1,4 +1,4 @@
-import { createModel, Models } from '../src'
+import { createModel, Models } from '../../src'
 
 describe('circular references', () => {
 	it("shouldn't throw error accessing rootState in effects with a return value", () => {

--- a/packages/core/test/ts_typings/dispatcher-typings.test.ts
+++ b/packages/core/test/ts_typings/dispatcher-typings.test.ts
@@ -1,0 +1,142 @@
+import { createModel, init, Models, RematchDispatch } from '../../src'
+
+describe('Dispatcher typings', () => {
+	describe("shouldn't throw error accessing reducers with", () => {
+		it('required payload', () => {
+			const model = createModel<RootModel>()({
+				state: 0,
+				reducers: {
+					inc(state, payload: number) {
+						return state + payload
+					},
+				},
+			})
+			interface RootModel extends Models<RootModel> {
+				myModel: typeof model
+			}
+
+			const store = init({ models: { myModel: model } })
+
+			const dispatch = store.dispatch as RematchDispatch<RootModel>
+			dispatch.myModel.inc(1)
+			// @ts-expect-error
+			dispatch.myModel.inc()
+		})
+		it('optional payload', () => {
+			const model = createModel<RootModel>()({
+				state: 0,
+				reducers: {
+					inc(state, payload?: number) {
+						return state + (payload ?? 0)
+					},
+				},
+			})
+			interface RootModel extends Models<RootModel> {
+				myModel: typeof model
+			}
+
+			const store = init({ models: { myModel: model } })
+
+			const dispatch = store.dispatch as RematchDispatch<RootModel>
+			dispatch.myModel.inc(1)
+			dispatch.myModel.inc()
+		})
+	})
+	describe("shouldn't throw error accessing effects with", () => {
+		it('required payload', () => {
+			const count = createModel<RootModel>()({
+				state: 0, // initial state
+				effects: () => ({
+					incrementEffect(payload: number) {
+						return payload
+					},
+				}),
+			})
+			interface RootModel extends Models<RootModel> {
+				count: typeof count
+			}
+
+			const store = init<RootModel>({ models: { count } })
+			const dispatch = store.dispatch as RematchDispatch<RootModel>
+
+			// @ts-expect-error
+			dispatch.count.incrementEffect()
+			// @ts-expect-error
+			dispatch.count.incrementEffect('test')
+			dispatch.count.incrementEffect(2)
+		})
+		it('optional payload', () => {
+			const count = createModel<RootModel>()({
+				state: 0, // initial state
+				effects: () => ({
+					incrementEffect(payload?: number) {
+						return payload
+					},
+				}),
+			})
+			interface RootModel extends Models<RootModel> {
+				count: typeof count
+			}
+
+			const store = init<RootModel>({ models: { count } })
+			const { dispatch } = store
+
+			dispatch.count.incrementEffect(2)
+			dispatch.count.incrementEffect()
+			// @ts-expect-error
+			dispatch.count.incrementEffect('test')
+		})
+	})
+
+	describe("shouldn't throw error accessing effects with", () => {
+		it('required payload and accessing rootState', () => {
+			const count = createModel<RootModel>()({
+				state: 0, // initial state
+				effects: () => ({
+					incrementEffect(payload: number, rootState) {
+						if (rootState.count) {
+							// do nothing
+						}
+						return payload
+					},
+				}),
+			})
+			interface RootModel extends Models<RootModel> {
+				count: typeof count
+			}
+
+			const store = init<RootModel>({ models: { count } })
+			const dispatch = store.dispatch as RematchDispatch<RootModel>
+
+			// @ts-expect-error
+			dispatch.count.incrementEffect()
+			// @ts-expect-error
+			dispatch.count.incrementEffect('test')
+			dispatch.count.incrementEffect(2)
+		})
+		it('optional payload  and accessing rootState', () => {
+			const count = createModel<RootModel>()({
+				state: 0, // initial state
+				effects: () => ({
+					incrementEffect(payload?: number, rootState?): number | undefined {
+						if (rootState.count) {
+							// do nothing
+						}
+						return payload
+					},
+				}),
+			})
+			interface RootModel extends Models<RootModel> {
+				count: typeof count
+			}
+
+			const store = init<RootModel>({ models: { count } })
+			const dispatch = store.dispatch as RematchDispatch<RootModel>
+
+			dispatch.count.incrementEffect(2)
+			dispatch.count.incrementEffect()
+			// @ts-expect-error
+			dispatch.count.incrementEffect('test', { prueba: 'hola ' })
+		})
+	})
+})


### PR DESCRIPTION
Related to #901 

Introduces a new test to avoid regression with dispatcher system:
- Reducers
	- With optional payload
	- With required payload
- Effects
	- With optional payload
	- With required payload
	- With optional payload and rootState
	- With required payload and required rootstate