### PR TITLE
fix: circular reference in dispatch

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -352,9 +352,14 @@ export type RematchDispatch<TModels extends Models<TModels>> = ReduxDispatch &
 export type ExtractRematchDispatchersFromModels<
 	TModels extends Models<TModels>
 > = {
+	// this causes the "Type of property 'base' circularly references itself in mapped type 'ExtractRematchDispatchersFromModels<ExtendedModel>'" typescript error when reusing models
 	[modelKey in keyof TModels]: TModels[modelKey] extends Model<TModels>
 		? ModelDispatcher<TModels[modelKey], TModels>
 		: never
+
+	// this modification also fixes the broken circular dependency issue:
+	// QUESTION: why is the conditional type check even needed in the first place?
+	// [modelKey in keyof TModels]: ModelDispatcher<TModels[modelKey], TModels>
 }
 
 /**


### PR DESCRIPTION
When reusing an existing model in another model that includes additional models (aka. extending it) there is a circular reference detected: `Type of property 'base' circularly references itself in mapped type 'ExtractRematchDispatchersFromModels<ExtendedModel>'.`

The new test introduced will fail at the moment which is intended, but a solution in `types.ts` is provided but the implications of the change are not 100% clear to me.