### PR TITLE
chore: convert Typescript to TypeScript

### DIFF
--- a/.github/workflows/next-typescript-ci.yml
+++ b/.github/workflows/next-typescript-ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install
         run: yarn install --frozen-lockfile --pure-lockfile
 
-      - name: Add Typescript@next
+      - name: Add TypeScript@next
         run: yarn add --dev typescript@${{ matrix.typescript }} tslib -W
 
       - name: Build & Testing

--- a/blog/2021-02-01-welcome.md
+++ b/blog/2021-02-01-welcome.md
@@ -13,10 +13,10 @@ I'm super happy to announce that the new website is the continuation of the work
 Today we're announcing version 2.0.0 of Rematch. Almost 6 months passed since we opened the [Roadmap V2 for Rematch](https://github.com/rematch/rematch/issues/792). Here we are writing this post telling you guys all the incredible improvements and features we introduced to this new version of Rematch.
 
 ### Bug fixes
- - We're 100% compatible with [`Typescript`](https://www.typescriptlang.org/), YES!! Using `createModel()` helper we get autocomplete of effects, reducers, also the state, also we accept if the state is complex (like custom types) with a simple `as`. This is thanks to much people but [Zhi Tian](https://github.com/tianzhich) worked hard here with d.ts files, he's the type sorcerer.
+ - We're 100% compatible with [`TypeScript`](https://www.typescriptlang.org/), YES!! Using `createModel()` helper we get autocomplete of effects, reducers, also the state, also we accept if the state is complex (like custom types) with a simple `as`. This is thanks to much people but [Zhi Tian](https://github.com/tianzhich) worked hard here with d.ts files, he's the type sorcerer.
 
 :::tip
