### PR TITLE
fix: immer behaves unexpectedly when model state is a nullable primitive value

### DIFF
--- a/packages/immer/src/index.ts
+++ b/packages/immer/src/index.ts
@@ -10,13 +10,9 @@ export type ImmerPluginConfig = {
 function wrapReducerWithImmer(reducer: Redux.Reducer) {
 	// reducer must return value because literal don't support immer
 	return (state: any, payload: any): any =>
-		typeof state === 'object'
-			? produce(state, (draft: any) => {
-					const next = reducer(draft, payload)
-					if (typeof next === 'object') return next
-					return undefined
-			  })
-			: reducer(state, payload)
+		produce(state, (draft: any) => {
+			return reducer(draft, payload)
+		})
 }
 
 const immerPlugin = <

--- a/packages/immer/src/index.ts
+++ b/packages/immer/src/index.ts
@@ -8,7 +8,6 @@ export type ImmerPluginConfig = {
 }
 
 function wrapReducerWithImmer(reducer: Redux.Reducer) {
-	// reducer must return value because literal don't support immer
 	return (state: any, payload: any): any =>
 		produce(state, (draft: any) => {
 			return reducer(draft, payload)

--- a/packages/immer/test/immer.test.ts
+++ b/packages/immer/test/immer.test.ts
@@ -25,6 +25,28 @@ describe('immer', () => {
 		})
 	})
 
+	test('should load the immer plugin with a nullable basic literal', () => {
+		const model = {
+			state: null as number | null,
+			reducers: {
+				set(_state: number, payload: number): number {
+					return payload
+				},
+			},
+		}
+
+		const store = init({
+			plugins: [immerPlugin()],
+			models: { model },
+		})
+
+		store.dispatch({ type: 'model/set', payload: 1 })
+
+		expect(store.getState()).toEqual({
+			model: 1,
+		})
+	})
+
 	test('should load the immer plugin with a object condition', () => {
 		const todo = {
 			state: [


### PR DESCRIPTION
By the way, why we treat primitive different from object value? I think the default behavior is ok.