### PR TITLE
feat: @rematch/loading with type: 'full' returns success/error/loading

### DIFF
--- a/docs/plugins/loading.md
+++ b/docs/plugins/loading.md
@@ -1,7 +1,7 @@
 ---
 id: loading
 title: Loading
-sidebar_label: "@rematch/loading"
+sidebar_label: '@rematch/loading'
 slug: /plugins/loading/
 ---
 
@@ -73,17 +73,17 @@ export type Dispatch = RematchDispatch<RootModel>
 export type RootState = RematchRootState<RootModel, FullModel>
 ```
 
-```twoslash include storeAsDetailed
-// @filename: storeAsDetailed.ts
+```twoslash include storeAsFull
+// @filename: storeAsFull.ts
 import loadingPlugin, { ExtraModelsFromLoading } from "@rematch/loading"
 import { init, RematchDispatch, RematchRootState } from "@rematch/core"
 import { models, RootModel } from "./models"
 
-type FullModel = ExtraModelsFromLoading<RootModel, { type: 'detailed' }>
+type FullModel = ExtraModelsFromLoading<RootModel, { type: 'full' }>
 
 export const store = init<RootModel, FullModel>({
   models,
-  plugins: [loadingPlugin({ type: 'detailed' })],
+  plugins: [loadingPlugin({ type: 'full' })],
 })
 
 export type Store = typeof store
@@ -114,7 +114,7 @@ The loading plugin accepts one optional argument - **config**, which is an objec
 
 - [`name`] (_string?_): key for the loading model in your store. If you name it "custom", loading state can be accessed from _state.custom_. **Defaults to _loading_**.
 - [`asNumber`] (_boolean?_): loading plugin by default keeps track of running effects using booleans, so for example: _state.loading.global === true_. You can change that behaviour and use numbers instead - plugin will keep track of the number of times an effect was executed, for example: _state.loading.global === 5_. Defaults to _false_. **Deprecated, use `type` instead**
-- [`type`] (_"number"|"boolean"|"detailed"_): Loading plugin by default keeps track of running effects using booleans, but sometimes you want to track errors and if the promise is resolved, in that case you can use `detailed`. If you want to track the number of times an effect was executed, you can use `number` instead.
+- [`type`] (_"number"|"boolean"|"full"_): Loading plugin by default keeps track of running effects using booleans, but sometimes you want to track if the effect promise is resolved to an Error, or loading, or if the promise is resolved correctly, in that case you can use `full`. If you want to track the number of times an effect was executed, you can use `number` instead.
 - [`whitelist`] (_string[]?_): an array of effects names that you want to use loading plugin for. If defined, plugin will work only for the whitelisted effects.
 - [`blacklist`] (_string[]?_): an array of effects names that you **don't want** to use loading plugin for. If defined, plugin will work for all effects except those blacklisted.
 
@@ -128,15 +128,15 @@ Let's say we have a model 'count' in our store. Loading plugin's state will have
 
 ```json
 {
-  "global": true, // true when any effect in any model is loading
-  "models": {
-    "count": true // true when any effect in 'count' model is loading
-  },
-  "effects": {
-    "count": {
-      "addOne": true // true when effect 'addOne' in model 'count' is loading
-    }
-  }
+	"global": true, // true when any effect in any model is loading
+	"models": {
+		"count": true // true when any effect in 'count' model is loading
+	},
+	"effects": {
+		"count": {
+			"addOne": true // true when effect 'addOne' in model 'count' is loading
+		}
+	}
 }
 ```
 
@@ -168,13 +168,12 @@ If you want to use the `loadingPlugin` with detailed Errors and Success informat
 // @include: countModel
 // @include: rootModel
 // ---cut---
-// @include: storeAsDetailed
+// @include: storeAsFull
 ```
 
 ### React usage
 
 Use state created by the loading plugin in your view.
-
 
 #### Default
 
@@ -184,44 +183,40 @@ Use state created by the loading plugin in your view.
 // @include: store
 // ---cut---
 // @filename: appTemplate.tsx
-import React from "react"
-import { useSelector } from "react-redux"
-import { RootState } from "./store"
+import React from 'react'
+import { useSelector } from 'react-redux'
+import { RootState } from './store'
 
 export const App = () => {
-  const isCountLoading = useSelector((rootState: RootState) => rootState.loading.models.count)
-  if (isCountLoading) return <div>LOADING...</div>
+	const isCountLoading = useSelector(
+		(rootState: RootState) => rootState.loading.models.count
+	)
+	if (isCountLoading) return <div>LOADING...</div>
 
-  return (
-    <div>
-      Data succesfully loaded
-    </div>
-  )
+	return <div>Data succesfully loaded</div>
 }
 ```
 
-#### Detailed
+#### Full
 
 ```tsx twoslash
 // @include: countModel
 // @include: rootModel
-// @include: storeAsDetailed
+// @include: storeAsFull
 // ---cut---
 // @filename: appTemplate.tsx
-import React from "react"
-import { useSelector } from "react-redux"
-import { RootState } from "./storeAsDetailed"
+import React from 'react'
+import { useSelector } from 'react-redux'
+import { RootState } from './storeAsFull'
 
 export const App = () => {
-  const { loading, success, error } = useSelector((rootState: RootState) => rootState.loading.models.count)
-  if (loading) return <div>LOADING...</div>
-  if (error) return <div>{(error as Error).name}</div>
+	const { loading, success, error } = useSelector(
+		(rootState: RootState) => rootState.loading.models.count
+	)
+	if (loading) return <div>LOADING...</div>
+	if (error) return <div>{(error as Error).name}</div>
 
-  return (
-    <div>
-      Data succesfully loaded
-    </div>
-  )
+	return <div>Data succesfully loaded</div>
 }
 ```
 
@@ -233,18 +228,16 @@ export const App = () => {
 // @include: storeAsNumber
 // ---cut---
 // @filename: appTemplate.tsx
-import React from "react"
-import { useSelector } from "react-redux"
-import { RootState } from "./storeAsNumber"
+import React from 'react'
+import { useSelector } from 'react-redux'
+import { RootState } from './storeAsNumber'
 
 export const App = () => {
-  const countCalledTimes = useSelector((rootState: RootState) => rootState.loading.models.count)
-  if (countCalledTimes > 0) return <div>LOADING...</div>
+	const countCalledTimes = useSelector(
+		(rootState: RootState) => rootState.loading.models.count
+	)
+	if (countCalledTimes > 0) return <div>LOADING...</div>
 
-  return (
-    <div>
-      Data succesfully loaded
-    </div>
-  )
+	return <div>Data succesfully loaded</div>
 }
 ```

