### PR TITLE
docs: replaced bullet points in api docs with table

### DIFF
--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -20,13 +20,12 @@ The function called to setup Rematch.
 
 Init accepts one argument - **config**, which is an object with the following properties:
 
-- [`name`] (_string_): a name for your store. It might be useful when creating multiple stores. Default value is: _"Rematch Store {counter}"_.
-
-- [`models`] (_Object_): each model describes its part of the state, reducers and effects. This parameter is a mapping from models' names to their configuration. See [Model API](models) for details.
-
-- [`plugins`] (_Array_): plugins are special sets of configuration that can extend the functionality of your store. You can pass an array of plugins that you want to use in your store. See the [plugins](/docs/plugins/) developed by the Rematch team or the [API for creating plugins](plugins).
-
-- [`redux`] (_Object_): there are situations where you might want to access Redux configuration directly, e.g. to migrate existing redux project or add middlewares. See [Redux API](redux) for details.
+| Property Name | Data Type |                                                                                                                                 Description                                                                                                                                 |
+| :-----------: | :-------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+|    `name`     | _string_  |                                                                           a name for your store. It might be useful when creating multiple stores. Default value is: _"Rematch Store {counter}"_.                                                                           |
+|   `models`    | _Object_  |                                                ach model describes its part of the state, reducers and effects. This parameter is a mapping from models' names to their configuration. See [Model API](models) for details.                                                 |
+|   `plugins`   |  _Array_  | plugins are special sets of configuration that can extend the functionality of your store. You can pass an array of plugins that you want to use in your store. See the [plugins](/docs/plugins/) developed by the Rematch team or the [API for creating plugins](plugins). |
+|    `redux`    | _Object_  |                                              there are situations where you might want to access Redux configuration directly, e.g. to migrate existing redux project or add middlewares. See [Redux API](redux) for details.                                               |
 
 **Returns**:
 

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -20,12 +20,12 @@ The function called to setup Rematch.
 
 Init accepts one argument - **config**, which is an object with the following properties:
 
-| Property Name | Data Type |                                                                                                                                 Description                                                                                                                                 |
-| :-----------: | :-------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
-|    `name`     | _string_  |                                                                           a name for your store. It might be useful when creating multiple stores. Default value is: _"Rematch Store {counter}"_.                                                                           |
-|   `models`    | _Object_  |                                                ach model describes its part of the state, reducers and effects. This parameter is a mapping from models' names to their configuration. See [Model API](models) for details.                                                 |
-|   `plugins`   |  _Array_  | plugins are special sets of configuration that can extend the functionality of your store. You can pass an array of plugins that you want to use in your store. See the [plugins](/docs/plugins/) developed by the Rematch team or the [API for creating plugins](plugins). |
-|    `redux`    | _Object_  |                                              there are situations where you might want to access Redux configuration directly, e.g. to migrate existing redux project or add middlewares. See [Redux API](redux) for details.                                               |
+| Property Name | Data Type |                                                                                                                                 Description                                                                                                                                  |
+| :-----------: | :-------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+|    `name`     | _string_  |                                                                           A name for your store. It might be useful when creating multiple stores. Default value is: _"Rematch Store {counter}"_.                                                                            |
+|   `models`    | _Object_  |                                                Each model describes its part of the state, reducers and effects. This parameter is a mapping from models' names to their configuration. See [Model API](models) for details.                                                 |
+|   `plugins`   |  _Array_  | Plugins are special sets of configurations that can extend the functionality of your store. You can pass an array of plugins that you want to use in your store. See the [plugins](/docs/plugins/) developed by the Rematch team or the [API for creating plugins](plugins). |
+|    `redux`    | _Object_  |                                               There are situations where you might want to access Redux configuration directly, e.g. to migrate existing redux project or add middlewares. See [Redux API](redux) for details.                                               |
 
 **Returns**:
 


### PR DESCRIPTION
Swaped bullet points in api documentation with tables @semoal 

<img width="1031" alt="Apidocstable" src="https://user-images.githubusercontent.com/53011850/132044110-e7f3e89f-46ed-4e2a-896e-69b708ea7c44.png">
