### PR TITLE
fix: circular reference destructuring works with all models

### DIFF
--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -49,7 +49,7 @@ const createActionDispatcher = <
  * Creates a dispatcher object for a model - it contains a mapping from all
  * reducers to functions which dispatch their corresponding actions.
  */
-export const createDispatcher = <
+export const createReducerDispatcher = <
 	TModels extends Models<TModels>,
 	TExtraModels extends Models<TModels>,
 	TModel extends NamedModel<TModels>
@@ -57,7 +57,7 @@ export const createDispatcher = <
 	rematch: RematchStore<TModels, TExtraModels>,
 	model: TModel
 ): void => {
-	const modelDispatcher = rematch.dispatch[model.name] || {}
+	const modelDispatcher = rematch.dispatch[model.name]
 
 	// map reducer names to dispatch actions
 	const modelReducersKeys = Object.keys(model.reducers)

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -47,19 +47,17 @@ const createActionDispatcher = <
 
 /**
  * Creates a dispatcher object for a model - it contains a mapping from all
- * reducers and effects *names* to functions which dispatch their corresponding
- * actions.
+ * reducers to functions which dispatch their corresponding actions.
  */
-const createDispatcher = <
+export const createDispatcher = <
 	TModels extends Models<TModels>,
 	TExtraModels extends Models<TModels>,
 	TModel extends NamedModel<TModels>
 >(
 	rematch: RematchStore<TModels, TExtraModels>,
-	bag: RematchBag<TModels, TExtraModels>,
 	model: TModel
 ): void => {
-	const modelDispatcher = rematch.dispatch[model.name]
+	const modelDispatcher = rematch.dispatch[model.name] || {}
 
 	// map reducer names to dispatch actions
 	const modelReducersKeys = Object.keys(model.reducers)
@@ -73,7 +71,22 @@ const createDispatcher = <
 			false
 		)
 	})
+}
 
+/**
+ * Creates effects dispatcher for a model - it contains a mapping from all
+ * effects *names* to functions which dispatch their corresponding actions.
+ */
+export const createEffectDispatcher = <
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>,
+	TModel extends NamedModel<TModels>
+>(
+	rematch: RematchStore<TModels, TExtraModels>,
+	bag: RematchBag<TModels, TExtraModels>,
+	model: TModel
+): void => {
+	const modelDispatcher = rematch.dispatch[model.name]
 	let effects: ModelEffects<TModels> = {}
 
 	// 'effects' might be actually a function creating effects
@@ -100,5 +113,3 @@ const createDispatcher = <
 		)
 	})
 }
-
-export default createDispatcher

--- a/packages/core/src/rematchStore.ts
+++ b/packages/core/src/rematchStore.ts
@@ -16,7 +16,7 @@ import createReduxStore, {
 	createModelReducer,
 	createRootReducer,
 } from './reduxStore'
-import { createDispatcher, createEffectDispatcher } from './dispatcher'
+import { createReducerDispatcher, createEffectDispatcher } from './dispatcher'
 import { validateModel } from './validate'
 import createRematchBag from './bag'
 
@@ -103,7 +103,7 @@ function prepareModel<
 	rematchStore.dispatch[`${model.name}` as keyof RematchDispatch<TModels>] =
 		modelDispatcher
 
-	createDispatcher(rematchStore, model)
+	createReducerDispatcher(rematchStore, model)
 }
 
 function enhanceModel<

--- a/packages/core/src/rematchStore.ts
+++ b/packages/core/src/rematchStore.ts
@@ -16,7 +16,7 @@ import createReduxStore, {
 	createModelReducer,
 	createRootReducer,
 } from './reduxStore'
-import createDispatcher from './dispatcher'
+import { createDispatcher, createEffectDispatcher } from './dispatcher'
 import { validateModel } from './validate'
 import createRematchBag from './bag'
 
@@ -43,7 +43,8 @@ export default function createRematchStore<
 		addModel(model: NamedModel<TModels>) {
 			validateModel(model)
 			createModelReducer(bag, model)
-			prepareModel(rematchStore, bag, model)
+			prepareModel(rematchStore, model)
+			enhanceModel(rematchStore, bag, model)
 			reduxStore.replaceReducer(createRootReducer(bag))
 			reduxStore.dispatch({ type: '@@redux/REPLACE' })
 		},
@@ -51,8 +52,15 @@ export default function createRematchStore<
 
 	addExposed(rematchStore, config.plugins)
 
