### PR TITLE
fix!: @rematch/select is now compatible with latest Reselect

### DIFF
--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -26,11 +26,12 @@
     "../../README.md"
   ],
   "dependencies": {
-    "reselect": "^4.0.0"
+    "reselect": "^4.1.2"
   },
   "devDependencies": {
     "@rematch/core": "^2.2.0",
-    "redux": "^4.0.5"
+    "redux": "^4.0.5",
+    "reselect": "^4.1.2"
   },
   "peerDependencies": {
     "@rematch/core": ">=2",

--- a/packages/select/src/types.ts
+++ b/packages/select/src/types.ts
@@ -180,7 +180,9 @@ export type RematchSelect<
 	TExtraModels extends Models<TModels>,
 	TRootState = RematchRootState<TModels, TExtraModels>
 > = (<TReturn extends { [key: string]: (state: TRootState) => any }>(
-	mapSelectToProps: (select: RematchSelect<TModels, TExtraModels>) => TReturn
+	mapSelectToProps: (
+		select: RematchSelect<TModels, TExtraModels, TRootState>
+	) => TReturn
 ) => Reselect.OutputParametricSelector<
 	TRootState,
 	any,
@@ -188,10 +190,11 @@ export type RematchSelect<
 	Reselect.Selector<TRootState, TRootState>
 > &
 	Reselect.OutputSelector<
-		TRootState,
+		Reselect.SelectorArray,
 		{ [K in keyof TReturn]: ReturnType<TReturn[K]> },
 		Reselect.Selector<TRootState, TRootState>
-	>) &
+	> &
+	Reselect.Selector<TRootState, TRootState>) &
 	StoreSelectors<TModels, TExtraModels>
 
 declare module '@rematch/core' {

--- a/yarn.lock
+++ b/yarn.lock
@@ -18141,6 +18141,11 @@ reselect@^4.0.0:
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
   integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
 
+reselect@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.2.tgz#7bf642992d143d4f3b0f2dca8aa52018808a1d51"
+  integrity sha512-wg60ebcPOtxcptIUfrr7Jt3h4BR86cCW3R7y4qt65lnNb4yz4QgrXcbSioVsIOYguyz42+XTHIyJ5TEruzkFgQ==
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"


### PR DESCRIPTION
This is a breaking change, since on 4.0.0 `Reselect.SelectorArray`, doesn't exist.