### PR TITLE
refactor: improve type system

### DIFF
--- a/examples/hooks-react-ts/src/index.tsx
+++ b/examples/hooks-react-ts/src/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import App from './App'
 import { Provider } from 'react-redux'
+import App from './App'
 import { store } from './store'
 
 ReactDOM.render(

--- a/examples/hooks-react-ts/src/models/dolphins.ts
+++ b/examples/hooks-react-ts/src/models/dolphins.ts
@@ -1,10 +1,11 @@
 import { createModel } from '@rematch/core'
 import { delay } from './utils'
-import { RootModel } from '.'
+import type { RootModel } from '.'
 
 export const dolphins = createModel<RootModel>()({
 	state: 0,
 	reducers: {
+		// eslint-disable-next-line @typescript-eslint/no-inferrable-types
 		increment: (state, payload: number = 1) => state + payload,
 	},
 	effects: (dispatch) => ({

--- a/examples/hooks-react-ts/src/models/sharks.ts
+++ b/examples/hooks-react-ts/src/models/sharks.ts
@@ -1,6 +1,6 @@
 import { createModel } from '@rematch/core'
 import { delay } from './utils'
-import { RootModel } from '.'
+import type { RootModel } from '.'
 
 export const sharks = createModel<RootModel>()({
 	state: 0,

--- a/packages/core/src/bag.ts
+++ b/packages/core/src/bag.ts
@@ -6,8 +6,8 @@ import { validateModel } from './validate'
  * used by the Rematch library in various functions.
  */
 export default function createRematchBag<
-	TModels extends Models<TModels> = Record<string, any>,
-	TExtraModels extends Models<TModels> = Record<string, any>
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>
 >(config: Config<TModels, TExtraModels>): RematchBag<TModels, TExtraModels> {
 	return {
 		models: createNamedModels(config.models),
@@ -28,9 +28,9 @@ export default function createRematchBag<
  * 'named' models - models with embedded name and default value for reducers
  * if user didn't provide any.
  */
-function createNamedModels<
-	TModels extends Models<TModels> = Record<string, any>
->(models: TModels | Partial<TModels>): NamedModel<TModels>[] {
+function createNamedModels<TModels extends Models<TModels>>(
+	models: TModels | Partial<TModels>
+): NamedModel<TModels>[] {
 	return Object.keys(models).map((modelName: string) => {
 		const model = createNamedModel(modelName, (models as TModels)[modelName])
 		validateModel(model)
@@ -42,9 +42,10 @@ function createNamedModels<
  * Transforms a model into 'named' model - model which contains 'name' and
  * 'reducers' properties if user didn't provide any.
  */
-function createNamedModel<
-	TModels extends Models<TModels> = Record<string, any>
->(name: string, model: Model<TModels>): NamedModel<TModels> {
+function createNamedModel<TModels extends Models<TModels>>(
+	name: string,
+	model: Model<TModels>
+): NamedModel<TModels> {
 	return {
 		name,
 		reducers: {},

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -9,8 +9,8 @@ let count = 0
  * the plugins selected by the user.
  */
 export default function createConfig<
-	TModels extends Models<TModels> = Record<string, any>,
-	TExtraModels extends Models<TModels> = Record<string, any>
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>
 >(
 	initConfig: InitConfig<TModels, TExtraModels>
 ): Config<TModels, TExtraModels> {
@@ -33,7 +33,7 @@ export default function createConfig<
 				...(initConfig.redux?.devtoolOptions ?? {}),
 			},
 		},
-	} as Config
+	} as Config<TModels, TExtraModels>
 
 	validateConfig(config)
 
@@ -88,9 +88,9 @@ export default function createConfig<
  * Shallow merges original object with the extra object, giving the precedence
  * to the original object.
  */
-function merge<T extends Record<string, any>>(
-	original: T,
-	extra: T | undefined
-): T {
+function merge<
+	T extends Record<string, unknown>,
+	U extends Record<string, unknown> = T
+>(original: T, extra?: U): T | (T & U) {
 	return extra ? { ...extra, ...original } : original
 }

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -18,9 +18,10 @@ import { validateModelEffect, validateModelReducer } from './validate'
  * isEffect helps to differentiate effects dispatchers from reducer dispatchers.
  */
 const createActionDispatcher = <
-	TModels extends Models<TModels> = Record<string, any>
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>
 >(
-	rematch: RematchStore<TModels>,
+	rematch: RematchStore<TModels, TExtraModels>,
 	modelName: string,
 	actionName: string,
 	isEffect: boolean
@@ -51,11 +52,12 @@ const createActionDispatcher = <
  * actions.
  */
 const createDispatcher = <
-	TModels extends Models<TModels> = Record<string, any>,
-	TModel extends NamedModel<TModels> = NamedModel
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>,
+	TModel extends NamedModel<TModels>
 >(
-	rematch: RematchStore<TModels>,
-	bag: RematchBag<TModels>,
+	rematch: RematchStore<TModels, TExtraModels>,
+	bag: RematchBag<TModels, TExtraModels>,
 	model: TModel
 ): void => {
 	const modelDispatcher = rematch.dispatch[model.name]

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,8 +6,8 @@ import createConfig from './config'
  * Prepares a complete configuration and creates a Rematch store.
  */
 export const init = <
-	TModels extends Models<TModels> = Record<string, any>,
-	TExtraModels extends Models<TModels> = Record<string, any>
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels> = Record<string, never>
 >(
 	initConfig?: InitConfig<TModels, TExtraModels>
 ): RematchStore<TModels, TExtraModels> => {

--- a/packages/core/src/reduxStore.ts
+++ b/packages/core/src/reduxStore.ts
@@ -16,8 +16,8 @@ import {
  * middlewares and enhancers.
  */
 export default function createReduxStore<
-	TModels extends Models<TModels> = Record<string, any>,
-	TExtraModels extends Models<TModels> = Record<string, any>,
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>,
 	RootState = RematchRootState<TModels, TExtraModels>
 >(bag: RematchBag<TModels, TExtraModels>): Redux.Store<RootState> {
 	bag.models.forEach((model) => createModelReducer(bag, model))
@@ -53,8 +53,8 @@ export default function createReduxStore<
  * The final result - a function, is returned.
  */
 export function createModelReducer<
-	TModels extends Models<TModels> = Record<string, any>,
-	TExtraModels extends Models<TModels> = Record<string, any>,
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>,
 	TState extends NamedModel<TModels>['state'] = any
 >(bag: RematchBag<TModels, TExtraModels>, model: NamedModel<TModels>): void {
 	const modelReducers: ModelReducers<TState> = {}
@@ -104,8 +104,8 @@ export function createModelReducer<
  */
 export function createRootReducer<
 	TRootState,
-	TModels extends Models<TModels> = Record<string, any>,
-	TExtraModels extends Models<TModels> = Record<string, any>
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>
 >(bag: RematchBag<TModels, TExtraModels>): Redux.Reducer<TRootState, Action> {
 	const { rootReducers } = bag.reduxConfig
 	const mergedReducers = mergeReducers<TRootState>(bag.reduxConfig)

--- a/packages/core/src/rematchStore.ts
+++ b/packages/core/src/rematchStore.ts
@@ -70,7 +70,7 @@ function createEffectsMiddleware<
 			next(action)
 
 			// then run the effect and return its result
-			return bag.effects[action.type](
+			return (bag.effects as any)[action.type](
 				action.payload,
 				store.getState(),
 				action.meta

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -246,10 +246,12 @@ export interface InitConfigRedux<TRootState = any> {
 	enhancers?: StoreEnhancer[]
 	middlewares?: Middleware[]
 	rootReducers?: ReducersMapObject<TRootState, Action>
-	combineReducers?: (
-		reducers: ReducersMapObject<TRootState, Action>
-	) => ReduxReducer<TRootState>
-	createStore?: StoreCreator
+	combineReducers?:
+		| ((
+				reducers: ReducersMapObject<TRootState, Action>
+		  ) => ReduxReducer<TRootState>)
+		| undefined
+	createStore?: StoreCreator | undefined
 	devtoolOptions?: DevtoolOptions
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -88,9 +88,14 @@ export interface ModelEffects<
 	[key: string]: ModelEffect<TModels>
 }
 
+export type ModelEffectThisTyped = {
+	[key: string]: (payload?: any, meta?: any) => Action<any, any>
+}
+
 export type ModelEffect<
 	TModels extends Models<TModels> = Record<string, any>
 > = (
+	this: ModelEffectThisTyped,
 	payload: Action['payload'],
 	rootState: RematchRootState<TModels>,
 	meta: Action['meta']

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -717,7 +717,7 @@ declare module 'react-redux' {
 		TOwnProps,
 		RM extends Models<RM> = Models
 	> = (
-		dispatch: RematchDispatch<RM>,
+		dispatch: any,
 		ownProps: TOwnProps
 	) => MapRematchDispatchToPropsFunction<TDispatchProps, TOwnProps, RM>
 
@@ -725,7 +725,7 @@ declare module 'react-redux' {
 		TDispatchProps,
 		TOwnProps,
 		RM extends Models<RM> = Models
-	> = (dispatch: RematchDispatch<RM>, ownProps: TOwnProps) => TDispatchProps
+	> = (dispatch: any, ownProps: TOwnProps) => TDispatchProps
 }
 
 declare global {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -53,12 +53,12 @@ export type Reducer<TState = any> = (
  *
  * @template TModels List of all models
  */
-export interface Models<TModels extends Models<TModels> = Record<string, any>> {
+export interface Models<TModels extends Models<TModels>> {
 	[key: string]: Model<TModels>
 }
 
 export interface NamedModel<
-	TModels extends Models<TModels> = Record<string, any>,
+	TModels extends Models<TModels>,
 	TState = any,
 	TBaseState = TState
 > extends Model<TModels, TState, TBaseState> {
@@ -67,7 +67,7 @@ export interface NamedModel<
 }
 
 export interface Model<
-	TModels extends Models<TModels> = Record<string, any>,
+	TModels extends Models<TModels>,
 	TState = any,
 	TBaseState = TState
 > {
@@ -82,9 +82,7 @@ export type ModelReducers<TState = any> = {
 	[key: string]: Reducer<TState>
 }
 
-export interface ModelEffects<
-	TModels extends Models<TModels> = Record<string, any>
-> {
+export interface ModelEffects<TModels extends Models<TModels>> {
 	[key: string]: ModelEffect<TModels>
 }
 
@@ -92,24 +90,22 @@ export type ModelEffectThisTyped = {
 	[key: string]: (payload?: any, meta?: any) => Action<any, any>
 }
 
-export type ModelEffect<
-	TModels extends Models<TModels> = Record<string, any>
-> = (
+export type ModelEffect<TModels extends Models<TModels>> = (
 	this: ModelEffectThisTyped,
 	payload: Action['payload'],
 	rootState: RematchRootState<TModels>,
 	meta: Action['meta']
 ) => any
 
-export type ModelEffectsCreator<
-	TModels extends Models<TModels> = Record<string, any>
-> = (dispatch: RematchDispatch<TModels>) => ModelEffects<TModels>
+export type ModelEffectsCreator<TModels extends Models<TModels>> = (
+	dispatch: RematchDispatch<TModels>
+) => ModelEffects<TModels>
 
 /** ************************** Plugin *************************** */
 
 export interface PluginConfig<
-	TModels extends Models<TModels> = Record<string, any>,
-	TExtraModels extends Models<TModels> = Record<string, any>,
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>,
 	TExposedModels = Partial<TExtraModels>
 > {
 	models?: TExposedModels
@@ -117,36 +113,36 @@ export interface PluginConfig<
 }
 
 export interface Plugin<
-	TModels extends Models<TModels> = Record<string, any>,
-	TExtraModels extends Models<TModels> = Record<string, any>,
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels> = Record<string, never>,
 	TExposedModels = Partial<TExtraModels>
 > extends PluginHooks<TModels, TExtraModels> {
 	config?: PluginConfig<TModels, TExtraModels, TExposedModels>
-	exposed?: PluginExposed
+	exposed?: PluginExposed<TModels, TExtraModels>
 }
 
 export interface PluginHooks<
-	TModels extends Models<TModels> = Record<string, any>,
-	TExtraModels extends Models<TModels> = Record<string, any>
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>
 > {
 	onStoreCreated?: StoreCreatedHook<TModels, TExtraModels>
 	onModel?: ModelHook<TModels, TExtraModels>
 	onReducer?: ReducerHook<TModels, TExtraModels>
 	onRootReducer?: RootReducerHook<TModels, TExtraModels>
-	createMiddleware?: MiddlewareCreator<TModels>
+	createMiddleware?: MiddlewareCreator<TModels, TExtraModels>
 }
 
 export type ModelHook<
-	TModels extends Models<TModels> = Record<string, any>,
-	TExtraModels extends Models<TModels> = Record<string, any>
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>
 > = (
 	model: NamedModel<TModels>,
 	rematch: RematchStore<TModels, TExtraModels>
 ) => void
 
 export type ReducerHook<
-	TModels extends Models<TModels> = Record<string, any>,
-	TExtraModels extends Models<TModels> = Record<string, any>
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>
 > = (
 	reducer: ReduxReducer,
 	modelName: string,
@@ -154,24 +150,24 @@ export type ReducerHook<
 ) => ReduxReducer | void
 
 export type RootReducerHook<
-	TModels extends Models<TModels> = Record<string, any>,
-	TExtraModels extends Models<TModels> = Record<string, any>
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>
 > = (
 	reducer: ReduxReducer,
 	rematch: RematchBag<TModels, TExtraModels>
 ) => ReduxReducer | void
 
 export type StoreCreatedHook<
-	TModels extends Models<TModels> = Record<string, any>,
-	TExtraModels extends Models<TModels> = Record<string, any>
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>
 > = (
 	store: RematchStore<TModels, TExtraModels>,
 	rematch: RematchBag<TModels, TExtraModels>
 ) => RematchStore<TModels, TExtraModels> | void
 
 export type MiddlewareCreator<
-	TModels extends Models<TModels> = Record<string, any>,
-	TExtraModels extends Models<TModels> = Record<string, any>
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels> = Record<string, never>
 > = (rematch: RematchBag<TModels, TExtraModels>) => Middleware
 
 export type ObjectNotAFunction = { [k: string]: any } & (
@@ -179,11 +175,17 @@ export type ObjectNotAFunction = { [k: string]: any } & (
 	| { call?: never }
 )
 
-export type PluginExposed = {
-	[key: string]: ExposedFunction | ObjectNotAFunction
+export type PluginExposed<
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>
+> = {
+	[key: string]: ExposedFunction<TModels, TExtraModels> | ObjectNotAFunction
 }
 
-export type ExposedFunction = (rematch: RematchStore<any>, ...args: any) => any
+export type ExposedFunction<
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>
+> = (rematch: RematchStore<TModels, TExtraModels>, ...args: any) => any
 
 /** ************************** Rematch *************************** */
 
@@ -192,8 +194,8 @@ export type ExposedFunction = (rematch: RematchStore<any>, ...args: any) => any
  * Purposefully hidden from the end user.
  */
 export interface RematchBag<
-	TModels extends Models<TModels> = Record<string, any>,
-	TExtraModels extends Models<TModels> = Record<string, any>
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>
 > {
 	models: NamedModel<TModels>[]
 	reduxConfig: ConfigRedux
@@ -209,8 +211,8 @@ export interface RematchBag<
  * Rematch store should be configured.
  */
 export interface InitConfig<
-	TModels extends Models<TModels> = Record<string, any>,
-	TExtraModels extends Models<TModels> = Record<string, any>
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>
 > {
 	name?: string
 	models?: TModels | Partial<TModels>
@@ -224,8 +226,8 @@ export interface InitConfig<
  * (new models, etc.).
  */
 export interface Config<
-	TModels extends Models<TModels> = Record<string, any>,
-	TExtraModels extends Models<TModels> = Record<string, any>
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>
 > extends InitConfig<TModels, TExtraModels> {
 	name: string
 	models: TModels | Partial<TModels>
@@ -268,10 +270,13 @@ export interface ConfigRedux<TRootState = any>
 }
 
 export interface RematchStore<
-	TModels extends Models<TModels> = Record<string, any>,
-	TExtraModels extends Models<TModels> = Record<string, any>
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>
 > extends ReduxStore<RematchRootState<TModels, TExtraModels>, Action> {
-	[index: string]: ExposedFunction | Record<string, any> | string
+	[index: string]:
+		| ExposedFunction<TModels, TExtraModels>
+		| Record<string, any>
+		| string
 	name: string
 	dispatch: RematchDispatch<TModels>
 	addModel: (model: NamedModel<TModels>) => void
@@ -283,16 +288,16 @@ export interface RematchStore<
  * The type of state held by a store.
  */
 export type RematchRootState<
-	TModels extends Models<TModels> = Record<string, any>,
-	TExtraModels extends Models<TModels> = Record<string, any>
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels> = Record<string, never>
 > = ExtractRematchStateFromModels<TModels, TExtraModels>
 
 /**
  * A mapping from each model's name to a type of state it holds.
  */
 export type ExtractRematchStateFromModels<
-	TModels extends Models<TModels> = Record<string, any>,
-	TExtraModels extends Models<TModels> = Record<string, any>
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>
 > = {
 	[modelKey in keyof TModels]: TModels[modelKey]['state']
 } &
@@ -307,16 +312,15 @@ export type ExtractRematchStateFromModels<
  * an object allowing to dispatch specific actions by calling it the form of
  * dispatch[modelName][reducerName | effectName](payload).
  */
-export type RematchDispatch<
-	TModels extends Models<TModels> = Record<string, any>
-> = ReduxDispatch & ExtractRematchDispatchersFromModels<TModels>
+export type RematchDispatch<TModels extends Models<TModels>> = ReduxDispatch &
+	ExtractRematchDispatchersFromModels<TModels>
 
 /**
  * Goes over all models and extracts from each a type for dispatcher object
  * created by Rematch.
  */
 export type ExtractRematchDispatchersFromModels<
-	TModels extends Models<TModels> = Record<string, any>
+	TModels extends Models<TModels>
 > = {
 	[modelKey in keyof TModels]: TModels[modelKey] extends Model<TModels>
 		? ModelDispatcher<TModels[modelKey], TModels>
@@ -327,9 +331,13 @@ export type ExtractRematchDispatchersFromModels<
  * Combines together types extracted from reducers and effects for a model.
  */
 export type ModelDispatcher<
-	TModel extends Model<TModels> = Model,
-	TModels extends Models<TModels> = Record<string, any>
-> = ExtractRematchDispatchersFromReducers<TModel['state'], TModel['reducers']> &
+	TModel extends Model<TModels>,
+	TModels extends Models<TModels>
+> = ExtractRematchDispatchersFromReducers<
+	TModel['state'],
+	TModel['reducers'],
+	TModels
+> &
 	ExtractRematchDispatchersFromEffects<TModel['effects'], TModels>
 
 /** ************************ Reducers Dispatcher ************************* */
@@ -339,7 +347,8 @@ export type ModelDispatcher<
  */
 export type ExtractRematchDispatchersFromReducers<
 	TState,
-	TReducers extends Model<Models, TState>['reducers']
+	TReducers extends Model<TModels, TState>['reducers'],
+	TModels extends Models<TModels>
 > = {
 	[reducerKey in keyof TReducers]: ExtractRematchDispatcherFromReducer<
 		TState,
@@ -408,7 +417,7 @@ export type RematchDispatcher<TPayload = void, TMeta = void> = [
  */
 export type ExtractRematchDispatchersFromEffects<
 	TEffects extends Model<TModels>['effects'],
-	TModels extends Models<TModels> = Record<string, any>
+	TModels extends Models<TModels>
 > = TEffects extends (...args: any[]) => infer R
 	? R extends ModelEffects<TModels>
 		? ExtractRematchDispatchersFromEffectsObject<R, TModels>
@@ -422,7 +431,7 @@ export type ExtractRematchDispatchersFromEffects<
  */
 export type ExtractRematchDispatchersFromEffectsObject<
 	TEffects extends ModelEffects<TModels>,
-	TModels extends Models<TModels> = Record<string, any>
+	TModels extends Models<TModels>
 > = {
 	[effectKey in keyof TEffects]: ExtractRematchDispatcherFromEffect<
 		TEffects[effectKey],
@@ -687,13 +696,7 @@ declare module 'redux' {
  */
 declare module 'react-redux' {
 	interface Connect {
-		<
-			RM extends Models<RM> = Models,
-			State = DefaultRootState,
-			TStateProps = Record<string, any>,
-			TDispatchProps = Record<string, any>,
-			TOwnProps = Record<string, any>
-		>(
+		<RM extends Models<RM>, State, TStateProps, TDispatchProps, TOwnProps>(
 			mapStateToProps: MapStateToPropsParam<TStateProps, TOwnProps, State>,
 			mapDispatchToProps: MapRematchDispatchToPropsNonObject<
 				TDispatchProps,
@@ -709,7 +712,7 @@ declare module 'react-redux' {
 	type MapRematchDispatchToPropsNonObject<
 		TDispatchProps,
 		TOwnProps,
-		RM extends Models<RM> = Models
+		RM extends Models<RM>
 	> =
 		| MapRematchDispatchToPropsFactory<TDispatchProps, TOwnProps, RM>
 		| MapRematchDispatchToPropsFunction<TDispatchProps, TOwnProps, RM>
@@ -717,7 +720,7 @@ declare module 'react-redux' {
 	type MapRematchDispatchToPropsFactory<
 		TDispatchProps,
 		TOwnProps,
-		RM extends Models<RM> = Models
+		RM extends Models<RM>
 	> = (
 		dispatch: any,
 		ownProps: TOwnProps
@@ -726,7 +729,7 @@ declare module 'react-redux' {
 	type MapRematchDispatchToPropsFunction<
 		TDispatchProps,
 		TOwnProps,
-		RM extends Models<RM> = Models
+		RM extends Models<RM>
 	> = (dispatch: any, ownProps: TOwnProps) => TDispatchProps
 }
 

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -51,8 +51,8 @@ const validate = (runValidations: () => Validation[]): void => {
 }
 
 export const validateConfig = <
-	TModels extends Models<TModels> = Record<string, any>,
-	TExtraModels extends Models<TModels> = Record<string, any>
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>
 >(
 	config: Config<TModels, TExtraModels>
 ): void => {
@@ -82,9 +82,7 @@ export const validateConfig = <
 	])
 }
 
-export const validateModel = <
-	TModels extends Models<TModels> = Record<string, any>
->(
+export const validateModel = <TModels extends Models<TModels>>(
 	model: NamedModel<TModels>
 ): void => {
 	validate(() => [
@@ -102,8 +100,8 @@ export const validateModel = <
 }
 
 export const validatePlugin = <
-	TModels extends Models<TModels> = Record<string, any>,
-	TExtraModels extends Models<TModels> = Record<string, any>
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>
 >(
 	plugin: Plugin<TModels, TExtraModels>
 ): void => {

--- a/packages/core/test/plugins.test.ts
+++ b/packages/core/test/plugins.test.ts
@@ -20,7 +20,18 @@ describe('plugins:', () => {
 	})
 
 	test('should add middleware', () => {
-		const payloadIsAlways100Middleware: MiddlewareCreator = () => () => (
+		const a = {
+			state: 0,
+			reducers: {
+				set: (_state: number, payload: number): number => payload,
+			},
+		}
+
+		type RootModel = {
+			a: typeof a
+		}
+
+		const payloadIsAlways100Middleware: MiddlewareCreator<RootModel> = () => () => (
 			next
 		) => (action): any => {
 			return next({ ...action, payload: 100 })
@@ -28,12 +39,7 @@ describe('plugins:', () => {
 
 		const store = init({
 			models: {
-				a: {
-					state: 0,
-					reducers: {
-						set: (_state: number, payload: number): number => payload,
-					},
-				},
+				a,
 			},
 			plugins: [{ createMiddleware: payloadIsAlways100Middleware }],
 		})
@@ -96,7 +102,7 @@ describe('plugins:', () => {
 	})
 
 	test('plugins should be able to set a value in store', () => {
-		const pluginWithReturn: Plugin = {
+		const pluginWithReturn: Plugin<{}> = {
 			onStoreCreated: (store): void => {
 				// @ts-expect-error
 				store.returned = 42 // when creating plugin, we would need to expand type for the rematch store to include 'returned'

--- a/packages/core/test/ts_typings/circular-references.test.ts
+++ b/packages/core/test/ts_typings/circular-references.test.ts
@@ -1,4 +1,4 @@
-import { createModel, Models } from '../src'
+import { createModel, Models } from '../../src'
 
 describe('circular references', () => {
 	it("shouldn't throw error accessing rootState in effects with a return value", () => {

--- a/packages/core/test/ts_typings/dispatcher-typings.test.ts
+++ b/packages/core/test/ts_typings/dispatcher-typings.test.ts
@@ -1,0 +1,142 @@
+import { createModel, init, Models, RematchDispatch } from '../../src'
+
+describe('Dispatcher typings', () => {
+	describe("shouldn't throw error accessing reducers with", () => {
+		it('required payload', () => {
+			const model = createModel<RootModel>()({
+				state: 0,
+				reducers: {
+					inc(state, payload: number) {
+						return state + payload
+					},
+				},
+			})
+			interface RootModel extends Models<RootModel> {
+				myModel: typeof model
+			}
+
+			const store = init({ models: { myModel: model } })
+
+			const dispatch = store.dispatch as RematchDispatch<RootModel>
+			dispatch.myModel.inc(1)
+			// @ts-expect-error
+			dispatch.myModel.inc()
+		})
+		it('optional payload', () => {
+			const model = createModel<RootModel>()({
+				state: 0,
+				reducers: {
+					inc(state, payload?: number) {
+						return state + (payload ?? 0)
+					},
+				},
+			})
+			interface RootModel extends Models<RootModel> {
+				myModel: typeof model
+			}
+
+			const store = init({ models: { myModel: model } })
+
+			const dispatch = store.dispatch as RematchDispatch<RootModel>
+			dispatch.myModel.inc(1)
+			dispatch.myModel.inc()
+		})
+	})
+	describe("shouldn't throw error accessing effects with", () => {
+		it('required payload', () => {
+			const count = createModel<RootModel>()({
+				state: 0, // initial state
+				effects: () => ({
+					incrementEffect(payload: number) {
+						return payload
+					},
+				}),
+			})
+			interface RootModel extends Models<RootModel> {
+				count: typeof count
+			}
+
+			const store = init<RootModel>({ models: { count } })
+			const dispatch = store.dispatch as RematchDispatch<RootModel>
+
+			// @ts-expect-error
+			dispatch.count.incrementEffect()
+			// @ts-expect-error
+			dispatch.count.incrementEffect('test')
+			dispatch.count.incrementEffect(2)
+		})
+		it('optional payload', () => {
+			const count = createModel<RootModel>()({
+				state: 0, // initial state
+				effects: () => ({
+					incrementEffect(payload?: number) {
+						return payload
+					},
+				}),
+			})
+			interface RootModel extends Models<RootModel> {
+				count: typeof count
+			}
+
+			const store = init<RootModel>({ models: { count } })
+			const { dispatch } = store
+
+			dispatch.count.incrementEffect(2)
+			dispatch.count.incrementEffect()
+			// @ts-expect-error
+			dispatch.count.incrementEffect('test')
+		})
+	})
+
+	describe("shouldn't throw error accessing effects with", () => {
+		it('required payload and accessing rootState', () => {
+			const count = createModel<RootModel>()({
+				state: 0, // initial state
+				effects: () => ({
+					incrementEffect(payload: number, rootState) {
+						if (rootState.count) {
+							// do nothing
+						}
+						return payload
+					},
+				}),
+			})
+			interface RootModel extends Models<RootModel> {
+				count: typeof count
+			}
+
+			const store = init<RootModel>({ models: { count } })
+			const dispatch = store.dispatch as RematchDispatch<RootModel>
+
+			// @ts-expect-error
+			dispatch.count.incrementEffect()
+			// @ts-expect-error
+			dispatch.count.incrementEffect('test')
+			dispatch.count.incrementEffect(2)
+		})
+		it('optional payload  and accessing rootState', () => {
+			const count = createModel<RootModel>()({
+				state: 0, // initial state
+				effects: () => ({
+					incrementEffect(payload?: number, rootState?): number | undefined {
+						if (rootState.count) {
+							// do nothing
+						}
+						return payload
+					},
+				}),
+			})
+			interface RootModel extends Models<RootModel> {
+				count: typeof count
+			}
+
+			const store = init<RootModel>({ models: { count } })
+			const dispatch = store.dispatch as RematchDispatch<RootModel>
+
+			dispatch.count.incrementEffect(2)
+			dispatch.count.incrementEffect()
+			// @ts-expect-error
+			dispatch.count.incrementEffect('test', { prueba: 'hola ' })
+		})
+	})
+})

--- a/packages/core/test/ts_typings/dispatcher-typings.test.ts
+++ b/packages/core/test/ts_typings/dispatcher-typings.test.ts
@@ -1,4 +1,4 @@
-import { createModel, init, Models, RematchDispatch } from '../../src'
+import { createModel, init, Models } from '../../src'
 
 describe('Dispatcher typings', () => {
 	describe("shouldn't throw error accessing reducers with", () => {
@@ -17,7 +17,7 @@ describe('Dispatcher typings', () => {
 
 			const store = init({ models: { myModel: model } })
 
-			const dispatch = store.dispatch as RematchDispatch<RootModel>
+			const { dispatch } = store
 			dispatch.myModel.inc(1)
 			// @ts-expect-error
 			dispatch.myModel.inc()
@@ -37,8 +37,29 @@ describe('Dispatcher typings', () => {
 
 			const store = init({ models: { myModel: model } })
 
-			const dispatch = store.dispatch as RematchDispatch<RootModel>
+			const { dispatch } = store
 			dispatch.myModel.inc(1)
+			dispatch.myModel.inc()
+		})
+
+		it('optional payload with default value when nil', () => {
+			const model = createModel<RootModel>()({
+				state: 0,
+				reducers: {
+					// eslint-disable-next-line @typescript-eslint/no-inferrable-types
+					inc(state, payload: number = 3) {
+						return state + payload
+					},
+				},
+			})
+			interface RootModel extends Models<RootModel> {
+				myModel: typeof model
+			}
+
+			const store = init({ models: { myModel: model } })
+
+			const { dispatch } = store
+			dispatch.myModel.inc(4)
 			dispatch.myModel.inc()
 		})
 	})
@@ -57,7 +78,7 @@ describe('Dispatcher typings', () => {
 			}
 
 			const store = init<RootModel>({ models: { count } })
-			const dispatch = store.dispatch as RematchDispatch<RootModel>
+			const { dispatch } = store
 
 			// @ts-expect-error
 			dispatch.count.incrementEffect()
@@ -106,7 +127,7 @@ describe('Dispatcher typings', () => {
 			}
 
 			const store = init<RootModel>({ models: { count } })
-			const dispatch = store.dispatch as RematchDispatch<RootModel>
+			const { dispatch } = store
 
 			// @ts-expect-error
 			dispatch.count.incrementEffect()
@@ -131,7 +152,7 @@ describe('Dispatcher typings', () => {
 			}
 
 			const store = init<RootModel>({ models: { count } })
-			const dispatch = store.dispatch as RematchDispatch<RootModel>
+			const { dispatch } = store
 
 			dispatch.count.incrementEffect(2)
 			dispatch.count.incrementEffect()

--- a/packages/core/test/validatePlugins.test.ts
+++ b/packages/core/test/validatePlugins.test.ts
@@ -5,14 +5,14 @@ describe('validatePlugins:', () => {
 	test('should not create a plugin with invalid "onModel"', () => {
 		const plugin = {
 			onModel: {},
-		} as Plugin
+		} as Plugin<{}>
 		expect(() => validatePlugin(plugin)).toThrow()
 	})
 
 	test('should not create a plugin with invalid "createMiddleware"', () => {
 		const plugin = {
 			createMiddleware: {},
-		} as Plugin
+		} as Plugin<{}>
 		expect(() => validatePlugin(plugin)).toThrow()
 	})
 })

--- a/packages/immer/src/index.ts
+++ b/packages/immer/src/index.ts
@@ -21,7 +21,7 @@ function wrapReducerWithImmer(reducer: Redux.Reducer) {
 
 const immerPlugin = <
 	TModels extends Models<TModels>,
-	TExtraModels extends Models<TModels> = Record<string, any>
+	TExtraModels extends Models<TModels> = Record<string, never>
 >(
 	config?: ImmerPluginConfig
 ): Plugin<TModels, TExtraModels> => ({

--- a/packages/immer/test/immer.test.ts
+++ b/packages/immer/test/immer.test.ts
@@ -1,4 +1,4 @@
-import { init } from '@rematch/core'
+import { init, Models } from '@rematch/core'
 import immerPlugin from '../src'
 
 describe('immer', () => {
@@ -46,7 +46,11 @@ describe('immer', () => {
 			},
 		}
 
-		const store = init({
+		interface RootModel extends Models<RootModel> {
+			todo: typeof todo
+		}
+
+		const store = init<RootModel>({
 			plugins: [immerPlugin()],
 			models: { todo },
 		})
@@ -54,10 +58,10 @@ describe('immer', () => {
 		const newState = store.getState().todo
 
 		expect(todo.state.length).toBe(2)
-		expect(newState.length).toBe(3)
+		expect(newState).toHaveLength(3)
 
 		expect(todo.state[1].done).toBe(false)
-		expect(newState[1].done).toBe(true)
+		expect(newState[1].done).toEqual(true)
 	})
 
 	describe('whitelist/blacklist', () => {

--- a/packages/loading/test/loading-asBoolean.test.ts
+++ b/packages/loading/test/loading-asBoolean.test.ts
@@ -303,7 +303,7 @@ describe('loading asBoolean', () => {
 
 		try {
 			await store.dispatch.count.throwError()
-		} catch (err) {
+		} catch (err: any) {
 			expect(err.message).toBe('effect error')
 		}
 	})

--- a/packages/loading/test/loading-asNumber.test.ts
+++ b/packages/loading/test/loading-asNumber.test.ts
@@ -333,7 +333,7 @@ describe('loading asNumbers', () => {
 
 		try {
 			await store.dispatch.count.throwError()
-		} catch (err) {
+		} catch (err: any) {
 			expect(err.message).toBe('effect error')
 		}
 	})

--- a/packages/persist/src/index.ts
+++ b/packages/persist/src/index.ts
@@ -25,7 +25,7 @@ export type PersistorStoreOptionsNotExposed = {
 const persistPlugin = <
 	S,
 	TModels extends Models<TModels>,
-	TExtraModels extends Models<TModels> = Record<string, any>
+	TExtraModels extends Models<TModels> = Record<string, never>
 >(
 	persistConfig: PersistConfig<S>,
 	nestedPersistConfig: NestedPersist<TModels> = {},

--- a/packages/select/src/types.ts
+++ b/packages/select/src/types.ts
@@ -20,8 +20,8 @@ export type Selector<TState, TReturns, TProps = void> = TProps extends void
 	: (state: TState, props: TProps) => TReturns
 
 export type ExtractSelectorsFromModel<
-	TModels extends Models<TModels> = Record<string, any>,
-	TModel extends Model<TModels> = Model<TModels>
+	TModels extends Models<TModels>,
+	TModel extends Model<TModels>
 > =
 	// thunk case: (models) => ({...})
 	TModel['selectors'] extends (...args: any[]) => infer TReturnObj
@@ -49,24 +49,26 @@ export type ExtractSelectorsSignatureFromSelectorsModel<
 	: never
 
 export interface SelectConfig<
-	TModels extends Models<TModels> = Record<string, any>
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>
 > {
 	sliceState?: (
-		state: ExtractRematchStateFromModels<TModels>,
+		state: ExtractRematchStateFromModels<TModels, TExtraModels>,
 		model: Model<TModels>
 	) => Record<string, any> | undefined
 	selectorCreator?: any
 }
 
 export type ModelSelectors<
-	TModels extends Models<TModels> = Record<string, any>,
-	TModel extends Model<TModels> = Model<TModels>
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>,
+	TModel extends Model<TModels>
 > = {
 	[key in keyof ExtractSelectorsFromModel<
 		TModels,
 		TModel
 	>]: ExtractSelectorsSignatureFromSelectorsModel<
-		RematchRootState<TModels>,
+		RematchRootState<TModels, TExtraModels>,
 		ExtractSelectorsFromModel<TModels, TModel>,
 		key
 	>
@@ -78,109 +80,135 @@ export type Slicer<TSliceState, TRootState> = (<TReturns>(
 	Selector<TRootState, TSliceState>
 
 export interface ModelSelectorFactories<
-	TModels extends Models<TModels> = Record<string, any>,
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>,
 	TSliceState = any
 > {
 	[key: string]:
-		| SelectorFactory<TModels, TSliceState>
-		| SelectorParametricFactory<TModels, TSliceState>
+		| SelectorFactory<TModels, TExtraModels, TSliceState>
+		| SelectorParametricFactory<TModels, TExtraModels, TSliceState>
 }
 
 export type StoreSelectors<
-	TModels extends Models<TModels> = Record<string, any>
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>
 > = {
-	[TModelKey in keyof TModels]: ModelSelectors<TModels, TModels[TModelKey]>
+	[TModelKey in keyof TModels]: ModelSelectors<
+		TModels,
+		TExtraModels,
+		TModels[TModelKey]
+	>
 }
 
 export type SelectorFactory<
-	TModels extends Models<TModels> = Record<string, any>,
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>,
 	TSliceState = any
 > = <TReturns>(
 	// FIXME: https://github.com/Microsoft/TypeScript/issues/27862
-	this: ModelSelectorFactories<TModels, TSliceState>,
-	models: StoreSelectors<TModels>
+	this: ModelSelectorFactories<TModels, TExtraModels, TSliceState>,
+	models: StoreSelectors<TModels, TExtraModels>
 ) => Selector<RematchRootState<TModels>, TReturns>
 
 export type SelectorParametricFactory<
-	TModels extends Models<TModels> = Record<string, any>,
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>,
 	TSliceState = any,
 	TProps = any,
 	TReturns = any
 > = (
 	// FIXME: https://github.com/Microsoft/TypeScript/issues/27862
-	this: ModelSelectorFactories<TModels, TSliceState>,
-	models: StoreSelectors<TModels>,
+	this: ModelSelectorFactories<TModels, TExtraModels, TSliceState>,
+	models: StoreSelectors<TModels, TExtraModels>,
 	props: TProps
 ) => Selector<RematchRootState<TModels>, TReturns, TProps>
 
 // the same as `SelectorParametricFactory` but with different return signature
 export type ParameterizerSelectorFactory<
-	TModels extends Models<TModels> = Record<string, any>,
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>,
 	TSliceState = any,
 	TProps = any,
 	TReturns = any
 > = (
 	// FIXME: https://github.com/Microsoft/TypeScript/issues/27862
-	this: ModelSelectorFactories<TModels, TSliceState>,
-	models: StoreSelectors<TModels>,
+	this: ModelSelectorFactories<TModels, TExtraModels, TSliceState>,
+	models: StoreSelectors<TModels, TExtraModels>,
 	props: TProps
 ) => (props: TProps) => Selector<RematchRootState<TModels>, TReturns>
 
 export type Parameterizer<
-	TModels extends Models<TModels> = Record<string, any>,
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>,
 	TSliceState = any
 > = <TProps, TReturns>(
-	factory: SelectorParametricFactory<TModels, TSliceState, TProps, TReturns>
-) => ParameterizerSelectorFactory<TModels, TSliceState, TProps, TReturns>
+	factory: SelectorParametricFactory<
+		TModels,
+		TExtraModels,
+		TSliceState,
+		TProps,
+		TReturns
+	>
+) => ParameterizerSelectorFactory<
+	TModels,
+	TExtraModels,
+	TSliceState,
+	TProps,
+	TReturns
+>
 
 export type ModelSelectorsFactory<
-	TModels extends Models<TModels> = Record<string, any>,
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>,
 	TSliceState = any
 > = (
 	slice: Slicer<TSliceState, RematchRootState<TModels>>,
 	createSelector: typeof Reselect.createSelector,
-	hasProps: Parameterizer<TModels, TSliceState>
-) => ModelSelectorFactories<TModels, TSliceState>
+	hasProps: Parameterizer<TModels, TExtraModels, TSliceState>
+) => ModelSelectorFactories<TModels, TExtraModels, TSliceState>
 
 export type ModelSelectorsConfig<
-	TModels extends Models<TModels> = Record<string, any>,
-	TSliceState = any
+	TModels extends Models<TModels>,
+	TSliceState = any,
+	TExtraModels extends Models<TModels> = Record<string, never>
 > =
-	| ModelSelectorsFactory<TModels, TSliceState>
-	| ModelSelectorFactories<TModels, TSliceState>
+	| ModelSelectorsFactory<TModels, TExtraModels, TSliceState>
+	| ModelSelectorFactories<TModels, TExtraModels, TSliceState>
 
 export type RematchSelect<
 	TModels extends Models<TModels>,
-	TRootState = RematchRootState<TModels>
+	TExtraModels extends Models<TModels>,
+	TRootState = RematchRootState<TModels, TExtraModels>
 > = (<TReturn extends { [key: string]: (state: TRootState) => any }>(
-	mapSelectToProps: (select: RematchSelect<TModels>) => TReturn
+	mapSelectToProps: (select: RematchSelect<TModels, TExtraModels>) => TReturn
 ) => Reselect.OutputParametricSelector<
 	TRootState,
 	any,
 	{ [K in keyof TReturn]: ReturnType<TReturn[K]> },
-	Reselect.Selector<TRootState, Record<string, any>>
+	Reselect.Selector<TRootState, TRootState>
 > &
 	Reselect.OutputSelector<
 		TRootState,
 		{ [K in keyof TReturn]: ReturnType<TReturn[K]> },
-		Reselect.Selector<TRootState, Record<string, any>>
+		Reselect.Selector<TRootState, TRootState>
 	>) &
-	StoreSelectors<TModels>
+	StoreSelectors<TModels, TExtraModels>
 
 declare module '@rematch/core' {
 	// Add overloads for store to add select
 	interface RematchStore<
-		TModels extends Models<TModels> = Record<string, any>,
-		TExtraModels extends Models<TModels> = Record<string, any>
+		TModels extends Models<TModels>,
+		TExtraModels extends Models<TModels>
 	> extends ReduxStore<RematchRootState<TModels, TExtraModels>, Action> {
-		select: RematchSelect<TModels>
+		select: RematchSelect<
+			TModels,
+			TExtraModels,
+			RematchRootState<TModels, TExtraModels>
+		>
 	}
 
 	// add overloads for Model here.
-	interface Model<
-		TModels extends Models<TModels> = Record<string, any>,
-		TState = any
-	> {
+	interface Model<TModels extends Models<TModels>, TState = any> {
 		selectors?: ModelSelectorsConfig<TModels, TState>
 	}
 

--- a/packages/updated/src/index.ts
+++ b/packages/updated/src/index.ts
@@ -39,7 +39,7 @@ export interface ExtraModelsFromUpdated<
 
 const updatedPlugin = <
 	TModels extends Models<TModels>,
-	TExtraModels extends Models<TModels> = Record<string, any>,
+	TExtraModels extends Models<TModels> = Record<string, never>,
 	T = Date
 >(
 	config: UpdatedConfig<T> = {}

--- a/packages/updated/test/updated.test.ts
+++ b/packages/updated/test/updated.test.ts
@@ -67,7 +67,11 @@ describe('updated', () => {
 			},
 		}
 
-		const store = init({
+		interface RootModel extends Models<RootModel> {
+			count: typeof count
+		}
+
+		const store = init<RootModel, ExtraModelsFromUpdated<RootModel>>({
 			models: { count },
 			plugins: [
 				updatedPlugin({


### PR DESCRIPTION
There are some fixes or improvements related to the rematch type system. If you have any issues you can checkout a branch from the `improve-typing` and create a PR and set `improve-typing` as merge target.

### Bug fixes
- [x] #893 - Typescript connect() fails about circular references
- [X] #894 - #902 Improve Typescript dispatch.reducer inference and effects
- [x] #870 - this.reducer isn't typed correctly, probably this one since it's complex to fix, we can go with any.
- [X] #892 - init() models also accepts Partial<RootModel>, this can be used in conjuntion with store.addModel() for dynamic adding models

### Improvements
- [x] Remove all the default generic type variable `Record<string, any>`. If needed, use `Record<string, unknown>` or `Record<string, never>` instead.