-How to easily start with Typescript + Rematch [here](/docs/getting-started/installation)
+How to easily start with TypeScript + Rematch [here](/docs/getting-started/installation)
 :::
 
 And no more bug fixes... because there aren't any. Rematch is consolidated as a stable alternative to Redux and other state-management solutions, it's fast, light, easy, and maintanaible. *What else do we need?*

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -55,7 +55,7 @@ export const count = {
 - You must pass the `RootModel` type that is exported on your index.ts of your models.
 - State is automatically infered, if your state contains complex types you only need to use an `as` [Look at count-react-ts example on questions.ts](https://github.com/rematch/rematch/blob/next-types/examples/count-react-ts/src/models/questions.ts)
 
-> All the examples of Rematch with Typescript are fully tested in our testing suite, so feel free to look at the /examples folder for an easier integration with your codebase.
+> All the examples of Rematch with TypeScript are fully tested in our testing suite, so feel free to look at the /examples folder for an easier integration with your codebase.
 
 ```ts title="./models/countModel.ts"
 import { createModel } from "@rematch/core";

--- a/docs/migrating/from-v1-to-v2.md
+++ b/docs/migrating/from-v1-to-v2.md
@@ -11,7 +11,7 @@ Breaking changes for:
 
 - Changed the default name assigned to stores from a number to `Rematch Store ${number}` for clarity. This could be a potential breaking change in your testing suite.
 - Changed typings to avoid future issues, on v1.x types doesn't work so the change should be easy.
-- Effects dispatch param can't be destructured in function Typescript (typescript design limitation).
+- Effects dispatch param can't be destructured in function TypeScript (typescript design limitation).
 
 **Plugins:**
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -1,7 +1,7 @@
 ---
 id: typescript
-title: Typescript
-sidebar_label: Typescript
+title: TypeScript
+sidebar_label: TypeScript
 slug: /getting-started/typescript
 ---
 
@@ -61,9 +61,9 @@ export type Dispatch = RematchDispatch<RootModel>
 export type RootState = RematchRootState<RootModel>
 ```
 
-Rematch handles Typescript inference practically out of the box, we have all our codebase with Typescript (latest version) and we do continuous testing to our [typescript examples](https://github.com/rematch/rematch/tree/main/examples/all-plugins-react-ts).
+Rematch handles TypeScript inference practically out of the box, we have all our codebase with TypeScript (latest version) and we do continuous testing to our [TypeScript examples](https://github.com/rematch/rematch/tree/main/examples/all-plugins-react-ts).
 
-For getting a cool Typescript setup with Rematch, it's as easy as using `createModel` helper.
+For getting a cool TypeScript setup with Rematch, it's as easy as using `createModel` helper.
 
 ### createModel
 
@@ -174,7 +174,7 @@ In the case you use some plugin, please read this:
 
 ### init with plugins
 
-Some plugins modifies the store like [`@rematch/loading`](/docs/plugins/loading), that introduces a new state with all your promises status, Typescript to know that needs some helper.
+Some plugins modifies the store like [`@rematch/loading`](/docs/plugins/loading), that introduces a new state with all your promises status, TypeScript to know that needs some helper.
 
 You need to pass the [`RootModel`](#RootModel) to `init()` function and introduce the helpers:
 
@@ -289,7 +289,7 @@ export default connect(mapState, mapDispatch)(App);
 
 ## Effects returning values
 
-There's a situation where if you're accessing the `rootState` value of the same model and returning this value. Typescript will fail because circular references itself (has sense)...
+There's a situation where if you're accessing the `rootState` value of the same model and returning this value. TypeScript will fail because circular references itself (has sense)...
 
 You should try to avoid returning values on effects and just dispatch data to reducers or write pure functions outside Rematch for a better performance.
 

--- a/examples/all-plugins-react-ts/README.md
+++ b/examples/all-plugins-react-ts/README.md
@@ -1,5 +1,5 @@
-# Rematch Example - All Plugins React Typescript
+# Rematch Example - All Plugins React TypeScript
 
-Example demonstrating usage of Rematch in React with Typescript.
+Example demonstrating usage of Rematch in React with TypeScript.
 
 [![Edit rematch-example-count-js](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/rematch/rematch/tree/main/examples/all-plugins-react-ts?fontsize=14&hidenavigation=1&theme=dark)

--- a/examples/all-plugins-react-ts/public/index.html
+++ b/examples/all-plugins-react-ts/public/index.html
@@ -4,7 +4,7 @@
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<meta name="theme-color" content="#000000" />
-	<title>Rematch Example - Count React Typescript</title>
+	<title>Rematch Example - Count React TypeScript</title>
 </head>
 <body>
 <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/examples/count-react-ts/README.md
+++ b/examples/count-react-ts/README.md
@@ -1,5 +1,5 @@
-# Rematch Example - Count React Typescript
+# Rematch Example - Count React TypeScript
 
-Example demonstrating usage of Rematch in React with Typescript.
+Example demonstrating usage of Rematch in React with TypeScript.
 
 [![Edit rematch-example-count-js](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/rematch/rematch/tree/main/examples/count-react-ts?fontsize=14&hidenavigation=1&theme=dark)

--- a/examples/count-react-ts/public/index.html
+++ b/examples/count-react-ts/public/index.html
@@ -4,7 +4,7 @@
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<meta name="theme-color" content="#000000" />
-	<title>Rematch Example - Count React Typescript</title>
+	<title>Rematch Example - Count React TypeScript</title>
 </head>
 <body>
 <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/examples/hooks-react-ts/README.md
+++ b/examples/hooks-react-ts/README.md
@@ -1,5 +1,5 @@
-# Rematch Example - Hooks React Typescript
+# Rematch Example - Hooks React TypeScript
 
-Example demonstrating usage of Rematch in React with Typescript and hooks.
+Example demonstrating usage of Rematch in React with TypeScript and hooks.
 
 [![Edit rematch-example](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/rematch/rematch/tree/main/examples/hooks-react-ts?fontsize=14&hidenavigation=1&theme=dark)

--- a/examples/hooks-react-ts/public/index.html
+++ b/examples/hooks-react-ts/public/index.html
@@ -4,7 +4,7 @@
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<meta name="theme-color" content="#000000" />
-	<title>Rematch Example - Hooks React Typescript</title>
+	<title>Rematch Example - Hooks React TypeScript</title>
 </head>
 <body>
 <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/website/src/components/MultiLangComponent.tsx
+++ b/website/src/components/MultiLangComponent.tsx
@@ -4,7 +4,7 @@ import TabItem from '@theme/TabItem'
 
 const DEFAULT_LANGS = [
 	{ label: 'JavaScript', value: 'js' },
-	{ label: 'Typescript', value: 'ts' },
+	{ label: 'TypeScript', value: 'ts' },
 ]
 
 export const MultiLangComponent: React.FC<{

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -40,13 +40,13 @@ const features = [
 		),
 	},
 	{
-		title: 'Typescript support',
+		title: 'TypeScript support',
 		imageUrl: 'icons/type.svg',
 		description: (
 			<>
-				<code>Typescript</code> support out of the box. You will have
+				<code>TypeScript</code> support out of the box. You will have
 				autocomplete of all your methods, state and reducers. Written 100% in
-				Typescript.
+				TypeScript.
 			</>
 		),
 	},
@@ -210,7 +210,7 @@ const NeverHasBeenThatEasy = () => (
 					<p className={styles.p}>
 						<ul>
 							<li className="margin-top--md">
-								Automatic intellisense with Typescript steroids, autocomplete
+								Automatic intellisense with TypeScript steroids, autocomplete
 								everything, avoid regressions.
 							</li>
 							<li className="margin-top--md">
@@ -236,7 +236,7 @@ const NeverHasBeenThatEasy = () => (
 				<div className="col col--6 text--center margin-top--lg">
 					<img
 						loading="lazy"
-						alt="Real code of Rematch with Typescript"
+						alt="Real code of Rematch with TypeScript"
 						style={{ borderRadius: '0.75rem' }}
 						src={useBaseUrl('/img/real-code.gif')}
 					/>


### PR DESCRIPTION
Nice work with the twoslash code samples, I switched all the user-facing cases of "Typescript" to "TypeScript" ( [from here](https://www.typescriptlang.org/branding/))