-	// generate dispatch[modelName][actionName] for all reducers and effects
-	bag.models.forEach((model) => prepareModel(rematchStore, bag, model))
+	/**
+	 * generate dispatch[modelName][actionName] for all reducers and effects
+	 *
+	 * Note: To have circular models accessible in effects method with destructing,
+	 *       ensure that model generation and effects generation execute in
+	 *       different steps.
+	 */
+	bag.models.forEach((model) => prepareModel(rematchStore, model))
+	bag.models.forEach((model) => enhanceModel(rematchStore, bag, model))
 
 	bag.forEachPlugin('onStoreCreated', (onStoreCreated) => {
 		rematchStore = onStoreCreated(rematchStore, bag) || rematchStore
@@ -88,18 +96,26 @@ function prepareModel<
 	TModels extends Models<TModels>,
 	TExtraModels extends Models<TModels>,
 	TModel extends NamedModel<TModels>
->(
-	rematchStore: RematchStore<TModels, TExtraModels>,
-	bag: RematchBag<TModels, TExtraModels>,
-	model: TModel
-): void {
+>(rematchStore: RematchStore<TModels, TExtraModels>, model: TModel): void {
 	const modelDispatcher = {} as ModelDispatcher<TModel, TModels>
 
 	// inject model so effects creator can access it
 	rematchStore.dispatch[`${model.name}` as keyof RematchDispatch<TModels>] =
 		modelDispatcher
 
-	createDispatcher(rematchStore, bag, model)
+	createDispatcher(rematchStore, model)
+}
+
+function enhanceModel<
+	TModels extends Models<TModels>,
+	TExtraModels extends Models<TModels>,
+	TModel extends NamedModel<TModels>
+>(
+	rematchStore: RematchStore<TModels, TExtraModels>,
+	bag: RematchBag<TModels, TExtraModels>,
+	model: TModel
+): void {
+	createEffectDispatcher(rematchStore, bag, model)
 
 	bag.forEachPlugin('onModel', (onModel) => {
 		onModel(model, rematchStore)

--- a/packages/core/test/v1_regressions/circurlarmodels.test.ts
+++ b/packages/core/test/v1_regressions/circurlarmodels.test.ts
@@ -1,0 +1,45 @@
+import { init } from '../../src'
+
+it('circular models should destruct properly', async () => {
+	type CountState = number
+	const dolphins = {
+		state: 0,
+		reducers: {
+			increment: (state: CountState) => state + 1,
+		},
+		effects: ({ sharks, dolphins }: any) => {
+			return {
+				async incrementAsync(): Promise<void> {
+					dolphins.increment()
+				},
+				async incrementSharksAsync(): Promise<void> {
+					sharks.incrementAsync(1)
+				},
+			}
+		},
+	}
+	const sharks = {
+		state: 0,
+		reducers: {
+			increment: (state: CountState, payload: number) => state + payload,
+		},
+		effects: ({ dolphins, sharks }: any) => ({
+			async incrementAsync(payload: number): Promise<void> {
+				dolphins.increment()
+				sharks.increment(payload)
+			},
+		}),
+	}
+
+	const store = init({
+		models: { dolphins, sharks },
+	})
+
+	// store.dispatch({ type: 'count/addCount' })
+	await store.dispatch.sharks.incrementAsync(4)
+	expect(store.getState().sharks).toEqual(4)
+
+	await store.dispatch.dolphins.increment()
+	await store.dispatch.dolphins.incrementSharksAsync()
+	expect(store.getState().dolphins).toEqual(3)
+})


### PR DESCRIPTION
Fixes #811

Short version of this problem given below 

```js
/**---Problem---**/

const dispatch = {};

const gen = ({ a, b }) => {
  return {
    log: () => {
      console.log(a, b);
    }
  };
};

["a", "b"].forEach((item) => {
  const x = {};
  dispatch[item] = x;
  x['run' + item] = gen(dispatch);
});

dispatch["a"].runa.log();
dispatch["b"].runb.log();


/**--- Solution ---**/

const dispatch = {
  a: {},
  b: {}
};

const gen = ({ a, b }) => {
  return {
    log: () => {
      console.log(a, b);
    }
  };
};

["a", "b"].forEach((item) => {
  const x = dispatch[item] || {};
  dispatch[item] = x;
  x['run' + item] = gen(dispatch);
});

dispatch.a.runa.log();
dispatch.b.runb.log();
```

```sh
{ runa: { log: [Function: log] } } undefined
{ runa: { log: [Function: log] } } { runb: { log: [Function: log] } }

{ runa: { log: [Function: log] } } { runb: { log: [Function: log] } }
{ runa: { log: [Function: log] } } { runb: { log: [Function: log] } }
```

When effects method is called it can only access object references which were available to it at that time. I have separated model creation and effects creation process. Now correct models reference is available at the time of effects creation.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#811: Regression in destructuring models from effects dispatch param](https://issuehunt.io/repos/105411913/issues/811)
---
</details>
<!-- /Issuehunt content-->