### PR TITLE
fix: reducers and effects with same name are correctly typed 4.3.X

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -21,6 +21,22 @@ import {
 } from 'redux'
 
 /**
+ * Utility type taken by type-fest repository
+ * https://github.com/sindresorhus/type-fest/blob/main/source/merge-exclusive.d.ts
+ * Merges Exclusively two types into one
+ * Used to fix this https://github.com/rematch/rematch/issues/912
+ */
+type Without<FirstType, SecondType> = {
+	[KeyType in Exclude<keyof FirstType, keyof SecondType>]: never
+}
+export type MergeExclusive<FirstType, SecondType> =
+	| FirstType
+	| SecondType extends object
+	?
+			| (Without<FirstType, SecondType> & SecondType)
+			| (Without<SecondType, FirstType> & FirstType)
+	: FirstType | SecondType
+/**
  * Custom Action interface, adds an additional field - `payload`.
  *
  * Strings (instead of Symbols) are used as the type for `type` field inherited
@@ -333,13 +349,14 @@ export type ExtractRematchDispatchersFromModels<
 export type ModelDispatcher<
 	TModel extends Model<TModels>,
 	TModels extends Models<TModels>
-> = ExtractRematchDispatchersFromReducers<
-	TModel['state'],
-	TModel['reducers'],
-	TModels
-> &
-	ExtractRematchDispatchersFromEffects<TModel['effects'], TModels>
-
+> = MergeExclusive<
+	ExtractRematchDispatchersFromEffects<TModel['effects'], TModels>,
+	ExtractRematchDispatchersFromReducers<
+		TModel['state'],
+		TModel['reducers'],
+		TModels
+	>
+>
 /** ************************ Reducers Dispatcher ************************* */
 
 /**

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -1,5 +1,5 @@
 import { Middleware } from 'redux'
-import { init } from '../src'
+import { createModel, init, Models } from '../src'
 
 describe('init config:', () => {
 	test('should not throw with an empty config', () => {
@@ -29,16 +29,22 @@ describe('init config:', () => {
 			return next(newAction)
 		}
 
-		const store = init({
-			models: {
-				count: {
-					state: 0,
-					reducers: {
-						addBy(state: number, payload: number): number {
-							return state + payload
-						},
-					},
+		const count = createModel<RootModel>()({
+			state: 0,
+			reducers: {
+				addBy(state: number, payload: number): number {
+					return state + payload
 				},
+			},
+		})
+
+		interface RootModel extends Models<RootModel> {
+			count: typeof count
+		}
+
+		const store = init<RootModel>({
+			models: {
+				count,
 			},
 			redux: {
 				middlewares: [add5Middleware, subtract2Middleware],

--- a/packages/core/test/dispatcher.test.ts
+++ b/packages/core/test/dispatcher.test.ts
@@ -1,4 +1,4 @@
-import { init, ModelDispatcher, Models } from '../src'
+import { createModel, init, ModelDispatcher, Models } from '../src'
 
 describe('dispatch:', () => {
 	describe('action:', () => {
@@ -47,12 +47,15 @@ describe('dispatch:', () => {
 		it('should dispatch an action', () => {
 			type CountState = number
 
-			const count = {
+			interface RootModel extends Models<RootModel> {
+				count: typeof count
+			}
+			const count = createModel<RootModel>()({
 				state: 0,
 				reducers: {
 					add: (state: CountState): CountState => state + 1,
 				},
-			}
+			})
 
 			const store = init({
 				models: { count },
@@ -69,12 +72,15 @@ describe('dispatch:', () => {
 		it('should dispatch multiple actions', () => {
 			type CountState = number
 
-			const count = {
+			interface RootModel extends Models<RootModel> {
+				count: typeof count
+			}
+			const count = createModel<RootModel>()({
 				state: 0,
 				reducers: {
 					add: (state: CountState): CountState => state + 1,
 				},
-			}
+			})
 
 			const store = init({
 				models: { count },
@@ -91,21 +97,26 @@ describe('dispatch:', () => {
 		it('should handle multiple models', () => {
 			type CountState = number
 
-			const a = {
+			const a = createModel<RootModel>()({
 				state: 42,
 				reducers: {
 					add: (state: CountState): CountState => state + 1,
 				},
-			}
+			})
 
-			const b = {
+			const b = createModel<RootModel>()({
 				state: 0,
 				reducers: {
 					add: (state: CountState): CountState => state + 1,
 				},
+			})
+
+			interface RootModel extends Models<RootModel> {
+				a: typeof a
+				b: typeof b
 			}
 
-			const store = init({
+			const store = init<RootModel>({
 				models: { a, b },
 			})
 
@@ -124,7 +135,7 @@ describe('dispatch:', () => {
 				meta: any
 			}
 
-			const count = {
+			const count = createModel<RootModel>()({
 				state: {
 					count: 0,
 					meta: null,
@@ -141,9 +152,13 @@ describe('dispatch:', () => {
 						}
 					},
 				},
+			})
+
+			interface RootModel extends Models<RootModel> {
+				count: typeof count
 			}
 
-			const store = init({
+			const store = init<RootModel>({
 				models: { count },
 			})
 
@@ -154,25 +169,60 @@ describe('dispatch:', () => {
 				meta: { some_meta: true },
 			})
 		})
+
+		it('effects functions that share a name with a reducer are called after their reducer counterpart.', () => {
+			interface RootModel extends Models<RootModel> {
+				count: typeof count
+			}
+
+			const effectMock = jest.fn()
+			const reducerMock = jest.fn()
+
+			const count = createModel<RootModel>()({
+				state: {
+					count: 0,
+				},
+				reducers: {
+					add(state) {
+						reducerMock()
+						return state
+					},
+				},
+				effects: () => ({
+					add() {
+						effectMock()
+					},
+				}),
+			})
+
+			const store = init<RootModel>({
+				models: { count },
+			})
+
+			store.dispatch.count.add()
+			expect(effectMock.mock.invocationCallOrder[0]).toBeGreaterThan(
+				reducerMock.mock.invocationCallOrder[0]
+			)
+		})
 	})
 
 	it('should include a payload if it is a false value', () => {
 		type AState = boolean
 
-		const a = {
+		const a = createModel<RootModel>()({
 			state: true,
 			reducers: {
 				toggle: (_: AState, payload: boolean): boolean => payload,
 			},
-		}
-
-		type RootModel = {
-			a: typeof a
-		}
+		})
 
 		const models: RootModel = { a }
 
-		const store = init({
+		interface RootModel extends Models<RootModel> {
+			a: typeof a
+		}
+
+		const store = init<RootModel>({
 			models,
 		})
 
@@ -215,14 +265,18 @@ describe('dispatch:', () => {
 		it('should pass state as the first reducer param', () => {
 			type CountState = number
 
-			const count = {
+			const count = createModel<RootModel>()({
 				state: 0,
 				reducers: {
 					doNothing: (state: CountState): CountState => state,
 				},
+			})
+
+			interface RootModel extends Models<RootModel> {
+				count: typeof count
 			}
 
-			const store = init({
+			const store = init<RootModel>({
 				models: { count },
 			})
 
@@ -238,7 +292,7 @@ describe('dispatch:', () => {
 				countIds: number[]
 			}
 
-			const count = {
+			const count = createModel<RootModel>()({
 				state: {
 					countIds: [],
 				} as CountState,
@@ -250,9 +304,13 @@ describe('dispatch:', () => {
 						}
 					},
 				},
+			})
+
+			interface RootModel extends Models<RootModel> {
+				count: typeof count
 			}
 
-			const store = init({
+			const store = init<RootModel>({
 				models: { count },
 			})
 

--- a/packages/core/test/listener.test.ts
+++ b/packages/core/test/listener.test.ts
@@ -1,26 +1,26 @@
-import { init } from '../src'
+import { createModel, init, Models } from '../src'
 
 describe('listener:', () => {
 	test('should trigger state changes on another models reducers', () => {
 		type CountState = number
 
-		const count1 = {
+		const count1 = createModel<RootModel>()({
 			state: 0,
 			reducers: {
 				increment: (state: CountState, payload: number): CountState =>
 					state + payload,
 			},
-		}
+		})
 
-		const count2 = {
+		const count2 = createModel<RootModel>()({
 			state: 0,
 			reducers: {
 				'count1/increment': (state: CountState, payload: number): CountState =>
 					state + payload,
 			},
-		}
+		})
 
-		type RootModel = {
+		interface RootModel extends Models<RootModel> {
 			count1: typeof count1
 			count2: typeof count2
 		}

--- a/packages/core/test/multiple.test.ts
+++ b/packages/core/test/multiple.test.ts
@@ -1,4 +1,4 @@
-import { init } from '../src'
+import { createModel, init, Models } from '../src'
 
 describe('multiple stores:', () => {
 	afterEach(() => {
@@ -19,11 +19,15 @@ describe('multiple stores:', () => {
 	})
 
 	test('should be able to store.dispatch to specific stores', () => {
-		const count = {
+		const count = createModel<RootModel>()({
 			state: 0,
 			reducers: {
 				increment: (state: number): number => state + 1,
 			},
+		})
+
+		interface RootModel extends Models<RootModel> {
+			count: typeof count
 		}
 
 		const store1 = init({ models: { count } })
@@ -64,27 +68,28 @@ describe('multiple stores:', () => {
 	})
 
 	test('dispatch should not contain another stores reducers', () => {
-		const count1 = {
+		const count1 = createModel<RootModel>()({
 			state: 0,
 			reducers: {
 				increment: (state: number): number => state + 1,
 			},
-		}
+		})
 
-		const count2 = {
+		const count2 = createModel<RootModel>()({
 			state: 0,
 			reducers: {
 				add: (state: number): number => state + 2,
 			},
-		}
+		})
 
-		const store1 = init({ models: { count: count1 } })
-		const store2 = init({ models: { count: count2 } })
+		interface RootModel extends Models<RootModel> {
+			count: typeof count1 | typeof count2
+		}
+		const store1 = init<RootModel>({ models: { count: count1 } })
+		const store2 = init<RootModel>({ models: { count: count2 } })
 
 		expect(store1.dispatch.count.increment).toBeDefined()
-		// @ts-expect-error
 		expect(store2.dispatch.count.increment).not.toBeDefined()
-		// @ts-expect-error
 		expect(store1.dispatch.count.add).not.toBeDefined()
 		expect(store2.dispatch.count.add).toBeDefined()
 	})

--- a/packages/core/test/plugins.test.ts
+++ b/packages/core/test/plugins.test.ts
@@ -1,4 +1,4 @@
-import { init, MiddlewareCreator, Plugin } from '../src'
+import { createModel, init, MiddlewareCreator, Models, Plugin } from '../src'
 
 describe('plugins:', () => {
 	test('should add onModel subscription', () => {
@@ -20,14 +20,14 @@ describe('plugins:', () => {
 	})
 
 	test('should add middleware', () => {
-		const a = {
+		const a = createModel<RootModel>()({
 			state: 0,
 			reducers: {
 				set: (_state: number, payload: number): number => payload,
 			},
-		}
+		})
 
-		type RootModel = {
+		interface RootModel extends Models<RootModel> {
 			a: typeof a
 		}
 
@@ -37,7 +37,7 @@ describe('plugins:', () => {
 			return next({ ...action, payload: 100 })
 		}
 
-		const store = init({
+		const store = init<RootModel>({
 			models: {
 				a,
 			},

--- a/packages/core/test/store.test.ts
+++ b/packages/core/test/store.test.ts
@@ -1,4 +1,4 @@
-import { init } from '../src'
+import { createModel, init, Models } from '../src'
 
 describe('createStore:', () => {
 	it('no params should create store with state `{}`', () => {
@@ -85,15 +85,18 @@ describe('createStore:', () => {
 	})
 
 	test('should allow resetting state through root reducer', () => {
-		const count = {
+		const count = createModel<RootModel>()({
 			state: 0,
 			reducers: {
 				addOne(state: number): number {
 					return state + 1
 				},
 			},
+		})
+		interface RootModel extends Models<RootModel> {
+			count: typeof count
 		}
-		const store = init({
+		const store = init<RootModel>({
 			models: { count },
 			redux: {
 				rootReducers: {
@@ -112,9 +115,13 @@ describe('createStore:', () => {
 	})
 
 	test('root reducer should work with dynamic model', () => {
-		const store = init({
+		const countA = createModel<RootModel>()({
+			state: 0,
+			reducers: { up: (s): number => s + 1 },
+		})
+		const store = init<RootModel>({
 			models: {
-				countA: { state: 0, reducers: { up: (s): number => s + 1 } },
+				countA,
 				countB: { state: 0, reducers: {} },
 			},
 			redux: {
@@ -125,6 +132,10 @@ describe('createStore:', () => {
 				},
 			},
 		})
+
+		interface RootModel extends Models<RootModel> {
+			countA: typeof countA
+		}
 
 		store.addModel({ name: 'countC', state: 0, reducers: {} })
 

--- a/packages/core/test/ts_typings/dispatcher-typings.test.ts
+++ b/packages/core/test/ts_typings/dispatcher-typings.test.ts
@@ -160,4 +160,39 @@ describe('Dispatcher typings', () => {
 			dispatch.count.incrementEffect('test', { prueba: 'hola ' })
 		})
 	})
+
+	describe('dispatch to an effect with the same name of the reducer', () => {
+		interface RootModel extends Models<RootModel> {
+			count: typeof count
+		}
+
+		const count = createModel<RootModel>()({
+			state: 0,
+			reducers: {
+				increment(state, payload: number) {
+					return state + payload
+				},
+				decrement(state, payload: number) {
+					return state - payload
+				},
+			},
+			effects: () => ({
+				increment(payload: number) {
+					this.increment(payload)
+				},
+			}),
+		})
+
+		const store = init<RootModel>({
+			models: {
+				count,
+			},
+		})
+
+		store.dispatch.count.increment(1)
+		store.dispatch.count.increment(10)
+		store.dispatch.count.increment('10')
+		store.dispatch.count.decrement(1)
+		store.dispatch.count.decrement('10')
+	})
 })

--- a/packages/core/test/ts_typings/dispatcher-typings.test.ts
+++ b/packages/core/test/ts_typings/dispatcher-typings.test.ts
@@ -176,9 +176,11 @@ describe('Dispatcher typings', () => {
 					return state - payload
 				},
 			},
-			effects: () => ({
-				increment(payload: number) {
-					this.increment(payload)
+			effects: (dispatch) => ({
+				increment(_: number, state) {
+					if (state.count < 5) {
+						dispatch.count.increment(1)
+					}
 				},
 			}),
 		})
@@ -191,8 +193,10 @@ describe('Dispatcher typings', () => {
 
 		store.dispatch.count.increment(1)
 		store.dispatch.count.increment(10)
+		// @ts-expect-error because increment payload:number, not string
 		store.dispatch.count.increment('10')
-		store.dispatch.count.decrement(1)
+		store.dispatch.count.decrement(3)
+		// @ts-expect-error because increment payload:number, not string
 		store.dispatch.count.decrement('10')
 	})
 })


### PR DESCRIPTION
Resolves #912 

Before 4.3 TypeScript accepted "duplicated" types but now is more stricter, so we just merge them giving priority always to reducers because is the entrypoint (will be the first executed if the same is duplicated)