--- a/examples/all-plugins-react-ts/src/__snapshots__/index.test.tsx.snap
+++ b/examples/all-plugins-react-ts/src/__snapshots__/index.test.tsx.snap
@@ -41,7 +41,13 @@ exports[`Application is rendered correctly 1`] = `
       </div>
       <div
         class="container"
-      />
+      >
+        <div
+          class="loader"
+        >
+          Loading...
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/examples/all-plugins-react-ts/src/index.test.tsx
+++ b/examples/all-plugins-react-ts/src/index.test.tsx
@@ -4,7 +4,6 @@ import { Provider } from 'react-redux'
 
 import { GlobalApp } from './GlobalApp'
 import { store } from './store'
-import { cart } from './models/cart'
 
 const TestingProvider: React.FC = ({ children }) => (
 	<Provider store={store}>{children}</Provider>
@@ -32,14 +31,16 @@ test('Store is correctly initialized', () => {
 		loading: {
 			effects: {
 				cart: {},
-				players: {},
+				players: {
+					getPlayers: true,
+				},
 				settings: {},
 				updated: {},
 			},
-			global: false,
+			global: true,
 			models: {
 				cart: false,
-				players: false,
+				players: true,
 				settings: false,
 				updated: false,
 			},

--- a/examples/all-plugins-react-ts/tsconfig.json
+++ b/examples/all-plugins-react-ts/tsconfig.json
@@ -17,7 +17,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "noFallthroughCasesInSwitch": true
   },
   "include": [

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     },
     {
       "path": "./packages/loading/dist/loading.umd.production.min.js",
-      "limit": "700 B"
+      "limit": "1 kb"
     },
     {
       "path": "./packages/persist/dist/persist.umd.production.min.js",

--- a/packages/loading/src/index.ts
+++ b/packages/loading/src/index.ts
@@ -7,7 +7,7 @@ import {
 	Action,
 } from '@rematch/core'
 
-export type LoadingPluginType = 'number' | 'boolean' | 'detailed'
+export type LoadingPluginType = 'number' | 'boolean' | 'full'
 export interface LoadingConfig {
 	name?: string
 	whitelist?: string[]
@@ -22,7 +22,7 @@ type PickLoadingPluginType<
 	WhichType extends LoadingPluginType
 > = WhichType extends 'number'
 	? number
-	: WhichType extends 'detailed'
+	: WhichType extends 'full'
 	? DetailedPayload
 	: boolean
 
@@ -189,7 +189,7 @@ export default <
 		config.type = 'number'
 	}
 	const isAsNumber = config.type === 'number'
-	const isAsDetailed = config.type === 'detailed'
+	const isAsDetailed = config.type === 'full'
 
 	const converter: Converter<LoadingPluginType> = (cnt, detailedPayload) => {
 		if (isAsNumber) return cnt

--- a/packages/loading/src/index.ts
+++ b/packages/loading/src/index.ts
@@ -26,7 +26,7 @@ type PickLoadingPluginType<
 	? DetailedPayload
 	: boolean
 
-interface LoadingStateV2<
+interface LoadingState<
 	TModels extends Models<TModels>,
 	WhichType extends LoadingPluginType
 > {
@@ -44,7 +44,7 @@ interface LoadingStateV2<
 	}
 }
 
-interface InitialStateV2<WhichType extends LoadingPluginType> {
+interface InitialState<WhichType extends LoadingPluginType> {
 	global: PickLoadingPluginType<WhichType>
 	models: {
 		[modelName: string]: PickLoadingPluginType<WhichType>
@@ -61,13 +61,13 @@ type Converter<WhichType extends LoadingPluginType> = (
 	detailedPayload?: DetailedPayload
 ) => PickLoadingPluginType<WhichType>
 
-interface LoadingModelV2<
+interface LoadingModel<
 	TModels extends Models<TModels>,
 	WhichType extends LoadingPluginType
-> extends NamedModel<TModels, LoadingStateV2<TModels, WhichType>> {
+> extends NamedModel<TModels, LoadingState<TModels, WhichType>> {
 	reducers: {
-		hide: Reducer<LoadingStateV2<TModels, WhichType>>
-		show: Reducer<LoadingStateV2<TModels, WhichType>>
+		hide: Reducer<LoadingState<TModels, WhichType>>
+		show: Reducer<LoadingState<TModels, WhichType>>
 	}
 }
 
@@ -77,7 +77,7 @@ export interface ExtraModelsFromLoading<
 		type: 'boolean'
 	}
 > extends Models<TModels> {
-	loading: LoadingModelV2<
+	loading: LoadingModel<
 		TModels,
 		TConfig['type'] extends LoadingPluginType ? TConfig['type'] : 'boolean'
 	>
@@ -95,15 +95,15 @@ const createLoadingAction = <
 >(
 	converter: Converter<WhichType>,
 	i: number,
-	cntState: InitialStateV2<'number'>
-): Reducer<LoadingStateV2<TModels, WhichType>> => (
+	cntState: InitialState<'number'>
+): Reducer<LoadingState<TModels, WhichType>> => (
 	state,
 	payload: Action<{
 		name: string
 		action: string
 		detailedPayload: DetailedPayload
 	}>['payload']
-): LoadingStateV2<TModels, WhichType> => {
+): LoadingState<TModels, WhichType> => {
 	const { name, action, detailedPayload } = payload || { name: '', action: '' }
 
 	cntState.global += i
@@ -202,24 +202,24 @@ export default <
 		return cnt > 0
 	}
 
-	const loadingInitialState: InitialStateV2<LoadingPluginType> = {
+	const loadingInitialState: InitialState<LoadingPluginType> = {
 		global: converter(0),
 		models: {},
 		effects: {},
 	}
 
-	const cntState: InitialStateV2<'number'> = {
+	const cntState: InitialState<'number'> = {
 		global: 0,
 		models: {},
 		effects: {},
 	}
-	const loading: LoadingModelV2<TModels, LoadingPluginType> = {
+	const loading: LoadingModel<TModels, LoadingPluginType> = {
 		name: loadingModelName,
 		reducers: {
 			hide: createLoadingAction(converter, -1, cntState),
 			show: createLoadingAction(converter, 1, cntState),
 		},
-		state: loadingInitialState as LoadingStateV2<TModels, LoadingPluginType>,
+		state: loadingInitialState as LoadingState<TModels, LoadingPluginType>,
 	}
 
 	const initialLoadingValue = converter(0)

--- a/packages/loading/src/index.ts
+++ b/packages/loading/src/index.ts
@@ -7,67 +7,51 @@ import {
 	Action,
 } from '@rematch/core'
 
+export type LoadingPluginType = 'number' | 'boolean' | 'detailed'
 export interface LoadingConfig {
 	name?: string
 	whitelist?: string[]
 	blacklist?: string[]
-	type?: 'number' | 'boolean' | 'detailed'
+	type?: LoadingPluginType
 	/**
 	 * @deprecated Use `type: 'number'` instead
 	 */
 	asNumber?: boolean
 }
+type PickLoadingPluginType<
+	WhichType extends LoadingPluginType
+> = WhichType extends 'number'
+	? number
+	: WhichType extends 'detailed'
+	? DetailedPayload
+	: boolean
 
 interface LoadingStateV2<
 	TModels extends Models<TModels>,
-	WhichType extends 'number' | 'boolean' | 'detailed'
+	WhichType extends LoadingPluginType
 > {
-	global: WhichType extends 'number'
-		? number
-		: WhichType extends 'detailed'
-		? DetailedPayload
-		: boolean
+	global: PickLoadingPluginType<WhichType>
 	models: {
-		[modelName in keyof TModels]: WhichType extends 'number'
-			? number
-			: WhichType extends 'detailed'
-			? DetailedPayload
-			: boolean
+		[modelName in keyof TModels]: PickLoadingPluginType<WhichType>
 	}
 	effects: {
 		[modelName in keyof TModels]: {
 			[effectName in keyof ExtractRematchDispatchersFromEffects<
 				TModels[modelName]['effects'],
 				TModels
-			>]: WhichType extends 'number'
-				? number
-				: WhichType extends 'detailed'
-				? DetailedPayload
-				: boolean
+			>]: PickLoadingPluginType<WhichType>
 		}
 	}
 }
 
-interface InitialStateV2<WhichType extends 'number' | 'boolean' | 'detailed'> {
-	global: WhichType extends 'number'
-		? number
-		: WhichType extends 'detailed'
-		? DetailedPayload
-		: boolean
+interface InitialStateV2<WhichType extends LoadingPluginType> {
+	global: PickLoadingPluginType<WhichType>
 	models: {
-		[modelName: string]: WhichType extends 'number'
-			? number
-			: WhichType extends 'detailed'
-			? DetailedPayload
-			: boolean
+		[modelName: string]: PickLoadingPluginType<WhichType>
 	}
 	effects: {
 		[modelName: string]: {
-			[effectName: string]: WhichType extends 'number'
-				? number
-				: WhichType extends 'detailed'
-				? DetailedPayload
-				: boolean
+			[effectName: string]: PickLoadingPluginType<WhichType>
 		}
 	}
 }
@@ -79,7 +63,7 @@ type Converter = (
 
 interface LoadingModelV2<
 	TModels extends Models<TModels>,
-	WhichType extends 'number' | 'boolean' | 'detailed'
+	WhichType extends LoadingPluginType
 > extends NamedModel<TModels, LoadingStateV2<TModels, WhichType>> {
 	reducers: {
 		hide: Reducer<LoadingStateV2<TModels, WhichType>>
@@ -95,9 +79,7 @@ export interface ExtraModelsFromLoading<
 > extends Models<TModels> {
 	loading: LoadingModelV2<
 		TModels,
-		TConfig['type'] extends 'number' | 'boolean' | 'detailed'
-			? TConfig['type']
-			: 'boolean'
+		TConfig['type'] extends LoadingPluginType ? TConfig['type'] : 'boolean'
 	>
 }
 
@@ -109,7 +91,7 @@ type DetailedPayload = {
 
 const createLoadingAction = <
 	TModels extends Models<TModels>,
-	WhichType extends 'number' | 'boolean' | 'detailed'
+	WhichType extends LoadingPluginType
 >(
 	converter: Converter,
 	i: number,

--- a/packages/loading/src/index.ts
+++ b/packages/loading/src/index.ts
@@ -12,7 +12,9 @@ export interface LoadingConfig {
 	whitelist?: string[]
 	blacklist?: string[]
 	type?: 'number' | 'boolean' | 'detailed'
-	// @deprecated Use type: 'number' instead
+	/**
+	 * @deprecated Use `type: 'number'` instead
+	 */
 	asNumber?: boolean
 }
 

--- a/packages/loading/src/index.ts
+++ b/packages/loading/src/index.ts
@@ -181,6 +181,10 @@ const validateConfig = (config: LoadingConfig): void => {
 	}
 }
 
+function assignExtraPayload<T, B>(insert: boolean, error: T, success: B) {
+	return insert ? { error, success } : null
+}
+
 export default <
 	TModels extends Models<TModels>,
 	TExtraModels extends Models<TModels>,
@@ -297,12 +301,7 @@ export default <
 						rematch.dispatch[loadingModelName].show({
 							name,
 							action,
-							detailedPayload: isAsDetailed
-								? {
-										success: false,
-										error: false,
-								  }
-								: null,
+							detailedPayload: assignExtraPayload(isAsDetailed, false, false),
 						})
 						// dispatch the original action
 						const effectResult = origEffect(...props)
@@ -315,12 +314,11 @@ export default <
 									rematch.dispatch[loadingModelName].hide({
 										name,
 										action,
-										detailedPayload: isAsDetailed
-											? {
-													error: false,
-													success: true,
-											  }
-											: null,
+										detailedPayload: assignExtraPayload(
+											isAsDetailed,
+											false,
+											true
+										),
 									})
 									return r
 								})
@@ -328,12 +326,11 @@ export default <
 									rematch.dispatch[loadingModelName].hide({
 										name,
 										action,
-										detailedPayload: isAsDetailed
-											? {
-													error: err,
-													success: false,
-											  }
-											: null,
+										detailedPayload: assignExtraPayload(
+											isAsDetailed,
+											err,
+											false
+										),
 									})
 									throw err
 								})
@@ -343,12 +340,7 @@ export default <
 						rematch.dispatch[loadingModelName].hide({
 							name,
 							action,
-							detailedPayload: isAsDetailed
-								? {
-										error: false,
-										success: true,
-								  }
-								: null,
+							detailedPayload: assignExtraPayload(isAsDetailed, false, true),
 						})
 
 						// return the original result of this reducer
@@ -357,12 +349,7 @@ export default <
 						rematch.dispatch[loadingModelName].hide({
 							name,
 							action,
-							detailedPayload: isAsDetailed
-								? {
-										error,
-										success: false,
-								  }
-								: null,
+							detailedPayload: assignExtraPayload(isAsDetailed, error, false),
 						})
 						throw error
 					}

--- a/packages/loading/test/loading-asDetailed.test.ts
+++ b/packages/loading/test/loading-asDetailed.test.ts
@@ -1,0 +1,191 @@
+/* eslint-disable no-shadow */
+import { init } from '@rematch/core'
+import loadingPlugin, { ExtraModelsFromLoading } from '../src'
+import { delay } from './utils'
+
+describe('loading asDetailed', () => {
+	test('should capture all model and global loading for simultaneous effects', async () => {
+		const count2 = {
+			state: 0,
+			effects: {
+				async timeout1(): Promise<void> {
+					await delay(200)
+				},
+				async timeout2(): Promise<void> {
+					await delay(200)
+				},
+			},
+			reducers: {},
+		}
+
+		type Models = { count: typeof count2 }
+		type ExtraModels = ExtraModelsFromLoading<
+			Models,
+			{
+				type: 'detailed'
+			}
+		>
+		const store = init<Models, ExtraModels>({
+			models: { count: count2 },
+			plugins: [loadingPlugin({ type: 'detailed' })],
+		})
+
+		const effect1 = store.dispatch.count.timeout1()
+		await delay(100)
+		const effect2 = store.dispatch.count.timeout2()
+
+		const ld = (): any => store.getState().loading
+		// INITIAL LOAD
+		expect(ld().effects.count.timeout1).toEqual({
+			error: false,
+			loading: true,
+			success: false,
+		})
+		expect(ld().effects.count.timeout2).toEqual({
+			error: false,
+			loading: true,
+			success: false,
+		})
+		expect(ld().models.count).toEqual({
+			error: false,
+			loading: true,
+			success: false,
+		})
+		expect(ld().global).toEqual({
+			error: false,
+			loading: true,
+			success: false,
+		})
+
+		await effect1
+		expect(ld().effects.count.timeout1).toEqual({
+			error: false,
+			loading: false,
+			success: true,
+		})
+		expect(ld().effects.count.timeout2).toEqual({
+			error: false,
+			loading: true,
+			success: false,
+		})
+		expect(ld().models.count).toEqual({
+			error: false,
+			loading: true,
+			success: true,
+		})
+		expect(ld().global).toEqual({
+			error: false,
+			loading: true,
+			success: true,
+		})
+
+		await effect2
+		expect(ld().effects.count.timeout1).toEqual({
+			error: false,
+			loading: false,
+			success: true,
+		})
+		expect(ld().effects.count.timeout2).toEqual({
+			error: false,
+			loading: false,
+			success: true,
+		})
+		expect(ld().models.count).toEqual({
+			error: false,
+			loading: false,
+			success: true,
+		})
+		expect(ld().global).toEqual({
+			error: false,
+			loading: false,
+			success: true,
+		})
+	})
+
+	test('should capture the error correctly', async () => {
+		const count2 = {
+			state: 0,
+			effects: {
+				async success() {
+					await delay(100)
+				},
+			},
+			reducers: {},
+		}
+
+		type Models = { count: typeof count2 }
+		type ExtraModels = ExtraModelsFromLoading<
+			Models,
+			{
+				type: 'detailed'
+			}
+		>
+
+		const store = init<Models, ExtraModels>({
+			models: { count: count2 },
+			plugins: [loadingPlugin({ type: 'detailed' })],
+		})
+
+		await store.dispatch.count.success()
+		expect(store.getState().loading.global).toEqual({
+			success: true,
+			loading: false,
+			error: false,
+		})
+	})
+
+	test('should capture the error correctly', async () => {
+		const count2 = {
+			state: 0,
+			effects: {
+				throwError(): void {
+					throw new Error('effect error')
+				},
+			},
+			reducers: {},
+		}
+
+		type Models = { count: typeof count2 }
+		type ExtraModels = ExtraModelsFromLoading<
+			Models,
+			{
+				type: 'detailed'
+			}
+		>
+
+		const store = init<Models, ExtraModels>({
+			models: { count: count2 },
+			plugins: [loadingPlugin({ type: 'detailed' })],
+		})
+
+		try {
+			await store.dispatch.count.throwError()
+		} catch (err) {
+			expect(store.getState().loading).toMatchInlineSnapshot(`
+    Object {
+      "effects": Object {
+        "count": Object {
+          "throwError": Object {
+            "error": [Error: effect error],
+            "loading": false,
+            "success": false,
+          },
+        },
+      },
+      "global": Object {
+        "error": [Error: effect error],
+        "loading": false,
+        "success": false,
+      },
+      "models": Object {
+        "count": Object {
+          "error": [Error: effect error],
+          "loading": false,
+          "success": false,
+        },
+      },
+    }
+  `)
+		}
+	})
+})

--- a/packages/loading/test/loading-asFull.test.ts
+++ b/packages/loading/test/loading-asFull.test.ts
@@ -3,7 +3,7 @@ import { init } from '@rematch/core'
 import loadingPlugin, { ExtraModelsFromLoading } from '../src'
 import { delay } from './utils'
 
-describe('loading asDetailed', () => {
+describe('loading asFull', () => {
 	test('should capture all model and global loading for simultaneous effects', async () => {
 		const count2 = {
 			state: 0,
@@ -22,12 +22,12 @@ describe('loading asDetailed', () => {
 		type ExtraModels = ExtraModelsFromLoading<
 			Models,
 			{
-				type: 'detailed'
+				type: 'full'
 			}
 		>
 		const store = init<Models, ExtraModels>({
 			models: { count: count2 },
-			plugins: [loadingPlugin({ type: 'detailed' })],
+			plugins: [loadingPlugin({ type: 'full' })],
 		})
 
 		const effect1 = store.dispatch.count.timeout1()
@@ -117,13 +117,13 @@ describe('loading asDetailed', () => {
 		type ExtraModels = ExtraModelsFromLoading<
 			Models,
 			{
-				type: 'detailed'
+				type: 'full'
 			}
 		>
 
 		const store = init<Models, ExtraModels>({
 			models: { count: count2 },
-			plugins: [loadingPlugin({ type: 'detailed' })],
+			plugins: [loadingPlugin({ type: 'full' })],
 		})
 
 		await store.dispatch.count.success()
@@ -149,13 +149,13 @@ describe('loading asDetailed', () => {
 		type ExtraModels = ExtraModelsFromLoading<
 			Models,
 			{
-				type: 'detailed'
+				type: 'full'
 			}
 		>
 
 		const store = init<Models, ExtraModels>({
 			models: { count: count2 },
-			plugins: [loadingPlugin({ type: 'detailed' })],
+			plugins: [loadingPlugin({ type: 'full' })],
 		})
 
 		try {

--- a/packages/loading/test/loading-asNumber.test.ts
+++ b/packages/loading/test/loading-asNumber.test.ts
@@ -156,7 +156,6 @@ describe('loading asNumbers', () => {
 			init<Models, ExtraModels>({
 				models: { count },
 				plugins: [
-					// @ts-expect-error
 					loadingPlugin({
 						asNumber: true,
 						// @ts-expect-error
@@ -173,7 +172,6 @@ describe('loading asNumbers', () => {
 			init<Models, ExtraModels>({
 				models: { count },
 				plugins: [
-					// @ts-expect-error
 					loadingPlugin({
 						// @ts-expect-error
 						asNumber: 'should throw',
@@ -219,7 +217,6 @@ describe('loading asNumbers', () => {
 			init<Models, ExtraModels>({
 				models: { count },
 				plugins: [
-					// @ts-expect-error
 					loadingPlugin({
 						asNumber: true,
 						// @ts-expect-error
@@ -236,7 +233,6 @@ describe('loading asNumbers', () => {
 			init<Models, ExtraModels>({
 				models: { count },
 				plugins: [
-					// @ts-expect-error
 					loadingPlugin({
 						asNumber: true,
 						// @ts-expect-error

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -13,7 +13,6 @@ module.exports = {
 	themeConfig: {
 		image: 'img/meta-image.png',
 		hideableSidebar: true,
-		sidebarCollapsible: true,
 		colorMode: {
 			defaultMode: 'light',
 			disableSwitch: false,
@@ -118,6 +117,7 @@ module.exports = {
 			{
 				docs: {
 					path: '../docs',
+					sidebarCollapsible: true,
 					remarkPlugins: [require('./src/plugins/remark-npm2yarn')],
 					sidebarPath: require.resolve('./sidebars.js'),
 					editUrl: 'https://github.com/rematch/rematch/edit/main/docs/',

--- a/website/package.json
+++ b/website/package.json
@@ -17,9 +17,9 @@
     "clear": "docusaurus clear"
   },
   "dependencies": {
-    "@docusaurus/core": "^2.0.0-beta.3",
-    "@docusaurus/preset-classic": "^2.0.0-beta.3",
-    "@docusaurus/theme-classic": "^2.0.0-beta.3",
+    "@docusaurus/core": "^2.0.0-beta.4",
+    "@docusaurus/preset-classic": "^2.0.0-beta.4",
+    "@docusaurus/theme-classic": "^2.0.0-beta.4",
     "@mdx-js/react": "^1.6.22",
     "@octokit/rest": "^18.6.7",
     "clsx": "^1.1.1",
@@ -27,7 +27,7 @@
     "postel": "^0.1.4",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
-    "docusaurus-preset-shiki-twoslash": "^1.1.16"
+    "docusaurus-preset-shiki-twoslash": "^1.1.27"
   },
   "browserslist": {
     "production": [
@@ -62,7 +62,7 @@
     "prism-react-renderer": "^1.1.1",
     "stylelint": "^13.9.0",
     "stylelint-config-standard": "^20.0.0",
-    "typescript": "^4.1.3"
+    "typescript": "^4.3.5"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,24 +2,24 @@
 # yarn lockfile v1
 
 
-"@algolia/autocomplete-core@1.0.0-alpha.44":
-  version "1.0.0-alpha.44"
-  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-core/-/autocomplete-core-1.0.0-alpha.44.tgz#e626dba45f5f3950d6beb0ab055395ef0f7e8bb2"
-  integrity sha512-2iMXthldMIDXtlbg9omRKLgg1bLo2ZzINAEqwhNjUeyj1ceEyL1ck6FY0VnJpf2LsjmNthHCz2BuFk+nYUeDNA==
+"@algolia/autocomplete-core@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-core/-/autocomplete-core-1.2.1.tgz#95fc07cfa40b5a38e3f80acd75d1fb94968215a8"
+  integrity sha512-/SLS6636Wpl7eFiX7eEy0E3wBo60sUm1qRYybJBDt1fs8reiJ1+OSy+dZgrLBfLL4mSFqRIIUHXbVp25QdZ+iw==
   dependencies:
-    "@algolia/autocomplete-shared" "1.0.0-alpha.44"
+    "@algolia/autocomplete-shared" "1.2.1"
 
-"@algolia/autocomplete-preset-algolia@1.0.0-alpha.44":
-  version "1.0.0-alpha.44"
-  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.0.0-alpha.44.tgz#0ea0b255d0be10fbe262e281472dd6e4619b62ba"
-  integrity sha512-DCHwo5ovzg9k2ejUolGNTLFnIA7GpsrkbNJTy1sFbMnYfBmeK8egZPZnEl7lBTr27OaZu7IkWpTepLVSztZyng==
+"@algolia/autocomplete-preset-algolia@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.2.1.tgz#bda1741823268ff76ba78306259036f000198e01"
+  integrity sha512-Lf4PpPVgHNXm1ytrnVdrZYV7hAYSCpAI/TrebF8UC6xflPY6sKb1RL/2OfrO9On7SDjPBtNd+6MArSar5JmK0g==
   dependencies:
-    "@algolia/autocomplete-shared" "1.0.0-alpha.44"
+    "@algolia/autocomplete-shared" "1.2.1"
 
-"@algolia/autocomplete-shared@1.0.0-alpha.44":
-  version "1.0.0-alpha.44"
-  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-shared/-/autocomplete-shared-1.0.0-alpha.44.tgz#db13902ad1667e455711b77d08cae1a0feafaa48"
-  integrity sha512-2oQZPERYV+yNx/yoVWYjZZdOqsitJ5dfxXJjL18yczOXH6ujnsq+DTczSrX+RjzjQdVeJ1UAG053EJQF/FOiMg==
+"@algolia/autocomplete-shared@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@algolia/autocomplete-shared/-/autocomplete-shared-1.2.1.tgz#96f869fb2285ed6a34a5ac2509722c065df93016"
+  integrity sha512-RHCwcXAYFwDXTlomstjWRFIzOfyxtQ9KmViacPE5P5hxUSSjkmG3dAb77xdydift1PaZNbho5TNTCi5UZe0RpA==
 
 "@algolia/cache-browser-local-storage@4.10.2":
   version "4.10.2"
@@ -1744,25 +1744,25 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
-"@docsearch/css@3.0.0-alpha.36":
-  version "3.0.0-alpha.36"
-  resolved "https://registry.yarnpkg.com/@docsearch/css/-/css-3.0.0-alpha.36.tgz#0af69a86b845974d0f8cab62db0218f66b6ad2d6"
-  integrity sha512-zSN2SXuZPDqQaSFzYa1kOwToukqzhLHG7c66iO+/PlmWb6/RZ5cjTkG6VCJynlohRWea7AqZKWS/ptm8kM2Dmg==
+"@docsearch/css@3.0.0-alpha.39":
+  version "3.0.0-alpha.39"
+  resolved "https://registry.yarnpkg.com/@docsearch/css/-/css-3.0.0-alpha.39.tgz#1ebd390d93e06aad830492f5ffdc8e05d058813f"
+  integrity sha512-lr10MFTgcR3NRea/FtJ7uNtIpQz0XVwYxbpO5wxykgfHu1sxZTr6zwkuPquRgFYXnccxsTvfoIiK3rMH0fLr/w==
 
-"@docsearch/react@^3.0.0-alpha.36":
-  version "3.0.0-alpha.36"
-  resolved "https://registry.yarnpkg.com/@docsearch/react/-/react-3.0.0-alpha.36.tgz#f2dbd53ba9c389bc19aea89a3ad21782fa6b4bb5"
-  integrity sha512-synYZDHalvMzesFiy7kK+uoz4oTdWSTbe2cU+iiUjwFMyQ+WWjWwGVnvcvk+cjj9pRCVaZo5y5WpqNXq1j8k9Q==
+"@docsearch/react@^3.0.0-alpha.39":
+  version "3.0.0-alpha.39"
+  resolved "https://registry.yarnpkg.com/@docsearch/react/-/react-3.0.0-alpha.39.tgz#bbd253f6fc591f63c1a171e7ef2da26b253164d9"
+  integrity sha512-urTIt82tan6CU+D2kO6xXpWQom/r1DA7L/55m2JiCIK/3SLh2z15FJFVN2abeK7B4wl8pCfWunYOwCsSHhWDLA==
   dependencies:
-    "@algolia/autocomplete-core" "1.0.0-alpha.44"
-    "@algolia/autocomplete-preset-algolia" "1.0.0-alpha.44"
-    "@docsearch/css" "3.0.0-alpha.36"
+    "@algolia/autocomplete-core" "1.2.1"
+    "@algolia/autocomplete-preset-algolia" "1.2.1"
+    "@docsearch/css" "3.0.0-alpha.39"
     algoliasearch "^4.0.0"
 
-"@docusaurus/core@2.0.0-beta.3", "@docusaurus/core@^2.0.0-beta.3":
-  version "2.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-2.0.0-beta.3.tgz#3af14897dcf5b73554314f6ed02c46cf0f463336"
-  integrity sha512-vzKmQsvOCte9odf0ZRU2h5UzdI1km5D0NU3Ee6xn06VydYZ169B1IF5KV1LWHSYklnsEmzizJ/jeopFCry0cGg==
+"@docusaurus/core@2.0.0-beta.4", "@docusaurus/core@^2.0.0-beta.4":
+  version "2.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-2.0.0-beta.4.tgz#b41c5064c8737405cfceb1a373c9c5aa3410fd95"
+  integrity sha512-ITa976MPFl9KbYchMOWCCX6SU6EFDSdGeGOHtpaNcrJ9e9Sj7o77fKmMH/ciShwz1g8brTm3VxZ0FwleU8lTig==
   dependencies:
     "@babel/core" "^7.12.16"
     "@babel/generator" "^7.12.15"
@@ -1774,12 +1774,12 @@
     "@babel/runtime" "^7.12.5"
     "@babel/runtime-corejs3" "^7.12.13"
     "@babel/traverse" "^7.12.13"
-    "@docusaurus/cssnano-preset" "2.0.0-beta.3"
+    "@docusaurus/cssnano-preset" "2.0.0-beta.4"
     "@docusaurus/react-loadable" "5.5.0"
-    "@docusaurus/types" "2.0.0-beta.3"
-    "@docusaurus/utils" "2.0.0-beta.3"
-    "@docusaurus/utils-common" "2.0.0-beta.3"
-    "@docusaurus/utils-validation" "2.0.0-beta.3"
+    "@docusaurus/types" "2.0.0-beta.4"
+    "@docusaurus/utils" "2.0.0-beta.4"
+    "@docusaurus/utils-common" "2.0.0-beta.4"
+    "@docusaurus/utils-validation" "2.0.0-beta.4"
     "@slorber/static-site-generator-webpack-plugin" "^4.0.0"
     "@svgr/webpack" "^5.5.0"
     autoprefixer "^10.2.5"
@@ -1843,26 +1843,27 @@
     webpack-merge "^5.8.0"
     webpackbar "^5.0.0-3"
 
-"@docusaurus/cssnano-preset@2.0.0-beta.3":
-  version "2.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.3.tgz#b82d58df4e95b04cd57a3e9922d39056207d2c73"
-  integrity sha512-k7EkNPluB+TV++oZB8Je4EQ6Xs6cR0SvgIU9vdXm00qyPCu38MMfRwSY4HnsVUV797T/fQUD91zkuwhyXCUGLA==
+"@docusaurus/cssnano-preset@2.0.0-beta.4":
+  version "2.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@docusaurus/cssnano-preset/-/cssnano-preset-2.0.0-beta.4.tgz#a40c0bee39143a531ca4dde05bb3a84bec416668"
+  integrity sha512-KsmFEob0ElffnFFbz93wcYH4IncU4LDnKBerdomU0Wdg/vXTLo3Q7no8df9yjbcBXVRaSX+/tNFapY9Iu/4Cew==
   dependencies:
     cssnano-preset-advanced "^5.1.1"
     postcss "^8.2.15"
     postcss-sort-media-queries "^3.10.11"
 
-"@docusaurus/mdx-loader@2.0.0-beta.3":
-  version "2.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.3.tgz#e1d9f3265889e4728412dab9f45d940bd87639fd"
-  integrity sha512-xH6zjNokZD2D7Y+Af3gMO692lwfw5N3NzxuLqMF3D0HPHOLrokDeIeVPeY/EBJBxZiXgqWGZ/ESewNDU1ZUfRQ==
+"@docusaurus/mdx-loader@2.0.0-beta.4":
+  version "2.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-beta.4.tgz#cc1a88d693078be56c82571d1d88004dad0f18f4"
+  integrity sha512-dwYKFKcsgiMB/TECoieKnwQemBAozd2a+cm4xzrWhDzElvwlQPo/j45OOUb6U/H8NJp7DnAynLBqSyKJ3YZb4g==
   dependencies:
     "@babel/parser" "^7.12.16"
     "@babel/traverse" "^7.12.13"
-    "@docusaurus/core" "2.0.0-beta.3"
-    "@docusaurus/utils" "2.0.0-beta.3"
+    "@docusaurus/core" "2.0.0-beta.4"
+    "@docusaurus/utils" "2.0.0-beta.4"
     "@mdx-js/mdx" "^1.6.21"
     "@mdx-js/react" "^1.6.21"
+    chalk "^4.1.1"
     escape-html "^1.0.3"
     file-loader "^6.2.0"
     fs-extra "^10.0.0"
@@ -1880,16 +1881,16 @@
   resolved "https://registry.yarnpkg.com/@docusaurus/module-type-aliases/-/module-type-aliases-2.0.0-beta.3.tgz#6381df7d164708f2865c420dc3ab6e03def9ed7d"
   integrity sha512-vciejziDBu39cyfmdvbpn865YlvugJMUOeD2m/7Kg4RLUPIZzQTWns0ZGIMc/iToiwebHwkoJtRsHaHzj8FpnA==
 
-"@docusaurus/plugin-content-blog@2.0.0-beta.3":
-  version "2.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.3.tgz#cb7ea4c61ee8717a76595b339932e7ee9fe9e091"
-  integrity sha512-QynxHVzS3jItnDbmu9wkASyMxrduauqONVqYHrL4x2pC4kzSTIrcDnOK1JXUJAuDg9XY66ISWQ8dN7YZOpU+4Q==
+"@docusaurus/plugin-content-blog@2.0.0-beta.4":
+  version "2.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-beta.4.tgz#dfa70cc364debd77e28683b733b254d6abec197c"
+  integrity sha512-NyLqoem/r/m8mNO3H1PbbPayA5KjgRTeB5T7j949uvGwlK34c+W6bSvr3OSRJdmFXqhFL4CG8E8wbSq7h+8WEA==
   dependencies:
-    "@docusaurus/core" "2.0.0-beta.3"
-    "@docusaurus/mdx-loader" "2.0.0-beta.3"
-    "@docusaurus/types" "2.0.0-beta.3"
-    "@docusaurus/utils" "2.0.0-beta.3"
-    "@docusaurus/utils-validation" "2.0.0-beta.3"
+    "@docusaurus/core" "2.0.0-beta.4"
+    "@docusaurus/mdx-loader" "2.0.0-beta.4"
+    "@docusaurus/types" "2.0.0-beta.4"
+    "@docusaurus/utils" "2.0.0-beta.4"
+    "@docusaurus/utils-validation" "2.0.0-beta.4"
     chalk "^4.1.1"
     escape-string-regexp "^4.0.0"
     feed "^4.2.2"
@@ -1902,16 +1903,16 @@
     tslib "^2.2.0"
     webpack "^5.40.0"
 
-"@docusaurus/plugin-content-docs@2.0.0-beta.3":
-  version "2.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.3.tgz#8c4f1780c1264fcb5937183ab8ce9792f88f253a"
-  integrity sha512-lB9UjDyFtq89tpyif+JDIJ/gtwtSTEwOBNTLAzOsg4ZIfNLfyifrWN4ci0TkZV0xShWUHqGp36/5XTpHRn1jJQ==
+"@docusaurus/plugin-content-docs@2.0.0-beta.4":
+  version "2.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-beta.4.tgz#6322bf44fd43ba2f1e79711d2651e1143c7b725a"
+  integrity sha512-aVYycpOvtgPQ78a10jakCtrI7DEAffw+zVdZT6tgO8QIn5hNPcr5NB7Ms3kSZw83fMZwJqStHHGp0y13zt/gLw==
   dependencies:
-    "@docusaurus/core" "2.0.0-beta.3"
-    "@docusaurus/mdx-loader" "2.0.0-beta.3"
-    "@docusaurus/types" "2.0.0-beta.3"
-    "@docusaurus/utils" "2.0.0-beta.3"
-    "@docusaurus/utils-validation" "2.0.0-beta.3"
+    "@docusaurus/core" "2.0.0-beta.4"
+    "@docusaurus/mdx-loader" "2.0.0-beta.4"
+    "@docusaurus/types" "2.0.0-beta.4"
+    "@docusaurus/utils" "2.0.0-beta.4"
+    "@docusaurus/utils-validation" "2.0.0-beta.4"
     chalk "^4.1.1"
     combine-promises "^1.1.0"
     escape-string-regexp "^4.0.0"
@@ -1928,78 +1929,76 @@
     utility-types "^3.10.0"
     webpack "^5.40.0"
 
-"@docusaurus/plugin-content-pages@2.0.0-beta.3":
-  version "2.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.3.tgz#f90d565563551556354b8dbf48ab5765c3b36fa2"
-  integrity sha512-lV6ZoSkkVwN10kQLE4sEAubaEnzXjKBQBhMCx49wkrvRwKzjBoRnfWV8qAswN1KU2YZZL1ixFpcr8+oXvhxkuA==
+"@docusaurus/plugin-content-pages@2.0.0-beta.4":
+  version "2.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-beta.4.tgz#47bdaa8d8711502f6ba75ba036ebd64a3991034e"
+  integrity sha512-VZ/iuxT1kgBh/1+W3Li88UZVjqHtHOt4TyFoVwHmf2p91BPHiF7zpiLb4hYL8s694/V+AdfWf4ostSyEoeMx8A==
   dependencies:
-    "@docusaurus/core" "2.0.0-beta.3"
-    "@docusaurus/mdx-loader" "2.0.0-beta.3"
-    "@docusaurus/types" "2.0.0-beta.3"
-    "@docusaurus/utils" "2.0.0-beta.3"
-    "@docusaurus/utils-validation" "2.0.0-beta.3"
+    "@docusaurus/core" "2.0.0-beta.4"
+    "@docusaurus/mdx-loader" "2.0.0-beta.4"
+    "@docusaurus/types" "2.0.0-beta.4"
+    "@docusaurus/utils" "2.0.0-beta.4"
+    "@docusaurus/utils-validation" "2.0.0-beta.4"
     globby "^11.0.2"
     lodash "^4.17.20"
-    minimatch "^3.0.4"
     remark-admonitions "^1.2.1"
-    slash "^3.0.0"
     tslib "^2.1.0"
     webpack "^5.40.0"
 
-"@docusaurus/plugin-debug@2.0.0-beta.3":
-  version "2.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.3.tgz#2278cb537cb6acf153977733c19c704a32e15b28"
-  integrity sha512-EeHUcCPsr9S1tsyRo42SnhrCCOlcvkcA8CR4pOofiJkG1gJ8IwhY9fNOLJM7dYs0bMtViiqXy5fD2jUib4G1jw==
+"@docusaurus/plugin-debug@2.0.0-beta.4":
+  version "2.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-debug/-/plugin-debug-2.0.0-beta.4.tgz#7a69fee980a352cd338dba24d8e0d67f6f64ef0b"
+  integrity sha512-jc9o45NUuhVnFcoq6/6juxJQGgD2Q71IUokoOgw3sytHHOv1jv+eLWP1LDX71MHA1ElZ1MZTlz5mCd1wlzdCOw==
   dependencies:
-    "@docusaurus/core" "2.0.0-beta.3"
-    "@docusaurus/types" "2.0.0-beta.3"
-    "@docusaurus/utils" "2.0.0-beta.3"
+    "@docusaurus/core" "2.0.0-beta.4"
+    "@docusaurus/types" "2.0.0-beta.4"
+    "@docusaurus/utils" "2.0.0-beta.4"
     react-json-view "^1.21.3"
     tslib "^2.1.0"
 
-"@docusaurus/plugin-google-analytics@2.0.0-beta.3":
-  version "2.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.3.tgz#aff4a625b183c2c5bcb63ce61542592e98075f55"
-  integrity sha512-e6tO1FCIdAqIjcLAUaHugz/dErAP/wx67WyN6bWSdAMJRobmav+TFesE2iVzzIMxuRB3pY0Y7TtLL5dF5xpIsg==
+"@docusaurus/plugin-google-analytics@2.0.0-beta.4":
+  version "2.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-beta.4.tgz#88d17bd1a2b5da35fe625fae43d32430595c087e"
+  integrity sha512-mqMEnfMKIoR1UfIX+jiAcUolwYntqSNaW8Gg2tg8dlGvC3payT1gpNJaew6TWyrtE29vuZz6a830bIXBYm4uAA==
   dependencies:
-    "@docusaurus/core" "2.0.0-beta.3"
+    "@docusaurus/core" "2.0.0-beta.4"
 
-"@docusaurus/plugin-google-gtag@2.0.0-beta.3":
-  version "2.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.3.tgz#e52105a749e33e6ea44e7103f42df0fcac0268ac"
-  integrity sha512-p48CK7ZwThs9wc/UEv+zG3lZ/Eh4Rwg2c0MBBLYATGE+Wwh6HIyilhjQAj4dC6wf9iYvCZFXX2pNOr+cKKafIA==
+"@docusaurus/plugin-google-gtag@2.0.0-beta.4":
+  version "2.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-beta.4.tgz#52f5922857680dfb2acc2099f08ac97d3edcb725"
+  integrity sha512-MZ0Rr6LBZLKMVFXxV7Kr+l0U3Yz/Yn8L2E5z9DbgVi+9tyLn4xlMzuMPG3gN9TZ8kPcQ1ZWwv9crA+138UzIkw==
   dependencies:
-    "@docusaurus/core" "2.0.0-beta.3"
+    "@docusaurus/core" "2.0.0-beta.4"
 
-"@docusaurus/plugin-sitemap@2.0.0-beta.3":
-  version "2.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.3.tgz#61e0b52db51cc11dd59662041ffd32ef3f4ec5f1"
-  integrity sha512-ilEJ3Xb8zbShjGhdRHGAm4OZ0bUwFxtMtcTyqLlGmk9r0U2h0CWcaS+geJfLwgUJkwgKZfGdDrmTpmf8oeGQvw==
+"@docusaurus/plugin-sitemap@2.0.0-beta.4":
+  version "2.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-beta.4.tgz#60b189107af772ef2bbc94b83055eff8a3013da3"
+  integrity sha512-0sU1aMQmMN7fE3TlSM2wBZN/gFsuvo79DYxw8TIVtNakA84oDxurH/rhDQHwJ34JQufm5CuWNC1ICHtyI3qyWw==
   dependencies:
-    "@docusaurus/core" "2.0.0-beta.3"
-    "@docusaurus/types" "2.0.0-beta.3"
-    "@docusaurus/utils" "2.0.0-beta.3"
-    "@docusaurus/utils-common" "2.0.0-beta.3"
-    "@docusaurus/utils-validation" "2.0.0-beta.3"
+    "@docusaurus/core" "2.0.0-beta.4"
+    "@docusaurus/types" "2.0.0-beta.4"
+    "@docusaurus/utils" "2.0.0-beta.4"
+    "@docusaurus/utils-common" "2.0.0-beta.4"
+    "@docusaurus/utils-validation" "2.0.0-beta.4"
     fs-extra "^10.0.0"
     sitemap "^7.0.0"
     tslib "^2.2.0"
 
-"@docusaurus/preset-classic@^2.0.0-beta.3":
-  version "2.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.3.tgz#44fe60bb73e671cce56a028c8731d97631fe57b2"
-  integrity sha512-32B/7X3H8XX5jBqg23veEqNJ0JtKCG0Va+7wTX9+B36tMyPnsq3H3m0m5XICfX/NGfPICfjw/oCN2CEAYFd47Q==
+"@docusaurus/preset-classic@^2.0.0-beta.4":
+  version "2.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-2.0.0-beta.4.tgz#7f57be3368ed645ab634928d8564fe29b45136cd"
+  integrity sha512-fW8/iyGLJfBTtbCBQtnRcbDa+ZZMq6Ak20+8+ORB8mzjK4BNYmt9wIbfq0oV9/QBLyryQBYcsRimJoXpLZmWOg==
   dependencies:
-    "@docusaurus/core" "2.0.0-beta.3"
-    "@docusaurus/plugin-content-blog" "2.0.0-beta.3"
-    "@docusaurus/plugin-content-docs" "2.0.0-beta.3"
-    "@docusaurus/plugin-content-pages" "2.0.0-beta.3"
-    "@docusaurus/plugin-debug" "2.0.0-beta.3"
-    "@docusaurus/plugin-google-analytics" "2.0.0-beta.3"
-    "@docusaurus/plugin-google-gtag" "2.0.0-beta.3"
-    "@docusaurus/plugin-sitemap" "2.0.0-beta.3"
-    "@docusaurus/theme-classic" "2.0.0-beta.3"
-    "@docusaurus/theme-search-algolia" "2.0.0-beta.3"
+    "@docusaurus/core" "2.0.0-beta.4"
+    "@docusaurus/plugin-content-blog" "2.0.0-beta.4"
+    "@docusaurus/plugin-content-docs" "2.0.0-beta.4"
+    "@docusaurus/plugin-content-pages" "2.0.0-beta.4"
+    "@docusaurus/plugin-debug" "2.0.0-beta.4"
+    "@docusaurus/plugin-google-analytics" "2.0.0-beta.4"
+    "@docusaurus/plugin-google-gtag" "2.0.0-beta.4"
+    "@docusaurus/plugin-sitemap" "2.0.0-beta.4"
+    "@docusaurus/theme-classic" "2.0.0-beta.4"
+    "@docusaurus/theme-search-algolia" "2.0.0-beta.4"
 
 "@docusaurus/react-loadable@5.5.0":
   version "5.5.0"
@@ -2008,20 +2007,20 @@
   dependencies:
     prop-types "^15.6.2"
 
-"@docusaurus/theme-classic@2.0.0-beta.3", "@docusaurus/theme-classic@^2.0.0-beta.3":
-  version "2.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.3.tgz#a84241ad6dc22aec9a33136e9d592034aea4d865"
-  integrity sha512-d2I4r9FQ67hCTGq+fkz0tDNvpCLxm/HAtjuu+XsZkX6Snh50XpWYfwOD4w8oFbbup5Imli2q7Z8Q2+9izphizw==
+"@docusaurus/theme-classic@2.0.0-beta.4", "@docusaurus/theme-classic@^2.0.0-beta.4":
+  version "2.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-classic/-/theme-classic-2.0.0-beta.4.tgz#0f30f8d22770ab8bb2e2cacb006f2a2f675e16ce"
+  integrity sha512-gekEt/YuAEs7CLEJhBC5mE3AqXiDNL6U3WI9emokatpbPY7B12DLJ11QWJZ4mfKYWHuiTwPeybXkOySWMLuaaA==
   dependencies:
-    "@docusaurus/core" "2.0.0-beta.3"
-    "@docusaurus/plugin-content-blog" "2.0.0-beta.3"
-    "@docusaurus/plugin-content-docs" "2.0.0-beta.3"
-    "@docusaurus/plugin-content-pages" "2.0.0-beta.3"
-    "@docusaurus/theme-common" "2.0.0-beta.3"
-    "@docusaurus/types" "2.0.0-beta.3"
-    "@docusaurus/utils" "2.0.0-beta.3"
-    "@docusaurus/utils-common" "2.0.0-beta.3"
-    "@docusaurus/utils-validation" "2.0.0-beta.3"
+    "@docusaurus/core" "2.0.0-beta.4"
+    "@docusaurus/plugin-content-blog" "2.0.0-beta.4"
+    "@docusaurus/plugin-content-docs" "2.0.0-beta.4"
+    "@docusaurus/plugin-content-pages" "2.0.0-beta.4"
+    "@docusaurus/theme-common" "2.0.0-beta.4"
+    "@docusaurus/types" "2.0.0-beta.4"
+    "@docusaurus/utils" "2.0.0-beta.4"
+    "@docusaurus/utils-common" "2.0.0-beta.4"
+    "@docusaurus/utils-validation" "2.0.0-beta.4"
     "@mdx-js/mdx" "^1.6.21"
     "@mdx-js/react" "^1.6.21"
     chalk "^4.1.1"
@@ -2029,7 +2028,7 @@
     copy-text-to-clipboard "^3.0.1"
     fs-extra "^10.0.0"
     globby "^11.0.2"
-    infima "0.2.0-alpha.26"
+    infima "0.2.0-alpha.29"
     lodash "^4.17.20"
     parse-numeric-range "^1.2.0"
     postcss "^8.2.15"
@@ -2039,38 +2038,40 @@
     react-router-dom "^5.2.0"
     rtlcss "^3.1.2"
 
-"@docusaurus/theme-common@2.0.0-beta.3":
-  version "2.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-common/-/theme-common-2.0.0-beta.3.tgz#8dbe05f3436637b099aeada5c75a6f7c9bc163a5"
-  integrity sha512-XuiqpfQyOWGniN7d8uMfUQ3OmCc70u+O0ObPUONj7gFglCzwu33Izx05gNrV9ekhnpQ1pkPcvGU7Soe9Hc5i6g==
+"@docusaurus/theme-common@2.0.0-beta.4":
+  version "2.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-common/-/theme-common-2.0.0-beta.4.tgz#a60527fd436691621b10aeecfac09bf0feece019"
+  integrity sha512-RJ78rfb/K2dc/u/WDCZB8Q8mj19l7UtDx3F1yFC4WMwAd5tT8V5xlKc5UpHVJrKdc1c3Z4g+ki0wFm+LpCZj0w==
   dependencies:
-    "@docusaurus/core" "2.0.0-beta.3"
-    "@docusaurus/plugin-content-blog" "2.0.0-beta.3"
-    "@docusaurus/plugin-content-docs" "2.0.0-beta.3"
-    "@docusaurus/plugin-content-pages" "2.0.0-beta.3"
-    "@docusaurus/types" "2.0.0-beta.3"
+    "@docusaurus/core" "2.0.0-beta.4"
+    "@docusaurus/plugin-content-blog" "2.0.0-beta.4"
+    "@docusaurus/plugin-content-docs" "2.0.0-beta.4"
+    "@docusaurus/plugin-content-pages" "2.0.0-beta.4"
+    "@docusaurus/types" "2.0.0-beta.4"
+    clsx "^1.1.1"
+    fs-extra "^10.0.0"
     tslib "^2.1.0"
 
-"@docusaurus/theme-search-algolia@2.0.0-beta.3":
-  version "2.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.3.tgz#9ca8142fe4686d262d546c9ba309d02d9d4d59a9"
-  integrity sha512-fxWxcXGmqjwuA7zYRAbwqSANx3PVVjYUehV9SI28u5qq8U2tSYflhd1nGogM6guiV+Er6u8gwO91PL6wg3/vBA==
+"@docusaurus/theme-search-algolia@2.0.0-beta.4":
+  version "2.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.4.tgz#0c2051523428c4486ef1dd7cb5271b0d871f5c8e"
+  integrity sha512-W/DfGhlAe1Vl+IJiL9rCw8yswdUrX0lTyCMNRAFi749YN4vCWo2RoxylbUuWoV6lUKoIYfj3EGyotRT2OLqtZw==
   dependencies:
-    "@docsearch/react" "^3.0.0-alpha.36"
-    "@docusaurus/core" "2.0.0-beta.3"
-    "@docusaurus/theme-common" "2.0.0-beta.3"
-    "@docusaurus/utils" "2.0.0-beta.3"
-    "@docusaurus/utils-validation" "2.0.0-beta.3"
+    "@docsearch/react" "^3.0.0-alpha.39"
+    "@docusaurus/core" "2.0.0-beta.4"
+    "@docusaurus/theme-common" "2.0.0-beta.4"
+    "@docusaurus/utils" "2.0.0-beta.4"
+    "@docusaurus/utils-validation" "2.0.0-beta.4"
     algoliasearch "^4.8.4"
     algoliasearch-helper "^3.3.4"
     clsx "^1.1.1"
     eta "^1.12.1"
     lodash "^4.17.20"
 
-"@docusaurus/types@2.0.0-beta.3":
-  version "2.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-2.0.0-beta.3.tgz#042838d3a1ce0aa6f0df1b87180da0d503268d9b"
-  integrity sha512-ivQ6L1ahju06ldTvFsZLQxcN6DP32iIB7DscxWVRqP0eyuyX2xAy+jrASqih3lB8lyw0JJaaDEeVE5fjroAQ/Q==
+"@docusaurus/types@2.0.0-beta.4":
+  version "2.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-2.0.0-beta.4.tgz#9eef0a88b008ebd65bb9870b7ff0050de0e620c4"
+  integrity sha512-2aMCliUCBYhZO8UiiPIKpRu2KECtqt0nRu44EbN6rj1STf695AIOhJC1Zo5TiuW2WbiljSbkJTgG3XdBZ3FUBw==
   dependencies:
     commander "^5.1.0"
     joi "^17.4.0"
@@ -2078,36 +2079,38 @@
     webpack "^5.40.0"
     webpack-merge "^5.8.0"
 
-"@docusaurus/utils-common@2.0.0-beta.3":
-  version "2.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@docusaurus/utils-common/-/utils-common-2.0.0-beta.3.tgz#85fc7f7572d0f55e62b8f0baeb91967bf7d699e0"
-  integrity sha512-KJgDN4G2MzJcHy+OR2e/xgEwRy+vX26pzwtjPkRjNf24CPa0BwFbRmR5apbltCgTB10vT6xroStc8Quv/286Cg==
+"@docusaurus/utils-common@2.0.0-beta.4":
+  version "2.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils-common/-/utils-common-2.0.0-beta.4.tgz#eb2e5876f5f79d037fa7e1867177658661b9c1c2"
+  integrity sha512-QaKs96/95ztKgZqHMUS/vNl+GzZ/6vKVEPjBXWt7Fdhg2soT1Iu4cShnibEO5HaVlwSfnJbVmDLVm8phQRdr0A==
   dependencies:
-    "@docusaurus/types" "2.0.0-beta.3"
+    "@docusaurus/types" "2.0.0-beta.4"
     tslib "^2.2.0"
 
-"@docusaurus/utils-validation@2.0.0-beta.3":
-  version "2.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.3.tgz#24e8187ff853dfec111faaef75af432274bd8773"
-  integrity sha512-jGX78NNrxDZFgDjLaa6wuJ/eKDoHdZFG2CVX3uCaIGe1x8eTMG2/e/39GzbZl+W7VHYpW0bzdf/5dFhaKLfQbQ==
+"@docusaurus/utils-validation@2.0.0-beta.4":
+  version "2.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils-validation/-/utils-validation-2.0.0-beta.4.tgz#417ff389d61aab4c6544f169e31bb86573b518df"
+  integrity sha512-t1sxSeyVU02NkcFhPvE7eQFA0CFUst68hTnie6ZS3ToY3nlzdbYRPOAZY5MPr3zRMwum6yFAXgqVA+5fnR0OGg==
   dependencies:
-    "@docusaurus/utils" "2.0.0-beta.3"
+    "@docusaurus/utils" "2.0.0-beta.4"
     chalk "^4.1.1"
     joi "^17.4.0"
     tslib "^2.1.0"
 
-"@docusaurus/utils@2.0.0-beta.3":
-  version "2.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@docusaurus/utils/-/utils-2.0.0-beta.3.tgz#81bdf02c5128f3d307d56925cbc398dbf3600e50"
-  integrity sha512-DApc6xcb3CvvsBCfRU6Zk3KoZa4mZfCJA4XRv5zhlhaSb0GFuAo7KQ353RUu6d0eYYylY3GGRABXkxRE1SEClA==
+"@docusaurus/utils@2.0.0-beta.4":
+  version "2.0.0-beta.4"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils/-/utils-2.0.0-beta.4.tgz#6e572371b0a59360b49102d014579f5364f1d8da"
+  integrity sha512-6nI3ETBp0ZSt5yp5Fc5nthQjR1MmLgl2rXC3hcscrSUZx0QvzJFzTiRgD9EAIJtR/i2JkUK18eaFiBjMBoXEbQ==
   dependencies:
-    "@docusaurus/types" "2.0.0-beta.3"
+    "@docusaurus/types" "2.0.0-beta.4"
     "@types/github-slugger" "^1.3.0"
     chalk "^4.1.1"
     escape-string-regexp "^4.0.0"
     fs-extra "^10.0.0"
+    globby "^11.0.4"
     gray-matter "^4.0.3"
     lodash "^4.17.20"
+    micromatch "^4.0.4"
     resolve-pathname "^3.0.0"
     tslib "^2.2.0"
 
@@ -4652,10 +4655,10 @@
     "@typescript-eslint/types" "4.28.1"
     eslint-visitor-keys "^2.0.0"
 
-"@typescript/twoslash@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@typescript/twoslash/-/twoslash-2.1.0.tgz#0128312e002670367393bb9b48378ac818aceccd"
-  integrity sha512-J72HH+zAMPA9udOuOgAxTXnzeRyz0t33Ww1jQ6CgNfjP3HtrOS4lNgG+m3u1H497U366zbcUOjNkIgNGqefd/A==
+"@typescript/twoslash@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@typescript/twoslash/-/twoslash-2.2.0.tgz#176317e6bfeae2ebb8a5dd37dbf735096c4462e4"
+  integrity sha512-Lkgrs9L/OIn1JZcIv2k4uy/CsQ+9dmurN64YzSWIHleTE3PkZlV2lZdq9xM7TnLh5zFy3tP8KuPtUxbIGV9sIw==
   dependencies:
     "@typescript/vfs" "1.3.4"
     debug "^4.1.1"
@@ -8517,13 +8520,13 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-docusaurus-preset-shiki-twoslash@^1.1.16:
-  version "1.1.16"
-  resolved "https://registry.yarnpkg.com/docusaurus-preset-shiki-twoslash/-/docusaurus-preset-shiki-twoslash-1.1.16.tgz#6811d18b91508ace49a921398636d3057fa7a2b1"
-  integrity sha512-tvwCOw6Xnvu9Id8AsWIASm5Asbqa9yExeo8v6Zt7tbbVxwiEnuWkuN9bjMBnNQecUZPJYWMaq7m2jzLk6u7irA==
+docusaurus-preset-shiki-twoslash@^1.1.27:
+  version "1.1.27"
+  resolved "https://registry.yarnpkg.com/docusaurus-preset-shiki-twoslash/-/docusaurus-preset-shiki-twoslash-1.1.27.tgz#bfa40ba7d3a0d73d9d560a551405ca4b30e465f4"
+  integrity sha512-o8Zpd/NunFlOKLR+OVtooMP9I4V4447VWV42DDbKWQc7KP+wU6giPc/mniNzXG+Lm8A/EKawnR3yi5mDWiD8Rw==
   dependencies:
     copy-text-to-clipboard "^3.0.1"
-    remark-shiki-twoslash "2.0.1"
+    remark-shiki-twoslash "3.0.0"
     typescript ">3"
 
 dom-accessibility-api@^0.5.6:
@@ -10602,7 +10605,7 @@ globby@8.0.2:
     pify "^3.0.0"
     slash "^1.0.0"
 
-globby@^11.0.1, globby@^11.0.2, globby@^11.0.3:
+globby@^11.0.1, globby@^11.0.2, globby@^11.0.3, globby@^11.0.4:
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
   integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
@@ -11464,10 +11467,10 @@ infer-owner@^1.0.3, infer-owner@^1.0.4:
   resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
   integrity sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==
 
-infima@0.2.0-alpha.26:
-  version "0.2.0-alpha.26"
-  resolved "https://registry.yarnpkg.com/infima/-/infima-0.2.0-alpha.26.tgz#8582d40ef01a09dbbde8f0e574f8c61d6bc0992b"
-  integrity sha512-0/Dt+89mf8xW+9/hKGmynK+WOAsiy0QydVJL0qie6WK57yGIQv+SjJrhMybKndnmkZBQ+Vlt0tWPnTakx8X2Qw==
+infima@0.2.0-alpha.29:
+  version "0.2.0-alpha.29"
+  resolved "https://registry.yarnpkg.com/infima/-/infima-0.2.0-alpha.29.tgz#4ccf27c4c696e9a0884b333ad9ced5f65b7ae5f3"
+  integrity sha512-b6XX4QJekAYBPz2Y0XcXrDRaX/+96V95/WKWedY4zAWZ6xlzdxCrnyUgNaC4575aHcA2bfarLlTsP8FHFhjZFQ==
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -18503,17 +18506,17 @@ remark-parse@^9.0.0:
   dependencies:
     mdast-util-from-markdown "^0.8.0"
 
-remark-shiki-twoslash@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/remark-shiki-twoslash/-/remark-shiki-twoslash-2.0.1.tgz#f47a304f044e0d78fdb09505442397fa7104509e"
-  integrity sha512-Xj2pMArldasY6WvqjaVR/G7HJnqIGYGIQlpNCpeq2kGTaABU80nJ5lF7AiELUGbg1f5aK4tosE24zo2ChWi9Zg==
+remark-shiki-twoslash@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/remark-shiki-twoslash/-/remark-shiki-twoslash-3.0.0.tgz#429a3780c3d410d9aa3166182bdebac67299180e"
+  integrity sha512-d7Q5QgYX08CynmCdntqp7uvwf3d2GolW2F1I72bmZZr7tZALW1fQzSjjm3VZoV/ALv8YL5CBKsGTMwtm3F+4Iw==
   dependencies:
-    "@typescript/twoslash" "2.1.0"
+    "@typescript/twoslash" "2.2.0"
     "@typescript/vfs" "1.3.4"
     fenceparser "^1.1.0"
     regenerator-runtime "^0.13.7"
     shiki "0.9.3"
-    shiki-twoslash "2.0.3"
+    shiki-twoslash "3.0.0"
     tslib "2.1.0"
     typescript ">3"
     unist-util-visit "^2.0.0"
@@ -19327,12 +19330,12 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shiki-twoslash@2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/shiki-twoslash/-/shiki-twoslash-2.0.3.tgz#b3f212560f63c3a73c2622feb4d92748a91cdd2d"
-  integrity sha512-tUeoek4e0pShUp0AnkfLXl4DCnvcC3iI1pDspPfdWKaBYY8hPW7J4iWxf9VXkdCA7wxwmT1bsiZ6e9h9Tndehg==
+shiki-twoslash@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shiki-twoslash/-/shiki-twoslash-3.0.0.tgz#13b172b0e94700c3a593b6471f6abab300e90bea"
+  integrity sha512-mI8DeMNofS5Lg1p/2JolteHkQ3Y5EL57u/NdNHnxaVGJmIK+gnhc2yAvtmf62TYLOXHkvfepzrgg77a/yZBewQ==
   dependencies:
-    "@typescript/twoslash" "2.1.0"
+    "@typescript/twoslash" "2.2.0"
     "@typescript/vfs" "1.3.4"
     shiki "0.9.3"
     typescript ">3"
@@ -21002,7 +21005,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@>3, typescript@^4.0.3, typescript@^4.1.3:
+typescript@>3, typescript@^4.0.3, typescript@^4.1.3, typescript@^4.3.5:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
   integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==


### PR DESCRIPTION
Finally found some time to work on this cool feature.

This introduces a little breaking change (which is not, because under the hood adapts the configuration to match the newest one if users are using the old one)

Basically now @rematch/loading plugin accepts a `type` property (By default is type: boolean)

This property accepts: `'number'`, `'boolean'`, `'full'`

### { type: "full" }

Basically returns `{ success: false, loading: true, error: false }`, if the effect promise returns an error the error response is added to error.

Works fine with Typescript as far as I could check.

# Pending

- [x] Decide if 'detailed' is a good name
- [x] Documentation
- [x] More testing
- [x] Reduce bundle size a bit (there're some optimisations) 

Will resolve #877 